### PR TITLE
kpatch-build: extract GCC version from .comment section

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -105,7 +105,7 @@ find_dirs() {
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
 	local gccver=$(gcc --version |head -n1 |cut -d' ' -f3-)
-	local kgccver=$(strings $VMLINUX |grep "GCC:" |head -n1 |cut -d' ' -f3-)
+	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f6-)
 	if [[ $gccver != $kgccver ]]; then
 		warn "gcc/kernel version mismatch"
 		return 1


### PR DESCRIPTION
Extract the GCC version from the .comment section of vmlinux.  This
hopefully makes the version check more robust across various distros.

Fixes #297.
