### PR TITLE
kpatch Ubuntu support and more

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -98,11 +98,11 @@ load_module () {
 		else
 			find_core_module || die "can't find core module"
 			echo "loading core module: $COREMOD"
-			/usr/sbin/insmod "$COREMOD" || die "failed to load core module"
+			insmod "$COREMOD" || die "failed to load core module"
 		fi
 	fi
 	echo "loading patch module: $1"
-	/usr/sbin/insmod "$1" "$2"
+	insmod "$1" "$2"
 }
 
 unload_module () {
@@ -120,7 +120,7 @@ unload_module () {
 	fi
 
 	echo "unloading patch module: $PATCH"
-	/usr/sbin/rmmod "$(basename $1)"
+	rmmod "$(basename $1)"
 }
 
 unload_disabled_modules() {


### PR DESCRIPTION
See issue #156

On Ubuntu 14.04 LTS
- `kpatch load` failed to insert the kpatch core module and the patch module
- `kpatch unload` failed to remove the patch module

Because `kpatch` script assumes that  `insmod` and `rmmod` reside in `/usr/sbin` whic is NOT the case for Debian and Ubuntu (in `/sbin`).

> NOTE: On Arch Linux, `kmod` installs `insmod` and `rmmod` to `/usr/bin`. Could be more cases for different distros.

The patch is the simplest change I can think of which makes the script distro independent.
