### PR TITLE
man: use older '-c' option

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -3,10 +3,10 @@ include ../Makefile.inc
 all: kpatch.1.gz kpatch-build.1.gz
 
 kpatch.1.gz: kpatch.1
-	gzip -k -9 kpatch.1
+	gzip -c -9 $< > $@
 
 kpatch-build.1.gz: kpatch-build.1
-	gzip -k -9 kpatch-build.1
+	gzip -c -9 $< > $@
 
 install: all
 	$(INSTALL) -d $(MANDIR)


### PR DESCRIPTION
The gzip '-k' option isn't supported on older versions of gzip, so use
the more portable '-c' option to send the compressed file to stdout.
