### PR TITLE
kmod/core: add "notrace" to ftrace handler

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -171,8 +171,8 @@ out:
 }
 
 
-void kpatch_ftrace_handler(unsigned long ip, unsigned long parent_ip,
-		           struct ftrace_ops *op, struct pt_regs *regs)
+void notrace kpatch_ftrace_handler(unsigned long ip, unsigned long parent_ip,
+				   struct ftrace_ops *op, struct pt_regs *regs)
 {
 	struct kpatch_func *f;
 


### PR DESCRIPTION
The ftrace handler needs the notrace annotation so that ftrace won't
trace it and get into a recursive loop.
