### PR TITLE
add support for manually ignore functions

### DIFF
--- a/kmod/patch/kpatch-macros.h
+++ b/kmod/patch/kpatch-macros.h
@@ -18,6 +18,17 @@ struct kpatch_unload {
 };
 
 /*
+ * KPATCH_IGNORE_FUNCTION macro
+ *
+ * This macro is for ignoring functions that may change as a side effect of a
+ * change in another function.  The WARN class of macros, for example, embed
+ * the line number in an instruction, which will cause the function to be
+ * detected as changed when, in fact, there has been no functional change.
+ */
+#define KPATCH_IGNORE_FUNCTION(_fn) \
+	void *__kpatch_ignore_func_##_fn __section(.kpatch.ignore.funcs) = _fn;
+
+/*
  * KPATCH_LOAD_HOOK macro
  *
  * The first line only ensures that the hook being registered has the required


### PR DESCRIPTION
This commit adds the KPATCH_IGNORE_FUNC() macro for ignoring functions
that may change as a side effect of a change in another function.  The
WARN class of macros, for example, embed the line number in an
instruction, which will cause the function to be detected as changed
when, in fact, there has been no functional change.

Partially addresses #316 

Test patches:

To see the problem

```
diff --git a/mm/vmalloc.c b/mm/vmalloc.c
index bf233b2..9bf17c6 100644
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2322,6 +2322,7 @@ static unsigned long pvm_determine_end(struct vmap_area **pnext,
        const unsigned long vmalloc_end = VMALLOC_END & ~(align - 1);
        unsigned long addr;

+       pr_info("here!\n");
        if (*pnext)
                addr = min((*pnext)->va_start & ~(align - 1), vmalloc_end);
        else
```

Output:

```
vmalloc.o: changed function: pvm_determine_end
vmalloc.o: changed function: pcpu_get_vm_areas
```

To see how the macro fixes the problem

```
diff --git a/mm/vmalloc.c b/mm/vmalloc.c
index bf233b2..3876758 100644
--- a/mm/vmalloc.c
+++ b/mm/vmalloc.c
@@ -2322,6 +2322,7 @@ static unsigned long pvm_determine_end(struct vmap_area **pnext,
    const unsigned long vmalloc_end = VMALLOC_END & ~(align - 1);
    unsigned long addr;

+   pr_info("here!\n");
    if (*pnext)
        addr = min((*pnext)->va_start & ~(align - 1), vmalloc_end);
    else
@@ -2512,6 +2513,8 @@ err_free2:
    kfree(vms);
    return NULL;
 }
+#include "kpatch-macros.h"
+KPATCH_IGNORE_FUNC(pcpu_get_vm_areas);

 /**
  * pcpu_free_vm_areas - free vmalloc areas for percpu allocator
```

Output:

```
vmalloc.o: ignoring function pcpu_get_vm_areas
vmalloc.o: changed function: pvm_determine_end
```
