### PR TITLE
Fix problem with EXTRAVERSION in Makefile for kernel

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -100,6 +100,7 @@ else
 
 	cd "$SRCDIR"
 	cp .config "$OBJDIR" || die
+	perl -pi -e "s/EXTRAVERSION =/EXTRAVERSION = $LOCALVERSION/" Makefile || die
 	echo "$LOCALVERSION" > "$OBJDIR/localversion" || die
 fi
 


### PR DESCRIPTION
The Makefile used for building the hot patch module ignored the EXTRAVERSION of Makefile of the kernel. The build worked but it was not possible to insert the module due the wrong version. 
