### PR TITLE
kpatch-build: DEBUG for create-diff-object

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -385,6 +385,7 @@ for i in $FILES; do
 		KOBJFILE="$(readlink -f $KOBJFILE)"
 	fi
 	cd $TEMPDIR
+	debugopt=
 	[[ $DEBUG -eq 1 ]] && debugopt=-d
 	"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
 	[[ "${PIPESTATUS[0]}" -eq 0 ]] || die


### PR DESCRIPTION
Add -d option to create-diff-object when DEBUG is set.  That way for
weird kpatch-build issues we can just tell people to use the -d flag and
then provide the build log.
