### PR TITLE
add support for manually ignore functions

### DIFF
--- a/kmod/patch/kpatch-macros.h
+++ b/kmod/patch/kpatch-macros.h
@@ -18,6 +18,14 @@ struct kpatch_unload {
 };
 
 /*
+ * __kpatch_ignore
+ *
+ * Add this to a function definition if you want kpatch to ignore changes in
+ * that function
+ */
+#define __kpatch_ignore __section(.kpatch.ignore)
+
+/*
  * KPATCH_LOAD_HOOK macro
  *
  * The first line only ensures that the hook being registered has the required


### PR DESCRIPTION
This commit adds the __kpatch_ignore macro for ignore functions that
may change as a side effect of a change in another function.  The WARN
class of macros, for example, embed the line number in an instruction,
which will cause the function to be detected as changed when, in fact,
there has been no functional change.

Just at __kpatch_ignore to the function definition (like you would
__init) to cause the function to be ignored.

Partially addresses #316 

Test patches:

To see the problem

```
diff --git a/mm/vmalloc.c b/mm/vmalloc.c
index bf233b2..9bf17c6 100644
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2322,6 +2322,7 @@ static unsigned long pvm_determine_end(struct vmap_area **pnext,
        const unsigned long vmalloc_end = VMALLOC_END & ~(align - 1);
        unsigned long addr;

+       pr_info("here!\n");
        if (*pnext)
                addr = min((*pnext)->va_start & ~(align - 1), vmalloc_end);
        else
```

Output:

```
vmalloc.o: changed function: pvm_determine_end
vmalloc.o: changed function: pcpu_get_vm_areas
```

To see how the macro fixes the problem

```
diff --git a/mm/vmalloc.c b/mm/vmalloc.c
index bf233b2..a5a7f16 100644
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2322,6 +2322,7 @@ static unsigned long pvm_determine_end(struct vmap_area **pnext,
        const unsigned long vmalloc_end = VMALLOC_END & ~(align - 1);
        unsigned long addr;

+       pr_info("here!\n");
        if (*pnext)
                addr = min((*pnext)->va_start & ~(align - 1), vmalloc_end);
        else
@@ -2359,7 +2360,8 @@ static unsigned long pvm_determine_end(struct vmap_area **pnext,
  * area.  Scanning is repeated till all the areas fit and then all
  * necessary data structres are inserted and the result is returned.
  */
-struct vm_struct **pcpu_get_vm_areas(const unsigned long *offsets,
+#include "kpatch-macros.h"
+struct vm_struct __kpatch_ignore **pcpu_get_vm_areas(const unsigned long *offsets,
                                     const size_t *sizes, int nr_vms,
                                     size_t align)
 {
```

Output:

```
vmalloc.o: changed function: pvm_determine_end
```
