### PR TITLE
skip scripts/mod files when detecting changed objs

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -199,7 +199,7 @@ make "-j$CPUS" vmlinux "O=$OBJDIR" 2>&1 | tee -a "$TEMPDIR/patched_build.log" >>
 [[ "${PIPESTATUS[0]}" -eq 0 ]] || die
 
 echo "Detecting changed objects"
-grep CC "$TEMPDIR/patched_build.log" | grep -v init/version.o | grep -v scripts/mod/devicetable-offsets.s | grep -v scripts/mod/file2alias.o | awk '{print $2}' > "$TEMPDIR/changed_objs"
+grep CC "$TEMPDIR/patched_build.log" | grep -v -e init/version.o -e scripts/mod/devicetable-offsets.s -e scripts/mod/file2alias.o | awk '{print $2}' > "$TEMPDIR/changed_objs"
 [[ ! -s "$TEMPDIR/changed_objs" ]] && die "no changed objects were detected"
 
 echo "Rebuilding changed objects"


### PR DESCRIPTION
In some environments, some files in scripts/mod (devicetable-offsets.s
and file2alias.o) are always getting rebuilt, and thus get incorrectly
added to the changed_objs file, resulting in the following error:

 strip:/root/.kpatch/3.10.0-115.el7.x86_64/obj2/scripts/mod/devicetable-offsets.s: File format not recognized
