### PR TITLE
kpatch-build: add make scripts to avoid some errors

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -481,6 +481,7 @@ echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"
 cd "$SRCDIR"
 make prepare >> "$LOGFILE" 2>&1 || die
+make scripts >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/output"
 ld -r -o ../patch/output.o $FILES >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/patch"


### PR DESCRIPTION
To avoid some errors during the patch compilation.

```
+ mkdir -p /tmp/kpatch-build-w8E27h/patched/scripts/basic
+ cp -f /root/.kpatch/obj2/scripts/basic/fixdep /tmp/kpatch-build-w8E27h/patched/scripts/basic/fixdep
+ for i in '$(cat $TEMPDIR/changed_objs)'
+ KCFLAGS='-ffunction-sections -fdata-sections'
+ make scripts/selinux/genheaders/genheaders O=/root/.kpatch/obj2
+ die
+ [[ -z '' ]]
+ warn 'kpatch build failed. Check /tmp/kpatch-build-1404238429.log for more details.'
+ echo 'ERROR: kpatch build failed. Check /tmp/kpatch-build-1404238429.log for more details.'
ERROR: kpatch build failed. Check /tmp/kpatch-build-1404238429.log for more details.
+ exit 1
```
