### PR TITLE
error on symbol ambiguity in link-vmlinux-syms

### DIFF
--- a/kpatch-build/link-vmlinux-syms.c
+++ b/kpatch-build/link-vmlinux-syms.c
@@ -184,12 +184,17 @@ static void create_symlist(struct elf *elf, struct symlist *symlist)
 
 static struct sym *find_symbol_by_name(struct symlist *list, char *name)
 {
-	struct sym *cur;
+	struct sym *cur, *ret = NULL;
 
-	for_each_sym(list, cur)
-		if (!strcmp(cur->name, name))
-			return cur;
-	return NULL;
+	for_each_sym(list, cur) {
+		if (!strcmp(cur->name, name)) {
+			if (ret)
+				ERROR("unresolvable symbol ambiguity for symbol '%s'", name);
+			ret = cur;
+		}
+	}
+
+	return ret;
 }
 
 /*


### PR DESCRIPTION
Like in add-patches-section, we should continue to
search the vmlinux symbol table to see if there
is a duplicate global symbol.  This normally would
not be possible, however, because create-diff-object
modifies unchanged local functions to be global
as a hack so they can be linked, there is a chance
that these symbols could collide with an existing
global symbol.  We should detect this case and error
out.

Hopefully we can figure out a way to avoid this
situation altogether.  But for now, this is a
protection against improper linking.

Signed-off-by: Seth Jennings sjenning@redhat.com
