### PR TITLE
Revert "fail on changed init section"

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -512,11 +512,8 @@ void kpatch_compare_correlated_section(struct section *sec)
 	else
 		kpatch_compare_correlated_nonrela_section(sec);
 out:
-	if (sec->status == CHANGED) {
+	if (sec->status == CHANGED)
 		log_debug("section %s has changed\n", sec->name);
-		if (!strcmp(sec->name, ".init.text"))
-			DIFF_FATAL("init section has changed");
-	}
 }
 
 void kpatch_compare_sections(struct table *table)


### PR DESCRIPTION
This reverts commit 7b15e23149bcb9e8b4e671542485ac8d5d54ec1b.

After reverting this commit, create-diff-object correctly detects,
during the inclusion check, that the .init\* section hasn't been
included and fails, as it should.  Not sure that this was ever
a problem, but the fix is not needed.

Fixes #103

Signed-off-by: Seth Jennings sjenning@redhat.com
