### PR TITLE
create-diff-object: fixup new function handling

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -961,11 +961,8 @@ void kpatch_include_symbol(struct symbol *sym, int recurselevel)
 		goto out;
 	sec->rela->include = 1;
 	inc_printf("section %s is included\n", sec->rela->name);
-	list_for_each_entry(rela, &sec->rela->relas, list) {
-		if (rela->sym->include)
-			continue;
+	list_for_each_entry(rela, &sec->rela->relas, list)
 		kpatch_include_symbol(rela->sym, recurselevel+1);
-	}
 out:
 	inc_printf("end include_symbol(%s)\n", sym->name);
 	return;
@@ -999,12 +996,6 @@ int kpatch_include_changed_functions(struct kpatch_elf *kelf)
 		    sym->type == STT_FUNC) {
 			changed_nr++;
 			log_normal("changed function: %s\n", sym->name);
-			kpatch_include_symbol(sym, 0);
-		}
-
-		if (sym->status == NEW &&
-		    sym->type == STT_FUNC) {
-			log_normal("new function: %s\n", sym->name);
 			kpatch_include_symbol(sym, 0);
 		}
 


### PR DESCRIPTION
The original logic in the inclusion tree code worked under the
assumption that it was the only code path marking symbols for inclusion.
Therefore, if the symbol had been marked as included, it could be safely
assumed that we also already called kpatch_include_symbol() on it.  With
the special section handling marking symbols as included, however, this
assumption is not valid.

We should call kpatch_include_symbol() regardless of whether or not the
symbol has already been marked as included or not in order to possible
include the symbol's entire bundle.

Signed-off-by: Seth Jennings sjenning@redhat.com
