### PR TITLE
kpatch-build: don't show full kpatch-build path in usage message

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -166,7 +166,7 @@ find_kobj() {
 }
 
 usage() {
-	echo "usage: $0 [options] <patch file>" >&2
+	echo "usage: $(basename $0) [options] <patch file>" >&2
 	echo "		-h, --help	Show this help message" >&2
 	echo "		-r, --sourcerpm	Specify kernel source RPM" >&2
 	echo "		-s, --sourcedir	Specify kernel source directory" >&2


### PR DESCRIPTION
For interface consistency with other unix utilities.
