### PR TITLE
create-diff-object: don't create __fentry__ dynrelas

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1816,8 +1816,22 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 			} else {
 				/*
 				 * We have a patch to a module which references
-				 * a global symbol.  First try to find it in
-				 * the module being patched.
+				 * a global symbol.
+				 */
+
+				/*
+				 * __fentry__ relas can't be converted to
+				 * dynrelas because the ftrace module init code
+				 * runs before the dynrela code can initialize
+				 * them.  __fentry__ is exported by the kernel,
+				 * so leave it as a normal rela.
+				 */
+				if (!strcmp(rela->sym->name, "__fentry__"))
+					continue;
+
+				/*
+				 * Try to find the symbol in the module being
+				 * patched.
 				 */
 				if (lookup_global_symbol(table, rela->sym->name,
 							 &result))


### PR DESCRIPTION
This fixes the following issue for a patch which changes a module:

  kpatch_create_mcount_sections: 1968: bad first rela in .rela.text.e_show

The first rela is "bad" because the real first rela was converted to a
dynrela and then removed from the rela list.

This is a temporary fix.  The more permanent fix should be to allow
lookups in vmlinux for patched modules so we don't create any
unnecessary dynrelas.
