### PR TITLE
correct build requirements for Fedora 20; yum-utils was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install the dependencies for compiling kpatch:
 
 Install the dependencies for the "kpatch-build" command:
 
-    sudo yum install rpmdevtools pesign
+    sudo yum install rpmdevtools pesign yum-utils
     sudo yum-builddep kernel
 
     # optional, but highly recommended


### PR DESCRIPTION
correct build requirements for Fedora 20; yum-utils was missing but this package provides yum-builddep which is mentioned in the README.md file.
