### PR TITLE
always rebuild core module

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.inc
 
-all:
+all: clean
 	$(MAKE) -C core
 
 install:


### PR DESCRIPTION
If the kernel updates, make won't detect that the core module needs
rebuilding.  So always rebuild it.
