### PR TITLE
remove systemd service unit file

### DIFF
--- a/contrib/kpatch.service
+++ b/contrib/kpatch.service
@@ -1,9 +1,0 @@
-[Unit]
-Description=kpatch -- apply all enabled dynamic kernel patches
-Before=
-OnFailure=
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=/usr/bin/kpatch load --all


### PR DESCRIPTION
Now that we're using dracut instead of systemd to load modules at boot
time, the systemd unit file is no longer needed.
