### PR TITLE
kmod/core/Makefile: update the Makefile for Debian Like

### DIFF
--- a/kmod/core/Makefile
+++ b/kmod/core/Makefile
@@ -3,7 +3,7 @@ KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
 THISDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 ifeq ($(wildcard $(KPATCH_BUILD)),)
-$(error $(KPATCH_BUILD) doesn\'t exist.  Try installing the kernel-devel-$(shell uname -r) RPM.)
+$(error $(KPATCH_BUILD) doesn\'t exist.  Try installing the kernel-devel-$(shell uname -r) RPM or linux-image-$(shell uname -r)-dbg DEB.)
 endif
 
 KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(THISDIR)


### PR DESCRIPTION
Add information for Debian/Ubuntu if the debug package is not installed.
