### PR TITLE
fix DRACUTDIR to be in /usr/lib/dracut

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -10,7 +10,7 @@ MODULESDIR = $(DESTDIR)$(PREFIX)/lib/modules
 LIBEXECDIR = $(DESTDIR)$(PREFIX)/libexec/kpatch
 DATADIR    = $(DESTDIR)$(PREFIX)/share/kpatch
 MANDIR     = $(DESTDIR)$(PREFIX)/share/man/man1
-DRACUTDIR  = $(DESTDIR)$(PREFIX)/lib/dracut/modules.d/99kpatch
+DRACUTDIR  = $(DESTDIR)/usr/lib/dracut/modules.d/99kpatch
 
 .PHONY: all install clean
 .DEFAULT: all


### PR DESCRIPTION
Unforunately the dracut module doesn't work if installed in
/usr/local/lib/dracut.  It must always be installed in
/usr/lib/dracut regardless of the install prefix.
