### PR TITLE
create-diff-object: fix for unincluded sec->secsym

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1134,6 +1134,9 @@ void kpatch_migrate_included_elements(struct kpatch_elf *kelf, struct kpatch_elf
 		list_del(&sec->list);
 		list_add_tail(&sec->list, &out->sections);
 		sec->index = 0;
+		if (!is_rela_section(sec) && sec->secsym && !sec->secsym->include)
+			/* break link to non-included section symbol */
+			sec->secsym = NULL;
 	}
 
 	/* migrate included symbols from kelf to out */


### PR DESCRIPTION
When running kpatch-build with -d, I was getting a seg fault.  It was
faulting in kpatch_dump_kelf() when trying to print sec->secsym->name
for the .smp_locks section.  It turns out that the section was included
but its section symbol wasn't included, so sec->secsym pointed to freed
memory.
