### PR TITLE
build and install core module with make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.ko.cmd
 *.mod.c
 *.swp
+.tmp_versions
+Module.symvers
 kpatch-build/add-patches-section
 kpatch-build/create-diff-object
 kpatch-build/link-vmlinux-syms

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -5,6 +5,7 @@ INSTALL = /usr/bin/install
 
 PREFIX    ?= /usr/local
 SBINDIR    = $(DESTDIR)$(PREFIX)/sbin
+MODULESDIR = $(DESTDIR)$(PREFIX)/lib/modules
 LIBEXECDIR = $(DESTDIR)$(PREFIX)/libexec/kpatch
 DATADIR    = $(DESTDIR)$(PREFIX)/share/kpatch
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,25 @@ Quick Start
 kernel on any distribution, the "kpatch build" command currently
 only works on Fedora.*
 
-First, use diff to make a source patch against the kernel tree, e.g. foo.patch.
-Then:
+Load the kpatch core module:
 
-    kpatch build foo.patch
-    sudo insmod kpatch.ko kpatch-foo.ko
+    sudo insmod /usr/local/lib/modules/$(uname -r)/kpatch/kpatch.ko
 
-Voila, your kernel is patched.
+Make a source patch against the kernel tree:
+
+    # from a kernel git tree:
+    git diff > /path/to/foo.patch
+
+Build the hot patch kernel module:
+
+    kpatch build /path/to/foo.patch
+
+This outputs a hot patch module named `kpatch-foo.ko` in the current
+directory.  Now apply it to the running kernel:
+
+    sudo insmod kpatch-foo.ko
+
+Done!  The kernel is now patched.
 
 
 License

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -1,11 +1,13 @@
 include ../Makefile.inc
 
 all:
+	$(MAKE) -C core
 
 install:
-	$(INSTALL) -d $(DATADIR)/core
-	$(INSTALL) -m 644 core/* $(DATADIR)/core
+	$(INSTALL) -d $(MODULESDIR)/(uname -r)/kpatch
+	$(INSTALL) -m 644 core/kpatch.ko $(MODULESDIR)/(uname -r)/kpatch
 	$(INSTALL) -d $(DATADIR)/patch
 	$(INSTALL) -m 644 patch/* $(DATADIR)/patch
 
 clean:
+	$(MAKE) -C core clean

--- a/kmod/core/Makefile
+++ b/kmod/core/Makefile
@@ -1,6 +1,12 @@
 # make rules
-KPATCH_BUILD ?= /usr/lib/modules/$(shell uname -r)/build
-KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD)
+KPATCH_BUILD ?= /usr/src/kernels/$(shell uname -r)
+THISDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+ifeq ($(wildcard $(KPATCH_BUILD)),)
+$(error $(KPATCH_BUILD) doesn\'t exist.  Try installing the kernel-devel-$(shell uname -r) RPM.)
+endif
+
+KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(THISDIR)
 
 kpatch.ko: core.c trampoline.S
 	$(KPATCH_MAKE) kpatch.ko

--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -1,7 +1,6 @@
 KPATCH_NAME ?= patch
 KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
 KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD)
-ccflags-y += -I$(KPATCH_BASEDIR)
 
 obj-m += kpatch-$(KPATCH_NAME).o
 

--- a/kmod/patch/kpatch.h
+++ b/kmod/patch/kpatch.h
@@ -1,0 +1,1 @@
+../core/kpatch.h

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -153,21 +153,16 @@ for i in $FILES; do
 	"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "output/$i" >> "$LOGFILE" 2>&1 || die
 done
 
-echo "Building core module: kpatch.ko"
-cd core
-KPATCH_BUILD="$KSRCDIR" make >> "$LOGFILE" 2>&1 || die
-cd ..
-
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cd "$TEMPDIR/output"
 ld -r -o ../patch/output.o $FILES >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/patch"
 "$TOOLSDIR"/add-patches-section output.o ../vmlinux >> "$LOGFILE" 2>&1 || die
-KPATCH_BASEDIR="$TEMPDIR/core" KPATCH_BUILD="$KSRCDIR" KPATCH_NAME="$PATCHNAME" make >> "$LOGFILE" 2>&1 || die
+KPATCH_BUILD="$KSRCDIR" KPATCH_NAME="$PATCHNAME" make >> "$LOGFILE" 2>&1 || die
 "$STRIPCMD" "kpatch-$PATCHNAME.ko" >> "$LOGFILE" 2>&1 || die
 "$TOOLSDIR"/link-vmlinux-syms "kpatch-$PATCHNAME.ko" ../vmlinux >> "$LOGFILE" 2>&1 || die
 
-cp -f "$TEMPDIR/patch/kpatch-$PATCHNAME.ko" "$TEMPDIR/core/kpatch.ko" "$BASE" || die
+cp -f "$TEMPDIR/patch/kpatch-$PATCHNAME.ko" "$BASE" || die
 
 cleanup
 echo "SUCCESS"


### PR DESCRIPTION
Build and install the kpatch core module with make and make install,
rather than building it every time with kpatch build.

The only downside to this approach is that the user has to make and make
install kpatch every time they get a new kernel.  But this is only
temporary, until the kpatch module is delivered in an RPM.
