### PR TITLE
Fix the Issue #65: NMI handler live patching

### DIFF
--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -33,6 +33,7 @@ struct kpatch_func {
 	unsigned long old_size;
 	struct module *mod;
 	struct hlist_node node;
+	bool updating;
 };
 
 extern int kpatch_register(struct module *mod, struct kpatch_func *funcs,


### PR DESCRIPTION
This fixes issue #65, NMI handler live patching support. The basic idea is already discussed on that issue, and this is an implementation of that.

Short description: Live patching on NMI handler must be failed if an NMI happens when checking the backtrace on each task, because it can cause inconsistency between non-patched and patched functions which concurrently run. This adds an atomic counter to detect such concurrently running NMI handler while
updating.
