### PR TITLE
kmod/core: fix ftrace unregister order

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -459,21 +459,20 @@ static int kpatch_ftrace_remove_func(unsigned long ip)
 	if (kpatch_get_func(ip))
 		return 0;
 
+	if (kpatch_num_patched == 1) {
+		ret = unregister_ftrace_function(&kpatch_ftrace_ops);
+		if (ret) {
+			pr_err("can't unregister ftrace handler\n");
+			return ret;
+		}
+	}
+	kpatch_num_patched--;
+
 	ret = ftrace_set_filter_ip(&kpatch_ftrace_ops, ip, 1, 0);
 	if (ret) {
 		pr_err("can't remove ftrace filter at address 0x%lx\n", ip);
 		return ret;
 	}
-
-	if (kpatch_num_patched == 1) {
-		ret = unregister_ftrace_function(&kpatch_ftrace_ops);
-		if (ret) {
-			pr_err("can't unregister ftrace handler\n");
-			ftrace_set_filter_ip(&kpatch_ftrace_ops, ip, 0, 0);
-			return ret;
-		}
-	}
-	kpatch_num_patched--;
 
 	return 0;
 }


### PR DESCRIPTION
Currently, when removing a patch module, the ftrace buffer gets flooded
with traces.  This happens because we're clearing the ftrace ops filter
before unregistering the ops, which creates a small window where all
functions are being traced.

We should be doing the unregistering in the reverse order in which we
registered, meaning ops should be unregistered and _then_ the filter
should be cleared.
