### PR TITLE
Revert "fail on changed init section"

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -512,11 +512,8 @@ void kpatch_compare_correlated_section(struct section *sec)
 	else
 		kpatch_compare_correlated_nonrela_section(sec);
 out:
-	if (sec->status == CHANGED) {
+	if (sec->status == CHANGED)
 		log_debug("section %s has changed\n", sec->name);
-		if (!strcmp(sec->name, ".init.text"))
-			DIFF_FATAL("init section has changed");
-	}
 }
 
 void kpatch_compare_sections(struct table *table)


### PR DESCRIPTION
This reverts commit 7b15e23149bcb9e8b4e671542485ac8d5d54ec1b.

It seems that there was no bug to start with, so apparently the commit
didn't fix anything.

Fixes #103.
