### PR TITLE
dracut: fix core module path

### DIFF
--- a/contrib/module-setup.sh
+++ b/contrib/module-setup.sh
@@ -26,7 +26,7 @@ install() {
     inst /usr/bin/dirname
     
     # install core module
-    inst_any -d /usr/lib/modules/$kernel/kpatch/kpatch.ko /usr/local/lib/modules/$kernel/kpatch/kpatch.ko /usr/lib/modules/$kernel/kpatch/kpatch.ko
+    inst_any -d /usr/lib/modules/$kernel/extra/kpatch/kpatch.ko /usr/local/lib/modules/$kernel/extra/kpatch/kpatch.ko /usr/lib/modules/$kernel/extra/kpatch/kpatch.ko
 
     # install patch modules
     if [[ -e /var/lib/kpatch/$kernel ]]; then


### PR DESCRIPTION
Forgot to update this file when moving the core module to the extras
subdirectory with a6694ffffff879b1255332e3b03e00b61630fa52.
