### PR TITLE
remove quotes around for loop elements

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -125,7 +125,7 @@ fi
 
 echo "Rebuilding changed objects"
 mkdir "$TEMPDIR/patched"
-for i in "$(cat $TEMPDIR/changed_objs)"; do
+for i in $(cat $TEMPDIR/changed_objs); do
 	rm -f "$i"
 	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
 	"$STRIPCMD" "$i" >> "$LOGFILE" 2>&1 || die
@@ -135,7 +135,7 @@ for i in "$(cat $TEMPDIR/changed_objs)"; do
 done
 patch -R -p1 < "$PATCHFILE" >> "$LOGFILE" 2>&1
 mkdir "$TEMPDIR/orig"
-for i in "$(cat $TEMPDIR/changed_objs)"; do
+for i in $(cat $TEMPDIR/changed_objs); do
 	rm -f "$i"
 	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
 	"$STRIPCMD" -d "$i" >> "$LOGFILE" 2>&1 || die


### PR DESCRIPTION
Right now kpatch-build fails when more than one object
file has changed because the quotes around the for loop
arrays cause the for loop to execute only once for all
elements in a single string.

Remove the quotes around the for loop arrays so that the
for loop is execute for each element.

Signed-off-by: Seth Jennings sjenning@redhat.com
