### PR TITLE
correlate symbols also by type

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -626,7 +626,8 @@ void kpatch_correlate_symbols(struct list_head *symlist1, struct list_head *syml
 
 	list_for_each_entry(sym1, symlist1, list) {
 		list_for_each_entry(sym2, symlist2, list) {
-			if (!strcmp(sym1->name, sym2->name)) {
+			if (!strcmp(sym1->name, sym2->name) &&
+			    sym1->type == sym2->type) {
 				sym1->twin = sym2;
 				sym2->twin = sym1;
 				/* set initial status, might change */


### PR DESCRIPTION
Both unpatched and patched objects may contain FILE
symbol with empty name. This is unexpected for
create-diff-object and could correlate 2 symbols
with same (empty) name but different types:
  sym 00, type 0, bind 0, ndx 00, name  (SAME)
  ...
  sym 425, type 4, bind 0, ndx 65521, name  (SAME)
  ...
  signal.o: changed function: do_rt_tgsigqueueinfo
  signal.o: changed function: do_rt_sigqueueinfo
  signal.o: changed function: get_signal_to_deliver
  signal.o: signal.o: changed section .rela__jump_table not selected for inclusion
  signal.o: 1 unsupported section change(s)
  /root/kpatch/kpatch-build/create-diff-object: unreconcilable difference

Introduce condition to match symbols also by type.
Fixes #202 

Signed-off-by: Jan Stancek jstancek@redhat.com
