### PR TITLE
Fix kpatch.ko build on Ubuntu Saucy.

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -39,7 +39,7 @@
 #include <linux/stop_machine.h>
 #include <linux/ftrace.h>
 #include <linux/hashtable.h>
-#include <linux/preempt_mask.h>
+#include <linux/hardirq.h>
 #include <asm/stacktrace.h>
 #include <asm/cacheflush.h>
 #include "kpatch.h"


### PR DESCRIPTION
The error likes:

```
make -C /lib/modules/3.11.0-12-generic/build M=/home/ryan/kpatch/kmod/core kpatch.ko
make[3]: Entering directory `/usr/src/linux-headers-3.11.0-12-generic'
  CC [M]  /home/ryan/kpatch/kmod/core/core.o
/home/ryan/kpatch/kmod/core/core.c:42:32: fatal error: linux/preempt_mask.h: No such file or directory
 #include <linux/preempt_mask.h>
```

I feel sorry to introduce this problem from my laster commit 6c2d6444.
Some old kernel doesn't have header file preempt_mask.h, and the safe
way is using hardirq.h to find in_nmi().

Signed-off-by: Jincheng Miao jincheng.miao@gmail.com
