### PR TITLE
update supported kernel version

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ We do have plans to implement something like that.
 
 **Q. What kernels are supported?**
 
-kpatch needs gcc >= 4.8 and Linux >= 3.9 for use of the -mfentry flag.
+kpatch needs gcc >= 4.8 and Linux >= 3.9.
 
 **Q. Is it possible to remove a patch?**
 


### PR DESCRIPTION
Some of the kernel APIs that are used by the core kernel module were
updated in 3.9 and are incompatible with previous kernel versions.

Update the README to reflect this.

Fixes #257

Signed-off-by: Seth Jennings sjenning@redhat.com
