### PR TITLE
put localversions file in SRCDIR, not OBJDIR

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -100,7 +100,7 @@ else
 
 	cd "$SRCDIR"
 	cp .config "$OBJDIR" || die
-	echo "$LOCALVERSION" > "$OBJDIR/localversion" || die
+	echo "$LOCALVERSION" > "$SRCDIR/localversion" || die
 fi
 
 echo "Building original kernel"


### PR DESCRIPTION
The kernel Makefile looks for localversion in the source tree,
not the object tree.  The absense from the source tree results
in a patch module that will not load because the kernel versions
don't match.

Signed-off-by: Seth Jennings sjenning@redhat.com
