### PR TITLE
remove sh_link from section comparison

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -568,8 +568,7 @@ void kpatch_compare_correlated_section(struct section *sec)
 	    sec1->sh.sh_flags != sec2->sh.sh_flags ||
 	    sec1->sh.sh_addr != sec2->sh.sh_addr ||
 	    sec1->sh.sh_addralign != sec2->sh.sh_addralign ||
-	    sec1->sh.sh_entsize != sec2->sh.sh_entsize ||
-	    sec1->sh.sh_link != sec1->sh.sh_link)
+	    sec1->sh.sh_entsize != sec2->sh.sh_entsize)
 		DIFF_FATAL("%s section header details differ", sec1->name);
 
 	if (sec1->sh.sh_size != sec2->sh.sh_size ||


### PR DESCRIPTION
This sh_link line currently has a bug with both operands being sec1; the
second should be sec2.  However the bug is masking a logical flaw; that
is that the sh_link is the index of either the symtab or the strtab and
that can change if sections have been added or removed by the patch.

This commit removes the comparison.

Signed-off-by: Seth Jennings sjenning@redhat.com

Improves on #306
