### PR TITLE
core/kmod: use kmalloc instead of kzalloc

### DIFF
--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -38,7 +38,7 @@ static int __init patch_init(void)
 	patches = (struct kpatch_patch *)&__kpatch_patches;
 	num_funcs = (&__kpatch_patches_end - &__kpatch_patches) /
 		    sizeof(*patches);
-	funcs = kzalloc(num_funcs * sizeof(*funcs), GFP_KERNEL);
+	funcs = kmalloc(num_funcs * sizeof(*funcs), GFP_KERNEL);
 	if (!funcs)
 		return -ENOMEM;
 


### PR DESCRIPTION
There's no need to zero out the kpatch funcs array.  The addr fields are
initialized by the patch module, the mod field is intialized by the core
module, and the node struct doesn't need to be initialized because its
fields are overwritten by hash_add.
