### PR TITLE
kmod: install core module to "extra" subdir

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -4,9 +4,9 @@ all: clean
 	$(MAKE) -C core
 
 install:
-	$(INSTALL) -d $(MODULESDIR)/$(shell uname -r)/kpatch
-	$(INSTALL) -m 644 core/kpatch.ko $(MODULESDIR)/$(shell uname -r)/kpatch
-	$(INSTALL) -m 644 core/Module.symvers $(MODULESDIR)/$(shell uname -r)/kpatch
+	$(INSTALL) -d $(MODULESDIR)/$(shell uname -r)/extra/kpatch
+	$(INSTALL) -m 644 core/kpatch.ko $(MODULESDIR)/$(shell uname -r)/extra/kpatch
+	$(INSTALL) -m 644 core/Module.symvers $(MODULESDIR)/$(shell uname -r)/extra/kpatch
 	$(INSTALL) -d $(DATADIR)/patch
 	$(INSTALL) -m 644 patch/* $(DATADIR)/patch
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -75,7 +75,7 @@ find_dirs() {
 		# installation path
 		TOOLSDIR="$(readlink -f $SCRIPTDIR/../libexec/kpatch)"
 		DATADIR="$(readlink -f $SCRIPTDIR/../share/kpatch)"
-		SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/modules/$(uname -r)/kpatch/Module.symvers)"
+		SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/modules/$(uname -r)/extra/kpatch/Module.symvers)"
 		return
 	fi
 

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -83,10 +83,10 @@ find_core_module() {
 	COREMOD="$SCRIPTDIR"/../kmod/core/kpatch.ko
 	[[ -f "$COREMOD" ]] && return
 
-	COREMOD="/usr/local/lib/modules/$(uname -r)/kpatch/kpatch.ko"
+	COREMOD="/usr/local/lib/modules/$(uname -r)/extra/kpatch/kpatch.ko"
 	[[ -f "$COREMOD" ]] && return
 
-	COREMOD="/usr/lib/modules/$(uname -r)/kpatch/kpatch.ko"
+	COREMOD="/usr/lib/modules/$(uname -r)/extra/kpatch/kpatch.ko"
 	[[ -f "$COREMOD" ]] && return
 
 	return 1


### PR DESCRIPTION
To be more consistent with other out-of-tree modules, install the core
module to /usr[/local]/lib/modules/`uname -r`/extra/kpatch/kpatch.ko.
