### PR TITLE
kpatch-build: fix SCRIPTDIR for bash -x

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -38,7 +38,7 @@
 
 BASE="$PWD"
 LOGFILE="/tmp/kpatch-build-$(date +%s).log"
-SCRIPTDIR="$(readlink -f $(dirname $0))"
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 ARCHVERSION="$(uname -r)"
 DISTROVERSION="${ARCHVERSION%*.*}"
 LOCALVERSION="-${ARCHVERSION##*-}"


### PR DESCRIPTION
More adventures in bash-land.  Running "bash -x kpatch-build foo.patch"
causes SCRIPTDIR to not get set properly.  This fixes that.
