### PR TITLE
Revert "create-diff-object: support for __jump_table"

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1174,58 +1174,6 @@ void kpatch_regenerate_parainstructions_sections(struct kpatch_elf *kelf)
 	sec->base->data->d_size = offset;
 }
 
-void kpatch_regenerate_jump_table_sections(struct kpatch_elf *kelf)
-{
-	struct section *sec;
-	struct table table;
-	struct rela *rela, *dstrela;
-	int i, nr = 0, offset = 0;
-
-	sec = find_section_by_name(&kelf->sections, ".rela__jump_table");
-	if (!sec)
-		return;
-
-	/* alloc buffer of original size (probably won't use it all) */
-	alloc_table(&table, sizeof(struct rela), sec->relas.nr);
-	dstrela = table.data;
-
-	for_each_rela(i, rela, &sec->relas) {
-		if (rela->sym->sec->status != SAME) {
-			log_debug("new/changed symbol %s found in jump table\n",
-			          rela->sym->name);
-			*dstrela = *rela;
-			dstrela->offset = offset;
-			dstrela->rela.r_offset = offset;
-			dstrela++;
-			offset += 8;
-			nr++;
-		}
-	}
-
-	if (!nr) {
-		/* no changed functions referenced by jump table */
-		sec->status = SAME;
-		sec->base->status = SAME;
-		return;
-	}
-
-	/* overwrite with new relas table */
-	table.nr = nr;
-	sec->relas = table;
-	sec->include = 1;
-	sec->base->include = 1;
-	/*
-	 * Adjust d_size but not d_buf. d_buf is overwritten in
-	 * kpatch_create_rela_section() from the relas table. No
-	 * point in regen'ing the buffer here just to be discarded
-	 * later.
-	 */
-	sec->data->d_size = sec->sh.sh_entsize * nr;
-
-	/* truncate __jump_table section */
-	sec->base->data->d_size = offset;
-}
-
 void kpatch_create_rela_section(struct section *sec, int link)
 {
 	struct rela *rela;
@@ -1583,7 +1531,6 @@ int main(int argc, char *argv[])
 	kpatch_regenerate_bug_table_rela_section(kelf_patched);
 	kpatch_regenerate_smp_locks_sections(kelf_patched);
 	kpatch_regenerate_parainstructions_sections(kelf_patched);
-	kpatch_regenerate_jump_table_sections(kelf_patched);
 
 	kpatch_include_standard_sections(kelf_patched);
 	num_changed = kpatch_include_changed_functions(kelf_patched);


### PR DESCRIPTION
This reverts commit 5852ddb6a22c282979b1a15604572f1add198bf2.

The __jump_table section is more complex than the initial analysis
determined.  The __jump_table has three relocs per entry that must
be pulled in together and one of the relocs is to symbols contained
in the __tracepoints section whose rela section references the
__tracepoint_strings section.  So it's more complex and should just
fail rather than appear that it is being handled properly.

Issue continues to be tracked in #157

Signed-off-by: Seth Jennings sjenning@redhat.com
