### PR TITLE
Reworked version of spec file following the discussion of PR 80

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,0 +1,95 @@
+Name: kpatch
+Summary: Dynamic kernel patching
+Version: 0.0.1
+License: GPLv2 
+Group: System Environment/Kernel
+URL: http://github.com/dynup/kpatch
+Release: 1%{?dist}
+Source0: %{name}-%{version}.tar.gz
+
+Requires: kmod bash
+BuildRequires: gcc kernel-devel elfutils elfutils-devel
+BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+# needed for the kernel specific module
+%define KVER %(uname -r)
+
+%description 
+kpatch is a Linux dynamic kernel patching tool which allows you to patch a
+running kernel without rebooting or restarting any processes.  It enables
+sysadmins to apply critical security patches to the kernel immediately, without
+having to wait for long-running tasks to complete, users to log off, or
+for scheduled reboot windows.  It gives more control over up-time without
+sacrificing security or stability.
+
+
+%package runtime
+Summary: Dynamic kernel patching
+Buildarch: noarch
+Provides: %{name} = %{version}
+%description runtime
+kpatch is a Linux dynamic kernel patching tool which allows you to patch a
+running kernel without rebooting or restarting any processes.  It enables
+sysadmins to apply critical security patches to the kernel immediately, without
+having to wait for long-running tasks to complete, users to log off, or
+for scheduled reboot windows.  It gives more control over up-time without
+sacrificing security or stability.
+
+
+%package build
+Requires: %{name}
+Summary: Dynamic kernel patching
+%description build
+kpatch is a Linux dynamic kernel patching tool which allows you to patch a
+running kernel without rebooting or restarting any processes.  It enables
+sysadmins to apply critical security patches to the kernel immediately, without
+having to wait for long-running tasks to complete, users to log off, or
+for scheduled reboot windows.  It gives more control over up-time without
+sacrificing security or stability.
+
+%package %{KVER}
+Requires: %{name}
+Summary: Dynamic kernel patching
+%description %{KVER}
+kpatch is a Linux dynamic kernel patching tool which allows you to patch a
+running kernel without rebooting or restarting any processes.  It enables
+sysadmins to apply critical security patches to the kernel immediately, without
+having to wait for long-running tasks to complete, users to log off, or
+for scheduled reboot windows.  It gives more control over up-time without
+sacrificing security or stability.
+
+
+%prep
+%setup -q 
+cp Makefile.inc Makefile.inc.ORG
+%{__sed} 's%/usr/local%/usr%' Makefile.inc.ORG > Makefile.inc
+
+%build
+make %{_smp_mflags} 
+
+%install
+rm -rf %{buildroot}
+
+make install DESTDIR=%{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files runtime
+%defattr(-,root,root,-)
+%doc COPYING README.md
+%{_sbindir}/kpatch
+
+%files %{KVER}
+%defattr(-,root,root,-)
+%{_usr}/lib/modules/%{KVER}/%{name}/*
+
+%files build
+%defattr(-,root,root,-)
+%{_bindir}/*
+%{_libexecdir}/*
+%{_datadir}/%{name}
+
+%changelog
+* Sat Mar 22 2014 Udo Seidel <udoseidel@gmx.de> - 0.0.1-1
+- initial release


### PR DESCRIPTION
I could not create kpatch as noarch ... so I have renamed it to kpatch-runtime and this subpackage could be noarch.
The original devel was renamed to build .. which causes rpmlint to complain about the source files (see below).

$ rpmlint kpatch-0.0.1-1.fc20.src.rpm kpatch-runtime-0.0.1-1.fc20.noarch.rpm RPMS/x86_64/kpatch-_x86_
kpatch.src: W: invalid-url Source0: kpatch-0.0.1.tar.gz
kpatch-runtime.noarch: W: no-manual-page-for-binary kpatch
kpatch-3.13.6-200.fc20.x86_64.x86_64: W: unstripped-binary-or-object /usr/lib/modules/3.13.6-200.fc20.x86_64/kpatch/kpatch.ko
kpatch-3.13.6-200.fc20.x86_64.x86_64: W: no-documentation
kpatch-build.x86_64: W: no-documentation
kpatch-build.x86_64: W: devel-file-in-non-devel-package /usr/share/kpatch/patch/kpatch.h
kpatch-build.x86_64: W: devel-file-in-non-devel-package /usr/share/kpatch/patch/kpatch-patch-hook.c
kpatch-build.x86_64: W: devel-file-in-non-devel-package /usr/share/kpatch/patch/kpatch-patch.h
kpatch-build.x86_64: W: no-manual-page-for-binary kpatch-build
5 packages and 0 specfiles checked; 0 errors, 9 warnings.
$
