### PR TITLE
don't copy core kmod source files to tempdir

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -109,7 +109,7 @@ fi
 
 find_data_dir || (echo "can't find data dir" >&2 && die)
 
-cp -R "$DATADIR/core" "$DATADIR/patch" "$TEMPDIR" || die
+cp -R "$DATADIR/patch" "$TEMPDIR" || die
 cp vmlinux "$TEMPDIR" || die
 
 echo "Building patched kernel"


### PR DESCRIPTION
No need to copy them anymore now that the core kmod is getting
built elsewhere.
