### PR TITLE
[RFC] set CONFIG_DEBUG_INFO=n during builds

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -212,6 +212,7 @@ else
 		mkdir -p "$OBJDIR"
 		mv "$HOME"/rpmbuild/BUILD/kernel-*/linux-"$ARCHVERSION" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
 
+		sed -i -e's/CONFIG_DEBUG_INFO=y/CONFIG_DEBUG_INFO=n/' "$SRCDIR/.config" || die
 		cp "$SRCDIR/.config" "$OBJDIR" || die
 		echo "-${ARCHVERSION##*-}" > "$SRCDIR/localversion" || die
 


### PR DESCRIPTION
I notice that there is a TON of disk activity during this builds on the
order of GBs per patch built.  This is largely because the vmlinux
intermediate files are rebuilt each time, each containing all of the
debug info which increases the size of these file by about an order of
magnitude. These operations are:

  LINK    vmlinux
  LD      vmlinux.o
  MODPOST vmlinux.o
  GEN     .version
  CHK     include/generated/compile.h
  UPD     include/generated/compile.h
  CC      init/version.o
  LD      init/built-in.o
  KSYM    .tmp_kallsyms1.o
  KSYM    .tmp_kallsyms2.o
  LD      vmlinux
  SORTEX  vmlinux
  SYSMAP  System.map

I have tested and the symbols stay in alignment without the debug info.
We strip the debug info out for the object diff'ing anyway.

Just wanted to see what you thought about saving time (and our SSDs
lifetime) by doing this.  If not, I think I'm going to have to move
~/.kpatch to tmpfs :)

Signed-off-by: Seth Jennings sjenning@redhat.com
