### PR TITLE
kmod/core: taint kernel with TAINT_USER

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -266,8 +266,11 @@ int kpatch_register(struct module *mod, struct kpatch_func *funcs,
 		goto out;
 	}
 
-	pr_notice("loaded patch module \"%s\"\n", mod->name);
+	/* TODO: need TAINT_KPATCH */
+	pr_notice_once("tainting kernel with TAINT_USER\n");
+	add_taint(TAINT_USER, LOCKDEP_STILL_OK);
 
+	pr_notice("loaded patch module \"%s\"\n", mod->name);
 out:
 	up(&kpatch_mutex);
 	return ret;


### PR DESCRIPTION
For now, taint with TAINT_USER when loading a patch module so that the
user can always detect when a kpatch module has been previously loaded.
Eventually we will want a dedicated TAINT_KPATCH flag in the kernel.
