### PR TITLE
build objects in separate directory to fix caching

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -26,8 +26,10 @@ DISTROVERSION="${ARCHVERSION%*.*}"
 CPUS="$(grep -c ^processor /proc/cpuinfo)"
 LOCALVERSION="$(uname -r)"
 LOCALVERSION="-${LOCALVERSION##*-}"
-KSRCDIR="$HOME/.kpatch/$ARCHVERSION"
-KSRCDIR_DIR="$(dirname $KSRCDIR)"
+CACHEDIR="$HOME/.kpatch"
+SRCDIR="$CACHEDIR/$ARCHVERSION/src"
+OBJDIR="$CACHEDIR/$ARCHVERSION/obj"
+OBJDIR2="$CACHEDIR/$ARCHVERSION/obj2"
 TEMPDIR=
 STRIPCMD="strip -d --keep-file-symbols"
 APPLIEDPATCHFILE="applied-patch"
@@ -73,14 +75,13 @@ TEMPDIR="$(mktemp -d)" || die "mktemp failed"
 
 trap "rm -rf $TEMPDIR" EXIT INT TERM
 
-if [[ -d "$KSRCDIR" ]]; then
-	echo "Using cache at $KSRCDIR"
-	cd "$KSRCDIR" || die
+if [[ -d "$SRCDIR" ]]; then
+	echo "Using cache at $SRCDIR"
+	cd "$SRCDIR" || die
 	if [[ -f "$APPLIEDPATCHFILE" ]]; then
-		patch -R -p1 < "$APPLIEDPATCHFILE" || die "the kpatch cache is corrupted. \"rm -rf $KSRCDIR\" and try again"
+		patch -R -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die "the kpatch cache is corrupted. \"rm -rf $CACHEDIR\" and try again"
 		rm -f "$APPLIEDPATCHFILE"
 	fi
-	make "-j$CPUS" vmlinux >> "$LOGFILE" 2>&1 || die
 else
 	rpm -q --quiet rpmdevtools || die "rpmdevtools not installed"
 	rpm -q --quiet yum-utils || die "yum-utils not installed"
@@ -93,25 +94,28 @@ else
 	rpm -ivh "$TEMPDIR/kernel-$DISTROVERSION.src.rpm" >> "$LOGFILE" 2>&1 || die
 	rpmbuild -bp "--target=$(uname -m)" "$HOME/rpmbuild/SPECS/kernel.spec" >> "$LOGFILE" 2>&1 ||
 		die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
-	rm -rf "$KSRCDIR_DIR"
-	mkdir -p "$KSRCDIR_DIR"
-	mv "$HOME"/rpmbuild/BUILD/kernel-*/linux-"$ARCHVERSION" "$KSRCDIR" >> "$LOGFILE" 2>&1 || die
+	rm -rf "$CACHEDIR"
+	mkdir -p "$OBJDIR"
+	mv "$HOME"/rpmbuild/BUILD/kernel-*/linux-"$ARCHVERSION" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
 
-	echo "Building original kernel"
-	cd "$KSRCDIR"
-	echo "$LOCALVERSION" > localversion || die
-	make "-j$CPUS" vmlinux >> "$LOGFILE" 2>&1 || die
+	cd "$SRCDIR"
+	cp .config "$OBJDIR" || die
+	echo "$LOCALVERSION" > "$OBJDIR/localversion" || die
 fi
+
+echo "Building original kernel"
+make mrproper >> "$LOGFILE" 2>&1 || die
+make "-j$CPUS" vmlinux "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
 
 find_data_dir || (echo "can't find data dir" >&2 && die)
 
 cp -LR "$DATADIR/patch" "$TEMPDIR" || die
-cp vmlinux "$TEMPDIR" || die
+cp "$OBJDIR/vmlinux" "$TEMPDIR" || die
 
 echo "Building patched kernel"
 cp "$PATCHFILE" "$APPLIEDPATCHFILE" || die
 patch -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die
-make "-j$CPUS" vmlinux > "$TEMPDIR/patched_build.log" 2>&1 || die
+make "-j$CPUS" vmlinux "O=$OBJDIR" > "$TEMPDIR/patched_build.log" 2>&1 || die
 
 echo "Detecting changed objects"
 grep CC "$TEMPDIR/patched_build.log" | grep -v init/version.o | awk '{print $2}' >> "$TEMPDIR/changed_objs"
@@ -121,13 +125,15 @@ if [[ $? -ne 0 ]]; then
 fi
 
 echo "Rebuilding changed objects"
+rm -rf "$OBJDIR2"
+mkdir -p "$OBJDIR2"
+cp "$OBJDIR/.config" "$OBJDIR2" || die
 mkdir "$TEMPDIR/patched"
 for i in $(cat $TEMPDIR/changed_objs); do
-	rm -f "$i"
-	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
-	$STRIPCMD "$i" >> "$LOGFILE" 2>&1 || die
+	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
+	$STRIPCMD "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
 	mkdir -p "$TEMPDIR/patched/$(dirname $i)"
-	cp -f "$i" "$TEMPDIR/patched/$i" || die
+	cp -f "$OBJDIR2/$i" "$TEMPDIR/patched/$i" || die
 	
 done
 patch -R -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1
@@ -135,10 +141,10 @@ rm -f "$APPLIEDPATCHFILE"
 mkdir "$TEMPDIR/orig"
 for i in $(cat $TEMPDIR/changed_objs); do
 	rm -f "$i"
-	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" >> "$LOGFILE" 2>&1 || die
-	$STRIPCMD -d "$i" >> "$LOGFILE" 2>&1 || die
+	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
+	$STRIPCMD -d "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
 	mkdir -p "$TEMPDIR/orig/$(dirname $i)"
-	cp -f "$i" "$TEMPDIR/orig/$i" || die
+	cp -f "$OBJDIR2/$i" "$TEMPDIR/orig/$i" || die
 done
 
 echo "Extracting new and modified ELF sections"
@@ -152,11 +158,14 @@ for i in $FILES; do
 done
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"
+cp "$OBJDIR/.config" "$SRCDIR"
+cd "$SRCDIR"
+make prepare >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/output"
 ld -r -o ../patch/output.o $FILES >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/patch"
 "$TOOLSDIR"/add-patches-section output.o ../vmlinux >> "$LOGFILE" 2>&1 || die
-KPATCH_BUILD="$KSRCDIR" KPATCH_NAME="$PATCHNAME" make >> "$LOGFILE" 2>&1 || die
+KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$PATCHNAME" make "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
 $STRIPCMD "kpatch-$PATCHNAME.ko" >> "$LOGFILE" 2>&1 || die
 "$TOOLSDIR"/link-vmlinux-syms "kpatch-$PATCHNAME.ko" ../vmlinux >> "$LOGFILE" 2>&1 || die
 


### PR DESCRIPTION
Setting KCFLAGS="-ffunction-sections -fdata-sections" causes make to
invalidate all the kernel objects, resulting in all the objects getting
rebuilt on the next pass, thus no build caching.

To fix that, build the objects in a separate directory (obj) for normal
builds, and another separate directory (obj2) for the builds with added
cflags.
