### PR TITLE
test: remove annoying printks

### DIFF
--- a/test/integration/bug-table-section.patch
+++ b/test/integration/bug-table-section.patch
@@ -2,11 +2,12 @@ Index: src/fs/proc/proc_sysctl.c
 ===================================================================
 --- src.orig/fs/proc/proc_sysctl.c
 +++ src/fs/proc/proc_sysctl.c
-@@ -266,6 +266,7 @@ void sysctl_head_put(struct ctl_table_he
+@@ -266,6 +266,8 @@ void sysctl_head_put(struct ctl_table_he
  
  static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
  {
-+	printk("kpatch-test: testing __bug_table section changes\n");
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
  	BUG_ON(!head);
  	spin_lock(&sysctl_lock);
  	if (!use_table(head))

--- a/test/integration/fixup-section.patch
+++ b/test/integration/fixup-section.patch
@@ -2,11 +2,12 @@ Index: src/fs/readdir.c
 ===================================================================
 --- src.orig/fs/readdir.c
 +++ src/fs/readdir.c
-@@ -169,6 +169,7 @@ static int filldir(void * __buf, const c
+@@ -169,6 +169,8 @@ static int filldir(void * __buf, const c
  			goto efault;
  	}
  	dirent = buf->current_dir;
-+	printk("kpatch-test: testing .fixup section changes\n");
++	if (dirent->d_ino == 12345678)
++		printk("kpatch-test: testing .fixup section changes\n");
  	if (__put_user(d_ino, &dirent->d_ino))
  		goto efault;
  	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/smp-locks-section.patch
+++ b/test/integration/smp-locks-section.patch
@@ -2,11 +2,12 @@ Index: src/drivers/tty/tty_buffer.c
 ===================================================================
 --- src.orig/drivers/tty/tty_buffer.c
 +++ src/drivers/tty/tty_buffer.c
-@@ -245,6 +245,7 @@ static int __tty_buffer_request_room(str
+@@ -247,6 +247,8 @@ static int __tty_buffer_request_room(str
  	struct tty_buffer *b, *n;
  	int left, change;
  
-+	printk("kpatch-test: testing .smp_locks section changes\n");
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
  	b = buf->tail;
  	if (b->flags & TTYB_NORMAL)
  		left = 2 * b->size - b->used;

--- a/test/integration/tracepoints-section.patch
+++ b/test/integration/tracepoints-section.patch
@@ -2,11 +2,12 @@ Index: src/kernel/timer.c
 ===================================================================
 --- src.orig/kernel/timer.c
 +++ src/kernel/timer.c
-@@ -1370,6 +1370,8 @@ static void run_timer_softirq(struct sof
+@@ -1370,6 +1370,9 @@ static void run_timer_softirq(struct sof
  {
  	struct tvec_base *base = __this_cpu_read(tvec_bases);
  
-+	printk("kpatch-test: testing __tracepoints section changes\n");
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
 +
  	hrtimer_run_pending();
  


### PR DESCRIPTION
The printks in the integration tests aren't very useful and annoyingly
fill up the dmesg buffer.  Remove them by making them contingent on
unlikely conditions.
