### PR TITLE
kmod/core: fixes in the unregister path

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -543,7 +543,8 @@ int kpatch_unregister(struct kpatch_module *kpmod)
 	int num_funcs = kpmod->num_funcs;
 	int i, ret;
 
-	WARN_ON(!kpmod->enabled);
+	if (!kpmod->enabled)
+		return -EINVAL;
 
 	down(&kpatch_mutex);
 


### PR DESCRIPTION
A few fixes in the unregister path:
- always decrement kpatch_num_registered
- return -EINVAL if not enabled
