### PR TITLE
kpatch-build: --sourcedir 2.0

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -263,10 +263,9 @@ if [[ -n "$USERSRCDIR" ]]; then
 
 	echo "Detecting kernel version"
 	cd "$SRCDIR"
-	make mrproper >> "$LOGFILE" 2>&1 || die
-	make "O=$OBJDIR" include/generated/utsrelease.h >> "$LOGFILE" 2>&1 || die
-	ARCHVERSION=$(awk '{print $3}' "$OBJDIR"/include/generated/utsrelease.h) || die "can't find version in utsrelease.h"
-	ARCHVERSION=${ARCHVERSION//\"/}
+	make mrproper >> "$LOGFILE" 2>&1 || die "make mrproper failed"
+	make O="$OBJDIR" prepare >> "$LOGFILE" 2>&1 || die "make prepare failed"
+	ARCHVERSION=$(make O="$OBJDIR" kernelrelease) || die "make kernelrelease failed"
 
 elif [[ -e "$SRCDIR" ]] && [[ -e "$CACHEDIR"/version ]] && [[ $(cat "$CACHEDIR"/version) = $ARCHVERSION ]]; then
 	echo "Using cache at $SRCDIR"


### PR DESCRIPTION
In my experience this is a much more useful implementation of the
"--sourcedir" option:
- use the source tree in-place rather than first copying it to
  ~/.kpatch/src.  In my case this avoids a 5GB copy, including the
  entire .git subdirectory, and allows ccache to be reused.
- find the vmlinux and .config files in the sourcedir
- autodetect the ARCHVERSION
