### PR TITLE
create-diff-object: remove SHF_WRITE hack

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1687,7 +1687,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 	sec->sh.sh_type = SHT_PROGBITS;
 	sec->sh.sh_entsize = sizeof(*dynrelas);
 	sec->sh.sh_addralign = 8;
-	sec->sh.sh_flags = SHF_ALLOC | SHF_WRITE;
+	sec->sh.sh_flags = SHF_ALLOC;
 
 	/* create .rela.kpatch.dynrelas*/
 


### PR DESCRIPTION
We're no longer writing directly to the dynrela section, since the core
module has its own kpatch_dynrela data structures now.
