### PR TITLE
make the changed function output more readable

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -837,7 +837,7 @@ void kpatch_include_changed_functions(struct kpatch_elf *kelf)
 		if (sym->status == CHANGED &&
 		    sym->type == STT_FUNC &&
 		    !sym->include) {
-			log_normal("function %s has changed\n", sym->name);
+			log_normal("changed function: %s\n", sym->name);
 			kpatch_include_symbol(sym, 0);
 		}
 


### PR DESCRIPTION
This makes it much easier to spot which functions have changed,
especially when there are more than one of them.
