### PR TITLE
RFC: another interface refactoring

### DIFF
--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -23,13 +23,24 @@
 #ifndef _KPATCH_H_
 #define _KPATCH_H_
 
-struct kpatch_patch {
+#include <linux/types.h>
+#include <linux/module.h>
+
+struct kpatch_func {
+	/* public */
 	unsigned long new_addr;
 	unsigned long new_size;
 	unsigned long old_offset;
 	unsigned long old_size;
 	char *name;
 	char *objname;
+	struct list_head list;
+
+	/* private */
+	struct hlist_node node;
+	unsigned long old_addr;
+	struct kpatch_module *kpmod;
+	enum kpatch_op op;
 };
 
 struct kpatch_dynrela {
@@ -39,33 +50,33 @@ struct kpatch_dynrela {
 	char *name;
 	char *objname;
 	int addend;
+	struct list_head list;
 };
 
-#ifdef __KERNEL__
+struct kpatch_object {
+	struct list_head list;
+	struct list_head funcs;
+	struct list_head dynrelas;
 
-#include <linux/types.h>
-#include <linux/module.h>
+	/* private */
+	bool patched;
+};
 
 struct kpatch_module {
 	/* public */
 	struct module *mod;
-	struct kpatch_patch *patches;
-	struct kpatch_dynrela *dynrelas;
-	int patches_nr;
-	int dynrelas_nr;
+	struct list_head objects;
+
+	/* public read-only */
 	bool enabled;
 
 	/* private */
 	struct list_head list;
-	struct kpatch_func *funcs;
-	bool pending;
 };
 
 extern struct kobject *kpatch_patches_kobj;
 
 extern int kpatch_register(struct kpatch_module *kpmod, bool replace);
 extern int kpatch_unregister(struct kpatch_module *kpmod);
-
-#endif /* __KERNEL__ */
 
 #endif /* _KPATCH_H_ */

--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -1,0 +1,38 @@
+/*
+ * kpatch-patch.h
+ *
+ * Copyright (C) 2014 Josh Poimboeuf <jpoimboe@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ *
+ * Contains the structs used for the patch module special sections
+ */
+
+struct kpatch_patch_func {
+	unsigned long new_addr;
+	unsigned long new_size;
+	unsigned long old_offset;
+	unsigned long old_size;
+	char *name;
+	char *objname;
+};
+
+struct kpatch_patch_dynrela {
+	unsigned long dest;
+	unsigned long src;
+	unsigned long type;
+	char *name;
+	char *objname;
+	int addend;
+};


### PR DESCRIPTION
This is a proposal for how we can refactor the interfaces.  It doesn't
compile, so it's probably best not to merge it ;-)

The recent module patching code has exposed some problems with our data
structures.  We currently patch the funcs and dynrelas individually,
which is kind of scary now that different objects can be patched at
different times.  Instead I think it would be much cleaner to group them
by patched object.  Here's a proposal for new interfaces which would
make it a lot easier to do so.
- Completely separate the create-diff-object <-> patch module interface
  from the patch module <-> core module interface.  create-diff-object
  will include "kpatch-patch.h" but not "kpatch.h".  Thus,
  create-diff-object has no knowledge about the core module's
  interfaces, and the core module has no knowledge about the patch
  module's special sections.
- kpatch-patch.h defines the format of the patch module special
  sections.  It's used by create-diff-object to create the special
  sections and used by the patch module to read them.
- kpatch.h still defines the core module interfaces.  Each kpatch_module
  has a list of kpatch_objects for each module object to be patched.
  Each kpatch_object has a list of kpatch_funcs and a list of
  kpatch_dynrelas.  The patch module creates these lists when populating
  kpatch_module.  This way of structuring the data allows us to patch
  funcs and dynrelas on a per patched object basis.
