### PR TITLE
bash style standardization

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -22,142 +22,136 @@
 # - Builds the patched objects with gcc flags -f[function|data]-sections
 # - Runs kpatch tools to create and link the patch kernel module
 
-BASE=$PWD
-LOGFILE=$PWD/kpatch-build.log
+BASE="$PWD"
+LOGFILE="$PWD/kpatch-build.log"
 TOOLSDIR=/usr/local/libexec/kpatch
 DATADIR=/usr/local/share/kpatch
-ARCHVERSION=$(uname -r)
-DISTROVERSION=${ARCHVERSION%*.*}
-CPUS=$(grep -c ^processor /proc/cpuinfo)
-LOCALVERSION=$(uname -r)
-LOCALVERSION=-${LOCALVERSION##*-}
-KSRCDIR=~/.kpatch/$ARCHVERSION
-KSRCDIR_DIR=$(dirname $KSRCDIR)
-KSRCDIR_CACHE=$KSRCDIR.tgz
+ARCHVERSION="$(uname -r)"
+DISTROVERSION="${ARCHVERSION%*.*}"
+CPUS="$(grep -c ^processor /proc/cpuinfo)"
+LOCALVERSION="$(uname -r)"
+LOCALVERSION="-${LOCALVERSION##*-}"
+KSRCDIR="$HOME/.kpatch/$ARCHVERSION"
+KSRCDIR_DIR="$(dirname $KSRCDIR)"
+KSRCDIR_CACHE="$KSRCDIR.tgz"
+TEMPDIR=
 
 cleanup() {
-	rm -Rf $KSRCDIR kernel-$DISTROVERSION.src.rpm $LOGFILE $TEMPDIR > /dev/null 2>/dev/null
+	rm -Rf "$KSRCDIR" "kernel-$DISTROVERSION.src.rpm" "$LOGFILE" "$TEMPDIR" > /dev/null 2>/dev/null
 }
 
 die() {
-	echo "ERROR: kpatch build failed"
-	echo "check kpatch-build.log for more details"
+	echo "ERROR: kpatch build failed" >&2
+	echo "check kpatch-build.log for more details" >&2
 	exit 1
 }
 
-if [ $# -ne 1 ]
-then
-	echo "usage: $0 PATCH"
+if [[ "$#" -ne 1 ]]; then
+	echo "usage: $0 PATCH" >&2
 	exit 2
 fi
 
-PATCHFILE=$(readlink -f $1)
-if [ ! -e $PATCHFILE ]
-then
-	echo "patch file not found"
+PATCHFILE="$(readlink -f $1)"
+if [[ ! -f "$PATCHFILE" ]]; then
+	echo "ERROR: patch file $PATCHFILE not found" >&2
 	exit 3
 fi
 
-PATCHNAME=`basename $PATCHFILE`
-if [[ $PATCHNAME =~ \.patch ]] || [[ $PATCHNAME =~ \.diff ]]
-then
-	PATCHNAME=${PATCHNAME%.*}
+PATCHNAME="$(basename $PATCHFILE)"
+if [[ "$PATCHNAME" =~ \.patch ]] || [[ "$PATCHNAME" =~ \.diff ]]; then
+	PATCHNAME="${PATCHNAME%.*}"
 fi
 
 cleanup
 
-TEMPDIR=`mktemp -d` || die
+TEMPDIR="$(mktemp -d)" || die
 
-if [ -f "$KSRCDIR_CACHE" ]
-then
+if [[ -f "$KSRCDIR_CACHE" ]]; then
 	echo "Using cache at $KSRCDIR_CACHE"
-	rm -rf $KSRCDIR
-	tar xzf $KSRCDIR_CACHE -C $KSRCDIR_DIR || die
-	cd $KSRCDIR || die
+	rm -rf "$KSRCDIR"
+	tar xzf "$KSRCDIR_CACHE" -C "$KSRCDIR_DIR" >> "$LOGFILE" 2>&1 || die
+	cd "$KSRCDIR" || die
 else
 	echo "Verifying required development tools"
-	yum install rpmdevtools yum-utils || die
+	yum install rpmdevtools yum-utils >> "$LOGFILE" 2>&1 || die
 
 	echo "Downloading kernel source for $ARCHVERSION"
-	yumdownloader --source kernel-$ARCHVERSION || die
+	yumdownloader --source "kernel-$ARCHVERSION" >> "$LOGFILE" 2>&1 || die
 
 	echo "Verifying build dependencies for kernel package"
-	yum-builddep kernel-$DISTROVERSION.src.rpm || die
+	yum-builddep "kernel-$DISTROVERSION.src.rpm" >> "$LOGFILE" 2>&1 || die
 
 	echo "Unpacking kernel source"
-	rpmdev-setuptree >> $LOGFILE 2>&1 || die
-	rpm -Uvh kernel-$DISTROVERSION.src.rpm >> $LOGFILE 2>&1 || die
-	rpmbuild -bp --target=$(uname -m) ~/rpmbuild/SPECS/kernel.spec >> $LOGFILE 2>&1 || die
-	rm -rf $KSRCDIR
-	mkdir -p $KSRCDIR_DIR
-	mv ~/rpmbuild/BUILD/kernel-*/linux-$ARCHVERSION $KSRCDIR >> $LOGFILE 2>&1 || die
+	rpmdev-setuptree >> "$LOGFILE" 2>&1 || die
+	rpm -Uvh "kernel-$DISTROVERSION.src.rpm" >> "$LOGFILE" 2>&1 || die
+	rpmbuild -bp "--target=$(uname -m)" "$HOME/rpmbuild/SPECS/kernel.spec" >> "$LOGFILE" 2>&1 || die
+	rm -rf "$KSRCDIR"
+	mkdir -p "$KSRCDIR_DIR"
+	mv "$HOME"/rpmbuild/BUILD/kernel-*/linux-"$ARCHVERSION" "$KSRCDIR" >> "$LOGFILE" 2>&1 || die
 
 	echo "Building original kernel"
-	cd $KSRCDIR
-	echo $LOCALVERSION > localversion
-	make -j$CPUS vmlinux >> $LOGFILE 2>&1 || die
+	cd "$KSRCDIR"
+	echo "$LOCALVERSION" > localversion || die
+	make "-j$CPUS" vmlinux >> "$LOGFILE" 2>&1 || die
 
 	echo "Creating cache"
-	tar czf $KSRCDIR_CACHE -C $KSRCDIR_DIR $ARCHVERSION
+	tar czf "$KSRCDIR_CACHE" -C "$KSRCDIR_DIR" "$ARCHVERSION" >> "$LOGFILE" 2>&1 || die
 fi
 
-cp -R $DATADIR/core $DATADIR/patch $TEMPDIR || die
-cp vmlinux $TEMPDIR || die
+cp -R "$DATADIR/core" "$DATADIR/patch" "$TEMPDIR" || die
+cp vmlinux "$TEMPDIR" || die
 
 echo "Building patched kernel"
-patch -p1 < $PATCHFILE >> $LOGFILE 2>&1
-make -j$CPUS vmlinux > $TEMPDIR/patched_build.log 2>&1 || die
+patch -p1 < "$PATCHFILE" >> "$LOGFILE" 2>&1
+make "-j$CPUS" vmlinux > "$TEMPDIR/patched_build.log" 2>&1 || die
 
 echo "Detecting changed objects"
-grep CC $TEMPDIR/patched_build.log | grep -v init/version.o | awk '{print $2}' >> $TEMPDIR/changed_objs
-if [ $? -ne 0 ]
-then
+grep CC "$TEMPDIR/patched_build.log" | grep -v init/version.o | awk '{print $2}' >> "$TEMPDIR/changed_objs"
+if [[ $? -ne 0 ]]; then
 	echo "No changed objects"
-	exit 0
+	exit 1
 fi
 
 echo "Rebuilding changed objects"
-mkdir $TEMPDIR/patched
-for i in $(cat $TEMPDIR/changed_objs)
-do
-	rm -f $i
-	KCFLAGS="-ffunction-sections -fdata-sections" make $i >> $LOGFILE 2>&1 || die
-	strip -d $i
-	cp -f $i $TEMPDIR/patched/
+mkdir "$TEMPDIR/patched"
+for i in "$(cat $TEMPDIR/changed_objs)"; do
+	rm -f "$i"
+	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
+	strip -d "$i" >> "$LOGFILE" 2>&1 || die
+	cp -f "$i" "$TEMPDIR/patched/" || die
 	
 done
-patch -R -p1 < $PATCHFILE >> $LOGFILE 2>&1
-mkdir $TEMPDIR/orig
-for i in $(cat $TEMPDIR/changed_objs)
-do
-	rm -f $i
-	KCFLAGS="-ffunction-sections -fdata-sections" make $i >> $LOGFILE 2>&1 || die
-	strip -d $i
-	cp -f $i $TEMPDIR/orig/
+patch -R -p1 < "$PATCHFILE" >> "$LOGFILE" 2>&1
+mkdir "$TEMPDIR/orig"
+for i in "$(cat $TEMPDIR/changed_objs)"; do
+	rm -f "$i"
+	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
+	strip -d "$i" >> "$LOGFILE" 2>&1 || die
+	cp -f "$i" "$TEMPDIR/orig/" || die
 done
 
 echo "Extracting new and modified ELF sections"
-cd $TEMPDIR
+cd "$TEMPDIR"
 mkdir output
-for i in orig/* 
-do
-	FILE=`basename $i`
-	$TOOLSDIR/create-diff-object orig/$FILE patched/$FILE output/$FILE >> $LOGFILE 2>&1 || die
+for i in orig/*; do
+	FILE="$(basename $i)"
+	"$TOOLSDIR"/create-diff-object "orig/$FILE" "patched/$FILE" "output/$FILE" >> "$LOGFILE" 2>&1 || die
 done
 
 echo "Building core module: kpatch.ko"
 cd core
-KPATCH_BUILD=$KSRCDIR make >> $LOGFILE 2>&1 || die
+KPATCH_BUILD="$KSRCDIR" make >> "$LOGFILE" 2>&1 || die
 cd ..
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cd patch
-ld -r -o output.o ../output/* >> $LOGFILE 2>&1 || die
-$TOOLSDIR/add-patches-section output.o ../vmlinux >> $LOGFILE 2>&1 || die
-KPATCH_BASEDIR=$TEMPDIR/core KPATCH_BUILD=$KSRCDIR KPATCH_NAME=$PATCHNAME make >> $LOGFILE 2>&1 || die
-strip -d kpatch-$PATCHNAME.ko >> $LOGFILE 2>&1 || die
-$TOOLSDIR/link-vmlinux-syms kpatch-$PATCHNAME.ko ../vmlinux >> $LOGFILE 2>&1 || die
+ld -r -o output.o ../output/* >> "$LOGFILE" 2>&1 || die
+"$TOOLSDIR"/add-patches-section output.o ../vmlinux >> "$LOGFILE" 2>&1 || die
+KPATCH_BASEDIR="$TEMPDIR/core" KPATCH_BUILD="$KSRCDIR" KPATCH_NAME="$PATCHNAME" make >> "$LOGFILE" 2>&1 || die
+strip -d "kpatch-$PATCHNAME.ko" >> "$LOGFILE" 2>&1 || die
+"$TOOLSDIR"/link-vmlinux-syms "kpatch-$PATCHNAME.ko" ../vmlinux >> "$LOGFILE" 2>&1 || die
+
+cp -f "$TEMPDIR/patch/kpatch-$PATCHNAME.ko" "$TEMPDIR/core/kpatch.ko" "$BASE" || die
 
 echo "SUCCESS"
-cp -f $TEMPDIR/patch/kpatch-$PATCHNAME.ko $TEMPDIR/core/kpatch.ko $BASE
 cleanup

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -15,170 +15,159 @@
 # TODO: add kernelrelease option to manage releases other than the
 # currently running one
 
-KERNELRELEASE=$(uname -r)
-VARDIR=/var/lib/kpatch/$KERNELRELEASE
-USRDIR=/usr/lib/kpatch/$KERNELRELEASE
+KERNELRELEASE="$(uname -r)"
+VARDIR="/var/lib/kpatch/$KERNELRELEASE"
+USRDIR="/usr/lib/kpatch/$KERNELRELEASE"
 TOOLSDIR=/usr/local/libexec/kpatch
 
 usage () {
-	echo "usage:"
-	echo "kpatch enable MODULE"
-	echo "kpatch disable MODULE"
-	echo "kpatch load [--all | MODULE]"
-	echo "kpatch unload [--all | MODULE]"
-	echo "kpatch list"
-	echo "kpatch info MODULE"
-	echo "kpatch build PATCH"
+	echo "usage:" >&2
+	echo "kpatch enable MODULE" >&2
+	echo "kpatch disable MODULE" >&2
+	echo "kpatch load [--all | MODULE]" >&2
+	echo "kpatch unload [--all | MODULE]" >&2
+	echo "kpatch list" >&2
+	echo "kpatch info MODULE" >&2
+	echo "kpatch build PATCH" >&2
 	exit 1
 }
 
-# return either VARDIR or USRDIR (or exits if not found)
+warn() {
+	echo "kpatch: $@" >&2
+}
+
+die() {
+	warn "$@"
+	exit 1
+}
+
+# return either VARDIR or USRDIR
 find_patch () {
-	[ -e $VARDIR/available/$1 ] && DIR=$VARDIR && return
-	[ -e $USRDIR/available/$1 ] && DIR=$USRDIR && return
-	echo "Hotfix $2 is not installed"
-	echo "Use "kpatch list" for available patches"
-	exit 2
+	[[ -f "$VARDIR/available/$1" ]] && DIR="$VARDIR" && return
+	[[ -f "$USRDIR/available/$1" ]] && DIR="$USRDIR" && return
+	return 1
 }
 
 # takes full path to patch module
 load_patch () {
 	NAME=$(basename $1)
 	NAME=${NAME%.*}
-	insmod $1
-	if [ $? -ne 0 ]
-	then
-		echo "Hotfix $NAME failed to load"
-		exit 3
-	fi
-	echo "Hotfix $NAME loaded"
+	/usr/sbin/insmod "$1"
 }
 
 # takes only the module filename
 unload_patch () {
-	NAME=$(basename $1)
-	rmmod ${NAME%.*}
-	if [ $? -ne 0 ]
-	then
-		echo "Hotfix $NAME failed to unload"
-		exit 3
-	fi
-	echo "Hotfix $NAME unloaded"
+	NAME="$(basename $1)"
+	/usr/sbin/rmmod "${NAME%.*}"
 }
 
 unset DIR
-[ $# -gt 2 ] || [ $# -lt 1 ] && usage
-MODFILE=$2.ko
-case $1 in
+[[ "$#" -gt 2 ]] || [[ "$#" -lt 1 ]] && usage
+case "$1" in
 "enable")
-	[ $# -ne 2 ] && usage
-	find_patch $MODFILE
-	if [ -e $DIR/enabled/$MODFILE ]
-	then
-		echo "Hotfix $2 is already enabled"
-		exit 0
-	fi
-	ln -s $DIR/available/$MODFILE $DIR/enabled/$MODFILE
-	if [ $? -ne 0 ]
-	then
-		echo "Failed to enable patch $2"
-		exit 3
-	else
-		echo "Hotfix $2 enabled"
-	fi
+	[[ "$#" -ne 2 ]] && usage
+	PATCH=$2
+	MODFILE="$PATCH.ko"
+	find_patch "$MODFILE" || die "$PATCH is not installed"
+	[[ -e "$DIR/enabled/$MODFILE" ]] && die "patch $2 is already enabled"
+	mkdir -p $DIR/enabled
+	ln -s "$DIR/available/$MODFILE" "$DIR/enabled/$MODFILE" || die "failed to enable patch $PATCH"
 	;;
+
 "disable")
-	[ $# -ne 2 ] && usage
-	find_patch $MODFILE
-	if [ ! -e $DIR/enabled/$MODFILE ]
-	then
-		echo "Hotfix $2 is already disabled"
-		exit 0
-	fi
-	rm -f $DIR/enabled/$MODFILE
-	if [ $? -ne 0 ]
-	then
-		echo "Failed to disable patch $2"
-		exit 3
-	else
-		echo "Hotfix $2 disabled"
-	fi
+	[[ "$#" -ne 2 ]] && usage
+	PATCH=$2
+	MODFILE="$PATCH.ko"
+	find_patch "$MODFILE" || die "$PATCH is not installed"
+	[[ ! -e "$DIR/enabled/$MODFILE" ]] && die "$PATCH is already disabled"
+	rm -f "$DIR/enabled/$MODFILE" || die "failed to disable patch $PATCH"
 	;;
+
 "load")
-	[ $# -ne 2 ] && usage
-	case $2 in
+	[[ "$#" -ne 2 ]] && usage
+	case "$2" in
 	"--all")
-		for i in $(ls $VARDIR/enabled)
-		do
-			load_patch $VARDIR/enabled/$i
+		for i in "$VARDIR"/enabled/*.ko; do
+			[[ -e "$i" ]] || continue
+			load_patch "$VARDIR/enabled/$i" || die "failed to load patch $PATCH"
 		done
-		for i in $(ls $USRDIR/enabled)
-		do
-			load_patch $USRDIR/enabled/$i
+		for i in "$USRDIR"/enabled/*.ko; do
+			[[ -e "$i" ]] || continue
+			load_patch "$USRDIR/enabled/$i" || die "failed to load patch $PATCH"
 		done
 		;;
 	*)
-		find_patch $MODFILE
-		load_patch $DIR/available/$MODFILE
+		PATCH="$2"
+		MODFILE="$PATCH.ko"
+		find_patch "$MODFILE" || die "$PATCH is not installed"
+		load_patch "$DIR/available/$MODFILE" || die "failed to load patch $PATCH"
 		;;
 	esac
 	;;
+
 "unload")
-	[ $# -ne 2 ] && usage
-	case $2 in
+	[[ "$#" -ne 2 ]] && usage
+	case "$2" in
 	"--all")
-		for i in $(ls $VARDIR/available)
-		do
-			unload_patch ${i%.*}
+		for i in "$VARDIR"/available/*.ko; do
+			[[ -e "$i" ]] || continue
+			unload_patch "${i%.*}" || die "failed to unload patch $PATCH"
 		done
-		for i in $(ls $USRDIR/available)
-		do
-			unload_patch ${i%.*}
+		for i in "$USRDIR"/available/*.ko; do
+			[[ -e "$i" ]] || continue
+			unload_patch "${i%.*}" || die "failed to unload patch $PATCH"
 		done
 		;;
 	*)
-		find_patch $MODFILE
-		unload_patch $2
+		PATCH="$2"
+		MODFILE="$PATCH.ko"
+		find_patch "$MODFILE" || die "$PATCH is not installed"
+		unload_patch "$PATCH" || die "failed to unload patch $PATCH"
 		;;
 	esac
 	;;
+
 "list")
-	[ $# -ne 1 ] && usage
+	[[ "$#" -ne 1 ]] && usage
 	echo "User patches available:"
-	for i in $(ls $VARDIR/available)
-	do
-		echo ${i%.*}
+	for i in "$VARDIR"/available/*.ko; do
+		[[ -e "$i" ]] || continue
+		echo "$(basename ${i%.*})"
 	done
 	echo ""
 	echo "User patches enabled:"
-	for i in $(ls $VARDIR/enabled)
-	do
-		echo ${i%.*}
+	for i in "$VARDIR"/enabled/*.ko; do
+		[[ -e "$i" ]] || continue
+		echo "$(basename ${i%.*})"
 	done
 	echo ""
 	echo "System patches available:"
-	for i in $(ls $USRDIR/available)
-	do
-		echo ${i%.*}
+	for i in "$USRDIR"/available/*.ko; do
+		[[ -e "$i" ]] || continue
+		echo "$(basename ${i%.*})"
 	done
 	echo ""
 	echo "System patches enabled:"
-	for i in $(ls $USRDIR/enabled)
-	do
-		echo ${i%.*}
+	for i in "$USRDIR"/enabled/*.ko; do
+		[[ -e "$i" ]] || continue
+		echo "$(basename ${i%.*})"
 	done
 	;;
+
 "info")
-	[ $# -ne 2 ] && usage
-	find_patch $MODFILE
-	echo "Hotfix information for ${2%.*}:"
-	modinfo $DIR/available/$MODFILE
+	[[ "$#" -ne 2 ]] && usage
+	PATCH="$2"
+	MODFILE="$PATCH.ko"
+	find_patch "$MODFILE" || die "$PATCH is not installed"
+	echo "Patch information for $PATCH:"
+	/usr/sbin/modinfo "$DIR/available/$MODFILE"
 	;;
+
 "build")
-	[ $# -ne 2 ] && usage
-	$TOOLSDIR/kpatch-build $2
-	[ $? -ne 0 ] && exit 3
+	[[ "$#" -ne 2 ]] && usage
+	"$TOOLSDIR/kpatch-build" "$2" || die "kpatch build failed"
 	;;
+
 *)
 	echo "subcommand $1 not recognized"
 	usage


### PR DESCRIPTION
Before adding any more features to the scripts, standardize the bash
style.  I prefer something close to the google shell style guidelines:

  http://google-styleguide.googlecode.com/svn/trunk/shell.xml
- change [[ to [ (more robust)
- put variable references in quotes (more robust)
- put "then" on same line as "if" (more C-like, readable)
- print error messages on stdout

Also added a few error handling improvements, including using a die
function where appropriate.
