### PR TITLE
remove build pass from kpatch-build

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -79,6 +79,7 @@ cleanup() {
 
 clean_cache() {
 	[[ -z $USERSRCDIR ]] && rm -rf "$SRCDIR"
+	rm -rf "$OBJDIR" "$VERSIONFILE"
 	mkdir -p "$OBJDIR"
 }
 
@@ -416,7 +417,6 @@ done < "$TEMPDIR/patched_build.log"
 
 [[ ! -s "$TEMPDIR/changed_objs" ]] && die "no changed objects were detected"
 
-echo "Copying changed objects"
 mkdir "$TEMPDIR/patched"
 for i in $(cat $TEMPDIR/changed_objs); do
 	mkdir -p "$TEMPDIR/patched/$(dirname $i)"


### PR DESCRIPTION
Now that we use the vmlinux from the distro debug package we don't need
to do any build runs without -ffunction-sections -fdata-sections.

Old:
Build orig in objdir
Build patched in objdir
Build orig w/ flags in objdir2
Copy orig .o's into orig
Build patched w/ flags in objdir2
Copy patched .o's into patched

New:
Build orig w/ flags in objdir
Build patched w/ flags in objdir
Copy patched .o's into patched
Build orig w/ flags in objdir
Copy orig .o's into orig

This commit also does not try to build each changed object singularly since
there are cases in the kernel tree where the Makefile does not reside in
the same directory as the changed object.

Signed-off-by: Seth Jennings sjenning@redhat.com

Improves upon #325
