### PR TITLE
kmod/core: check for needed kernel config options

### DIFF
--- a/kmod/core/Makefile
+++ b/kmod/core/Makefile
@@ -19,7 +19,5 @@ clean:
 
 
 # kbuild rules
-ifdef CONFIG_HAVE_FENTRY
 obj-m := kpatch.o
 kpatch-y := core.o
-endif

--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -44,6 +44,13 @@
 #include <asm/cacheflush.h>
 #include "kpatch.h"
 
+#if !defined(CONFIG_FUNCTION_TRACER) || \
+	!defined(CONFIG_HAVE_FENTRY) || \
+	!defined(CONFIG_MODULES) || \
+	!defined(CONFIG_SYSFS)
+#error "CONFIG_FUNCTION_TRACER, CONFIG_HAVE_FENTRY, CONFIG_MODULES, and CONFIG_SYSFS kernel config options are required"
+#endif
+
 #define KPATCH_HASH_BITS 8
 static DEFINE_HASHTABLE(kpatch_func_hash, KPATCH_HASH_BITS);
 


### PR DESCRIPTION
Yes, this is ugly.  There's a much cleaner way to do this for an in-tree
module, but this is the only way I know how to do it here.
