### PR TITLE
Revert "kpatch-build: prevent die if only part of objects have no change...

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -248,13 +248,11 @@ cd "$TEMPDIR/orig"
 FILES="$(find * -type f)"
 cd "$TEMPDIR"
 mkdir output
-changed=0
 for i in $FILES; do
 	mkdir -p "output/$(dirname $i)"
 	"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "output/$i" 2>&1 |tee -a "$LOGFILE"
-	[[ "${PIPESTATUS[0]}" -eq 0 ]] && changed=$((changed+1))
+	[[ "${PIPESTATUS[0]}" -eq 0 ]] || die
 done
-[[ "$changed" -gt 0 ]] || die "Fatal: all generated objects has no changed function."
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"


### PR DESCRIPTION
..."

This reverts commit ab29b1ff59e1d180a14d3544140b8fe39257a7ed.

Reverting this commit because it causes kpatch-build to ignore any
errors reported by create-diff-object, treating all errors as meaning
that no changes occurred, which is a dangerous assumption to make.
