### PR TITLE
kmod/core: module old_addr fix

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -720,9 +720,15 @@ static int kpatch_link_object(struct kpatch_module *kpmod,
 							 old_addr);
 			if (ret)
 				goto err_unlink;
-		} else
-			old_addr = (unsigned long)mod->module_core +
-				   func->old_offset;
+		} else {
+			old_addr = kpatch_find_module_symbol(mod, func->name);
+			if (!old_addr) {
+				pr_err("unable to find symbol '%s' in module '%s\n",
+				       func->name, mod->name);
+				ret = -EINVAL;
+				goto err_unlink;
+			}
+		}
 
 		/* add to ftrace filter and register handler if needed */
 		ret = kpatch_ftrace_add_func(old_addr);


### PR DESCRIPTION
When patching a module, I ran into a "can't set ftrace filter at
address" error.  The root cause was due to the fact that
mod->module_core + old_offset is apparently not a reliable way to
determine the function's address.

Instead, just get the address from kallsyms like we do for module
dynrelas.
