### PR TITLE
Add dirname to initramfs

### DIFF
--- a/contrib/module-setup.sh
+++ b/contrib/module-setup.sh
@@ -22,6 +22,9 @@ install() {
     # install insmod (needed by kpatch script)
     inst_symlink /usr/sbin/insmod
 
+    # install dirname (needed by kpatch script)
+    inst /usr/bin/dirname
+    
     # install core module
     inst_any -d /usr/lib/modules/$kernel/kpatch/kpatch.ko /usr/local/lib/modules/$kernel/kpatch/kpatch.ko /usr/lib/modules/$kernel/kpatch/kpatch.ko
 


### PR DESCRIPTION
kpatch script need dirname to git SCRIPTDIR. But dracut won't copy it to
initramfs by default.

Signed-off-by: Madper Xie cxie@redhat.com
