### PR TITLE
kpatch-build: add -a flag to strings command to find gcc version

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -105,7 +105,7 @@ find_dirs() {
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
 	local gccver=$(gcc --version |head -n1 |cut -d' ' -f3-)
-	local kgccver=$(strings $VMLINUX |grep "GCC:" |head -n1 |cut -d' ' -f3-)
+	local kgccver=$(strings -a $VMLINUX |grep "GCC:" |head -n1 |cut -d' ' -f3-)
 	if [[ $gccver != $kgccver ]]; then
 		warn "gcc/kernel version mismatch"
 		return 1


### PR DESCRIPTION
Ran into a bit of trouble during the gcc version check. Sometimes the "GCC: . . ." line gets tucked away in the `.comment` section and doesn't show up in the default invocation of `strings`. Add the `-a` (all) flag to scan all sections.
