### PR TITLE
improve kpatch unload checking

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -106,27 +106,22 @@ load_module () {
 }
 
 unload_module () {
-	# strip leading path, .ko suffix and convert '-' to '_' so we can find
-	# the module name in sysfs
-	PATCH="$(basename $1)"
+	PATCH="${1//-/_}"
 	PATCH="${PATCH%.ko}"
-	PATCH="${PATCH//-/_}"
-
 	ENABLED=/sys/kernel/kpatch/patches/"$PATCH"/enabled
-
-	if [[ -e "$ENABLED" ]] && [[ $(cat "$ENABLED") -eq 1 ]]; then
+	[[ -e "$ENABLED" ]] || die "patch module $1 is not loaded"
+	if [[ $(cat "$ENABLED") -eq 1 ]]; then
 		echo "disabling patch module: $PATCH"
 		echo 0 > $ENABLED || die "can't disable $PATCH"
 	fi
-
 	echo "unloading patch module: $PATCH"
-	rmmod "$(basename $1)"
+	rmmod $PATCH
 }
 
 unload_disabled_modules() {
 	for module in /sys/kernel/kpatch/patches/*; do
 		if [[ $(cat $module/enabled) -eq 0 ]]; then
-			unload_module $module || die "failed to unload $module"
+			unload_module $(basename $module) || die "failed to unload $module"
 		fi
 	done
 }


### PR DESCRIPTION
Currently, kpatch unload passes the raw argument to basename since the
user may pass a path into the subcommand. This makes the argument hard
to validate.  This can be improved since the set of acceptable inputs is
already known, namely the list of loaded patch modules.

This commit changes the kpatch unload subcommand to accept only the
module name, since kpatch should already be aware of it since it is
loaded.  It is then trivial to validate the user input since, if it is
not the name of a loaded module, it is invalid.

Signed-off-by: Seth Jennings sjenning@redhat.com
