### PR TITLE
fix calling of kpatch-build from git dir

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -109,7 +109,7 @@ fi
 
 find_data_dir || (echo "can't find data dir" >&2 && die)
 
-cp -R "$DATADIR/patch" "$TEMPDIR" || die
+cp -LR "$DATADIR/patch" "$TEMPDIR" || die
 cp vmlinux "$TEMPDIR" || die
 
 echo "Building patched kernel"


### PR DESCRIPTION
When calling kpatch-build from the git directory, the patch kmod build
fails because it can't find kpatch.h because the symlink is broken.
Copy the kpatch.h file (instead of the symlink) to TEMPDIR.
