### PR TITLE
kpatch: pass basename of argument to unload_module

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -165,7 +165,7 @@ case "$1" in
 "unload")
 	[[ "$#" -ne 2 ]] && usage
 	[[ $2 =~ ^- ]] && usage
-	unload_module "$2" || die "failed to unload module $2"
+	unload_module "$(basename $2)" || die "failed to unload module $2"
 	;;
 
 "install")


### PR DESCRIPTION
The kpatch script is unable to recognize the module if I specify a path as an argument: `kpatch unload path/to/module.ko`.
