### PR TITLE
kmod/core: require fentry

### DIFF
--- a/kmod/core/Makefile
+++ b/kmod/core/Makefile
@@ -19,5 +19,7 @@ clean:
 
 
 # kbuild rules
+ifdef CONFIG_HAVE_FENTRY
 obj-m := kpatch.o
 kpatch-y := core.o
+endif


### PR DESCRIPTION
Only compile the core module if the compiler supports -mfentry.
