### PR TITLE
kpatch-build: replace special characters in module name

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -146,6 +146,10 @@ if [[ "$PATCHNAME" =~ \.patch ]] || [[ "$PATCHNAME" =~ \.diff ]]; then
 	PATCHNAME="${PATCHNAME%.*}"
 fi
 
+# Only allow alphanumerics and '_' and '-' in the module name.
+# Everything else is replaced with '-'.
+PATCHNAME=${PATCHNAME//[^a-zA-Z0-9_-]/-}
+
 TEMPDIR="$(mktemp -d /tmp/kpatch-build-XXXXXX)" || die "mktemp failed"
 
 trap cleanup EXIT INT TERM


### PR DESCRIPTION
Having a '.' in the kmod name confuses lsmod, which prints "Size" and
"Used by" values of -2.  Prevent any special characters other than '_'
and '-', so that our patch module names will be consistent with typical
kmod names.
