### PR TITLE
Adding preempt_mask.h to core.c

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -41,6 +41,7 @@
 #include <linux/stop_machine.h>
 #include <linux/ftrace.h>
 #include <linux/hashtable.h>
+#include <linux/preempt_mask.h>
 #include <asm/stacktrace.h>
 #include <asm/cacheflush.h>
 #include "kpatch.h"


### PR DESCRIPTION
When compiling core.c, it may report error like:
"error: implicit declaration of function ‘in_nmi’"

Adding header file in_nmi defined could avoid this.

Signed-off-by: Jincheng Miao jincheng.miao@gmail.com
