### PR TITLE
kpatch-build: getopts arg parsing cleanup

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -121,6 +121,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--)
 		if [[ -z "$2" ]]; then
+			echo "ERROR: no patch file specified" >&2
 			usage
 			exit 1
 		fi


### PR DESCRIPTION
Cleanup the kpatch-build argument parsing a little bit:
- gracefully handle no args
- allow white space in filenames
- use 'eval set -- $options' to allow use of $1 and $2 variables
