### PR TITLE
kpatch-build and README.md update

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ ccache --max-size=5G
 
 ####Ubuntu 14.04
 
-*NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in `~/.kpatch` and for ccache.*
+*NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in
+`~/.kpatch` and for ccache.*
 
 Install the dependencies for compiling kpatch:
 
@@ -196,13 +197,16 @@ OPTIONAL: Install kpatch to `/usr/local`:
 
     sudo make install
 
-Alternatively, the kpatch and kpatch-build scripts can be run directly from the git tree.
+Alternatively, the kpatch and kpatch-build scripts can be run directly from the
+git tree.
 
 
 Quick start
 -----------
 
-> NOTE: While kpatch is designed to work with any recent Linux kernel on any distribution, the `kpatch-build` command has **ONLY** been tested to work on Fedora 20, RHEL 7 and Ubuntu 14.04.
+> NOTE: While kpatch is designed to work with any recent Linux
+kernel on any distribution, the `kpatch-build` command has **ONLY** been tested
+and confirmed to work on Fedora 20, RHEL 7 and Ubuntu 14.04.
 
 First, make a source code patch against the kernel tree using diff, git, or
 quilt.

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -339,8 +339,6 @@ else
 		if [[ $DISTRO = ubuntu ]]; then
 
 			# url may be changed for a different mirror
-			# list of official archive mirrors for Ubuntu -> https://launchpad.net/ubuntu/+archivemirrors
-			# update the url below to use a close mirror otherwise wait for hours ;-)
 			url="http://archive.ubuntu.com/ubuntu/pool/main/l/linux"
 			extension="bz2"
 			sublevel="SUBLEVEL = 0"


### PR DESCRIPTION
- `kpatch-build`
  Sometimes the downloading of the kernel source tarball via `us.archive.ubuntu.com` can be very slow (20KB/s), switching to a close Ubuntu archive mirror (in my case `au.archive.ubuntu.com` was 25 times faster) will greatly speed up the download.

Generally it is a better idea to use the main archive instead of US specific archive (for load balancing and failover purpose), that's why I changed the URL. 

See the host output below.

``` bash
$ host us.archive.ubuntu.com
us.archive.ubuntu.com has address 91.189.91.13
us.archive.ubuntu.com has address 91.189.91.14
us.archive.ubuntu.com has address 91.189.91.15
us.archive.ubuntu.com has IPv6 address 2001:67c:1562::13
us.archive.ubuntu.com has IPv6 address 2001:67c:1562::14
us.archive.ubuntu.com has IPv6 address 2001:67c:1562::15

$ host archive.ubuntu.com
archive.ubuntu.com has address 91.189.92.200
archive.ubuntu.com has address 91.189.92.201
archive.ubuntu.com has address 91.189.88.153
archive.ubuntu.com has address 91.189.91.13
archive.ubuntu.com has address 91.189.91.14
archive.ubuntu.com has address 91.189.91.15
archive.ubuntu.com has IPv6 address 2001:67c:1360:8c01::19
archive.ubuntu.com has IPv6 address 2001:67c:1360:8c01::18

$ host au.archive.ubuntu.com
au.archive.ubuntu.com is an alias for mirror.aarnet.edu.au.
mirror.aarnet.edu.au has address 202.158.214.106
mirror.aarnet.edu.au has IPv6 address 2001:388:30bc:cafe::beef
```
- `README.md`
  Broke up long lines, tried to use GitHub flavored markdown to beautify the `README.md`.

Right now the `REAME.md` has mixed markdown syntaxes, may need an overhaul soon ;-D
