### PR TITLE
create-diff-object: fixup new function handling

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -948,7 +948,8 @@ void kpatch_include_symbol(struct symbol *sym, int recurselevel)
 	 * if an unchanged local symbol.  This a base case for the
 	 * inclusion recursion.
 	 */
-	if (!sym->sec || (sym->type != STT_SECTION && sym->status == SAME))
+	if (!sym->sec || sym->sec->include ||
+	    (sym->type != STT_SECTION && sym->status == SAME))
 		goto out;
 	sec = sym->sec;
 	sec->include = 1;
@@ -961,11 +962,8 @@ void kpatch_include_symbol(struct symbol *sym, int recurselevel)
 		goto out;
 	sec->rela->include = 1;
 	inc_printf("section %s is included\n", sec->rela->name);
-	list_for_each_entry(rela, &sec->rela->relas, list) {
-		if (rela->sym->include)
-			continue;
+	list_for_each_entry(rela, &sec->rela->relas, list)
 		kpatch_include_symbol(rela->sym, recurselevel+1);
-	}
 out:
 	inc_printf("end include_symbol(%s)\n", sym->name);
 	return;
@@ -999,12 +997,6 @@ int kpatch_include_changed_functions(struct kpatch_elf *kelf)
 		    sym->type == STT_FUNC) {
 			changed_nr++;
 			log_normal("changed function: %s\n", sym->name);
-			kpatch_include_symbol(sym, 0);
-		}
-
-		if (sym->status == NEW &&
-		    sym->type == STT_FUNC) {
-			log_normal("new function: %s\n", sym->name);
 			kpatch_include_symbol(sym, 0);
 		}
 


### PR DESCRIPTION
Lets try again.  This time with a check to see if the underlying section is already included before proceeding. Passes a quick integration test for me.

The original logic in the inclusion tree code worked under the
assumption that it was the only code path marking symbols for inclusion.
Therefore, if the symbol had been marked as included, it could be safely
assumed that we also already called kpatch_include_symbol() on it.  With
the special section handling marking symbols as included, however, this
assumption is not valid.

We should call kpatch_include_symbol() regardless of whether or not the
symbol has already been marked as included or not in order to possible
include the symbol's entire bundle.

Signed-off-by: Seth Jennings sjenning@redhat.com
