### PR TITLE
kpatch: remove the path to modinfo to fix the info function

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -256,7 +256,7 @@ case "$1" in
 	PATCH="$2"
 	find_module "$PATCH" || die "can't find $PATCH"
 	echo "Patch information for $PATCH:"
-	/usr/sbin/modinfo "$MODULE" || die "failed to get info for module $PATCH"
+	modinfo "$MODULE" || die "failed to get info for module $PATCH"
 	;;
 
 "help"|"-h"|"--help")


### PR DESCRIPTION
The path /usr/sbin to modinfo doesn't exist on Ubuntu/Debian.

```
# kpatch info kpatch-meminfo-string.ko
Patch information for kpatch-meminfo-string.ko:
/usr/local/sbin/kpatch: line 259: /usr/sbin/modinfo: No such file or directory
kpatch: failed to get info for module kpatch-meminfo-string.ko
```

Replaced /usr/sbin/modinfo by modinfo fixed the problem

```
# kpatch info kpatch-meminfo-string.ko
Patch information for kpatch-meminfo-string.ko:
filename:       /usr/src/kpatch-meminfo-string.ko
license:        GPL
depends:        kpatch
vermagic:       3.13.0.2-29-generic SMP mod_unload modversions 
parm:           replace:replace all previously loaded patch modules (bool)
```
