### PR TITLE
support forced patching

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -205,6 +205,9 @@ static void kpatch_backtrace_address_verify(void *data, unsigned long address,
 		const char *func_name;
 		struct kpatch_func *active_func;
 
+		if (func->force)
+			continue;
+
 		active_func = kpatch_get_func(func->old_addr);
 		if (!active_func) {
 			/* patching an unpatched func */

--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -40,6 +40,7 @@ struct kpatch_func {
 	unsigned long old_size;
 	const char *name;
 	struct list_head list;
+	int force;
 
 	/* private */
 	struct hlist_node node;

--- a/kmod/patch/kpatch-macros.h
+++ b/kmod/patch/kpatch-macros.h
@@ -40,7 +40,7 @@ struct kpatch_unload {
 	};
 
 /*
- * KPATCH_UNLOAD_HOOK
+ * KPATCH_UNLOAD_HOOK macro
  *
  * Same as LOAD hook with s/load/unload/
  */
@@ -50,5 +50,18 @@ struct kpatch_unload {
 		.fn = _fn, \
 		.objname = NULL \
 	};
+/*
+ * KPATCH_FORCE_UNSAFE macro
+ *
+ * USE WITH EXTREME CAUTION!
+ *
+ * Allows patch authors to bypass the activeness safety check at patch
+ * load time. Do this ONLY IF 1) the patch application will always/likely
+ * fail due to the function being on the stack of at least one thread at
+ * all times and 2) it is safe for both the original and patched versions
+ * of the function to run concurrently.
+ */
+#define KPATCH_FORCE_UNSAFE(_fn) \
+	void *__kpatch_force_func_##_fn __section(.kpatch.force) = _fn;
 
-#endif /* __KPATCH_HOOKS_H_ */
+#endif /* __KPATCH_MACROS_H_ */

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -34,6 +34,7 @@ extern struct kpatch_patch_func __kpatch_funcs[], __kpatch_funcs_end[];
 extern struct kpatch_patch_dynrela __kpatch_dynrelas[], __kpatch_dynrelas_end[];
 extern struct kpatch_patch_hook __kpatch_hooks_load[], __kpatch_hooks_load_end[];
 extern struct kpatch_patch_hook __kpatch_hooks_unload[], __kpatch_hooks_unload_end[];
+extern unsigned long __kpatch_force_funcs[], __kpatch_force_funcs_end[];
 
 static struct kpatch_module kpmod;
 static struct kobject *patch_kobj;
@@ -221,6 +222,15 @@ static void patch_free_objects(void)
 
 }
 
+static int is_func_forced(unsigned long addr)
+{
+	unsigned long *a;
+	for (a = __kpatch_force_funcs; a < __kpatch_force_funcs_end; a++)
+		if (*a == addr)
+			return 1;
+	return 0;
+}
+
 static int patch_make_funcs_list(struct list_head *objects)
 {
 	struct kpatch_object *object;
@@ -250,6 +260,7 @@ static int patch_make_funcs_list(struct list_head *objects)
 		func->old_offset = p_func->old_offset;
 		func->old_size = p_func->old_size;
 		func->name = p_func->name;
+		func->force = is_func_forced(func->new_addr);
 		list_add_tail(&func->list, &object->funcs);
 
 		func_obj = func_kobj_alloc();

--- a/kmod/patch/kpatch.lds
+++ b/kmod/patch/kpatch.lds
@@ -23,4 +23,10 @@ SECTIONS
     __kpatch_hooks_unload_end = . ;
     QUAD(0);
   }
+  .kpatch.force : {
+    __kpatch_force_funcs = . ;
+    *(.kpatch.force)
+    __kpatch_force_funcs_end = . ;
+    QUAD(0);
+  }
 }


### PR DESCRIPTION
Some functions in the kernel are always on the stack of some thread
in the system.  Attempts to patch these function will currently always
fail the activeness safety check.

However, through human inspection, it can be determined that, for a
particular function, consistency is maintained even if the old and new
versions of the function run concurrently.

This commit introduces a KPATCH_FORCE_UNSAFE() macro to define patched
functions that such be exempted from the activeness safety check.

Signed-off-by: Seth Jennings sjenning@redhat.com
