### PR TITLE
fix incompatible pointer type warning

### DIFF
--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -41,7 +41,7 @@ static ssize_t patch_enabled_show(struct kobject *kobj,
 }
 
 static ssize_t patch_enabled_store(struct kobject *kobj,
-				   struct kobj_attribute *attr, char *buf,
+				   struct kobj_attribute *attr, const char *buf,
 				   size_t count)
 {
 	int ret;


### PR DESCRIPTION
Fixes the following warning:

kpatch-patch-hook.c:71:2: warning: initialization from incompatible pointer type [enabled by default]
  __ATTR(enabled, 0644, patch_enabled_show, patch_enabled_store);
  ^

Signed-off-by: Seth Jennings sjenning@redhat.com
