### PR TITLE
kpatch-build module support

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -263,78 +263,76 @@ cd "$SRCDIR" || die
 patch -N -p1 --dry-run < "$PATCHFILE" || die "source patch file failed to apply"
 
 cp -LR "$DATADIR/patch" "$TEMPDIR" || die
-for TARGET in $TARGETS # START target loop
-do
-TARGETNAME=$(basename $TARGET)
-TEMPDIR="$TEMPDIR/$TARGETNAME"
-mkdir -p "$TEMPDIR"
-make "O=$OBJDIR" clean >> "$LOGFILE" 2>&1 || die
+for TARGET in $TARGETS; do # START target loop
+	TARGETNAME=$(basename $TARGET)
+	TEMPDIR="$TEMPDIR/$TARGETNAME"
+	mkdir -p "$TEMPDIR"
+	make "O=$OBJDIR" clean >> "$LOGFILE" 2>&1 || die
 
-echo "Building original $TARGETNAME"
-make mrproper >> "$LOGFILE" 2>&1 || die
-make "-j$CPUS" $TARGET "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
+	echo "Building original $TARGETNAME"
+	make mrproper >> "$LOGFILE" 2>&1 || die
+	make "-j$CPUS" $TARGET "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
 
-echo "Building patched $TARGETNAME"
-cp "$PATCHFILE" "$APPLIEDPATCHFILE" || die
-patch -N -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die
-make "-j$CPUS" $TARGET "O=$OBJDIR" 2>&1 | tee -a "$TEMPDIR/patched_build.log" >> "$LOGFILE"
-[[ "${PIPESTATUS[0]}" -eq 0 ]] || die
-
-echo "Detecting changed objects"
-grep CC "$TEMPDIR/patched_build.log" | grep -v -e init/version.o -e scripts/mod/devicetable-offsets.s -e scripts/mod/file2alias.o > "$TEMPDIR/tmp"
-while read FILE; do
-	if [[ $TARGET = "vmlinux" ]]; then
-		echo $FILE | awk '{print $2}' >> "$TEMPDIR/changed_objs"
-	else
-		echo $FILE | awk '{print $3}' >> "$TEMPDIR/changed_objs"
-	fi
-done < "$TEMPDIR/tmp"
-[[ ! -s "$TEMPDIR/changed_objs" ]] && die "no changed objects were detected"
-grep -q asm-offsets.s $TEMPDIR/changed_objs && die "a struct definition change was detected"
-
-echo "Rebuilding changed objects"
-rm -rf "$OBJDIR2"
-mkdir -p "$OBJDIR2"
-cp "$OBJDIR/.config" "$OBJDIR2" || die
-mkdir "$TEMPDIR/patched"
-for i in $(cat $TEMPDIR/changed_objs); do
-	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
-	$STRIPCMD "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
-	mkdir -p "$TEMPDIR/patched/$(dirname $i)"
-	cp -f "$OBJDIR2/$i" "$TEMPDIR/patched/$i" || die
-	
-done
-patch -R -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1
-rm -f "$APPLIEDPATCHFILE"
-mkdir "$TEMPDIR/orig"
-for i in $(cat $TEMPDIR/changed_objs); do
-	rm -f "$i"
-	KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
-	$STRIPCMD -d "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
-	mkdir -p "$TEMPDIR/orig/$(dirname $i)"
-	cp -f "$OBJDIR2/$i" "$TEMPDIR/orig/$i" || die
-done
-
-echo "Extracting new and modified ELF sections"
-cd "$TEMPDIR/orig"
-FILES="$(find * -type f)"
-cd "$TEMPDIR"
-mkdir output
-if [[ $TARGET = "vmlinux" ]]; then
-	KOBJFILE=$VMLINUX
-else
-	KOBJFILE="/lib/modules/$ARCHVERSION/kernel/$TARGET"
-	[[ -e "$KOBJFILE" ]] || die "module not found at $KOBJFILE. Ensure kernel package is installed."
-fi
-for i in $FILES; do
-	mkdir -p "output/$(dirname $i)"
-	"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+	echo "Building patched $TARGETNAME"
+	cp "$PATCHFILE" "$APPLIEDPATCHFILE" || die
+	patch -N -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die
+	make "-j$CPUS" $TARGET "O=$OBJDIR" 2>&1 | tee -a "$TEMPDIR/patched_build.log" >> "$LOGFILE"
 	[[ "${PIPESTATUS[0]}" -eq 0 ]] || die
-done
-cd output
-ld -r -o $TEMPDIR/output.o $FILES >> "$LOGFILE" 2>&1 || die
-TEMPDIR=$(dirname $TEMPDIR)
-cd "$SRCDIR"
+
+	echo "Detecting changed objects"
+	grep CC "$TEMPDIR/patched_build.log" | grep -v -e init/version.o -e scripts/mod/devicetable-offsets.s -e scripts/mod/file2alias.o > "$TEMPDIR/tmp"
+	while read FILE; do
+		if [[ $TARGET = "vmlinux" ]]; then
+			echo $FILE | awk '{print $2}' >> "$TEMPDIR/changed_objs"
+		else
+			echo $FILE | awk '{print $3}' >> "$TEMPDIR/changed_objs"
+		fi
+	done < "$TEMPDIR/tmp"
+	[[ ! -s "$TEMPDIR/changed_objs" ]] && die "no changed objects were detected"
+	grep -q asm-offsets.s $TEMPDIR/changed_objs && die "a struct definition change was detected"
+
+	echo "Rebuilding changed objects"
+	rm -rf "$OBJDIR2"
+	mkdir -p "$OBJDIR2"
+	cp "$OBJDIR/.config" "$OBJDIR2" || die
+	mkdir "$TEMPDIR/patched"
+	for i in $(cat $TEMPDIR/changed_objs); do
+		KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
+		$STRIPCMD "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
+		mkdir -p "$TEMPDIR/patched/$(dirname $i)"
+		cp -f "$OBJDIR2/$i" "$TEMPDIR/patched/$i" || die
+	done
+	patch -R -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1
+	rm -f "$APPLIEDPATCHFILE"
+	mkdir "$TEMPDIR/orig"
+	for i in $(cat $TEMPDIR/changed_objs); do
+		rm -f "$i"
+		KCFLAGS="-ffunction-sections -fdata-sections" make "$i" "O=$OBJDIR2" >> "$LOGFILE" 2>&1 || die
+		$STRIPCMD -d "$OBJDIR2/$i" >> "$LOGFILE" 2>&1 || die
+		mkdir -p "$TEMPDIR/orig/$(dirname $i)"
+		cp -f "$OBJDIR2/$i" "$TEMPDIR/orig/$i" || die
+	done
+
+	echo "Extracting new and modified ELF sections"
+	cd "$TEMPDIR/orig"
+	FILES="$(find * -type f)"
+	cd "$TEMPDIR"
+	mkdir output
+	if [[ $TARGET = "vmlinux" ]]; then
+		KOBJFILE=$VMLINUX
+	else
+		KOBJFILE="/lib/modules/$ARCHVERSION/kernel/$TARGET"
+		[[ -e "$KOBJFILE" ]] || die "module not found at $KOBJFILE. Ensure kernel package is installed."
+	fi
+	for i in $FILES; do
+		mkdir -p "output/$(dirname $i)"
+		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+		[[ "${PIPESTATUS[0]}" -eq 0 ]] || die
+	done
+	cd output
+	ld -r -o $TEMPDIR/output.o $FILES >> "$LOGFILE" 2>&1 || die
+	TEMPDIR=$(dirname $TEMPDIR)
+	cd "$SRCDIR"
 done # END target loop
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"


### PR DESCRIPTION
This commit adds support for module patching with kpatch-build.
It introduces a new option, -t/--targets, that allows the user to
specify kernel make targets that are impacted by the patch.  These
targets will be examined by kpatch-build for changes.

While this approach requires the user to provide more information to
kpatch-build about what exactly has changed, it is better that
rebuilding the entire source tree (make vmlinux && make modules) which
would dramatically increase the runtime and disk space requirements of
using kpatch-build.

Future improvements could include a script that will independently
generate the targets list file.
