### PR TITLE
kpatch-build: prevent die if only part of objects have no change

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -248,11 +248,13 @@ cd "$TEMPDIR/orig"
 FILES="$(find * -type f)"
 cd "$TEMPDIR"
 mkdir output
+changed=0
 for i in $FILES; do
 	mkdir -p "output/$(dirname $i)"
 	"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "output/$i" 2>&1 |tee -a "$LOGFILE"
-	[[ "${PIPESTATUS[0]}" -eq 0 ]] || die
+	[[ "${PIPESTATUS[0]}" -eq 0 ]] && changed=$((changed+1))
 done
+[[ "$changed" -gt 0 ]] || die "Fatal: all generated objects has no changed function."
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"


### PR DESCRIPTION
Consider following patch: https://lkml.org/lkml/diff/2014/1/7/637/1
Kpatch-build will generate two objects for it. however mlock.o has no
changed function and will cause kpatch-build die.
Signed-off-by: Madper Xie cxie@redhat.com
