### PR TITLE
ignore init functions during bundling

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -379,10 +379,15 @@ void kpatch_create_symbol_table(struct kpatch_elf *kelf)
 			 * to offsets inside the __ksymtab_strings section
 			 * for kernel exported symbols.  We want to ignore
 			 * those.
+			 *
+			 * Also, functions declared with __init do not honor
+			 * -ffunction-sections and can be at non-zero offsets
+			 *  in the .init.text section, so ignore those.
 			 */
 			if ((sym->type == STT_FUNC ||
 			     sym->type == STT_OBJECT) &&
-			    strcmp(sym->sec->name, "__ksymtab_strings")) {
+			    strcmp(sym->sec->name, "__ksymtab_strings") &&
+			    strcmp(sym->sec->name, ".init.text")) {
 				if (sym->sym.st_value != 0)
 					ERROR("symbol %s at offset %lu within section %s, expected 0",
 					      sym->name, sym->sym.st_value, sym->sec->name);


### PR DESCRIPTION
When linking function bundles (.text/.rela/section sym/func sym)
ignore __init functions as they do not honor -ffunction-sections
and violate the one-to-one func/section assumption of the
function bundling.

Signed-off-by: Seth Jennings sjenning@redhat.com
