### PR TITLE
testmod/doit.sh: set KBUILD_EXTRA_SYMBOLS to include core module's symbols

### DIFF
--- a/test/testmod/doit.sh
+++ b/test/testmod/doit.sh
@@ -17,7 +17,7 @@ make || exit 1
 cd ../../kmod/patch || exit 1
 make clean || exit 1
 cp ../../test/testmod/output.o . || exit 1
-make || exit 1
+KBUILD_EXTRA_SYMBOLS="$(readlink -e ../../kmod/core/Module.symvers)" make || exit 1
 cd ../../test/testmod
 
 if [[ -z "$REMOTE" ]]


### PR DESCRIPTION
As reported by Xie, when building the patch module, doit.sh warns about unknown symbols that are supposed to come from the kpatch core module. The patch module is then unable to load because of the missing symbols. 

```
make -C /lib/modules/3.16.0-rc6-ARCH-00118-g82e13c7-dirty/build M=/home/jyu/ft-kpatch/kmod/patch kpatch-patch.ko
make[1]: Entering directory '/home/jyu/.kpatch/obj'
make[1]: Entering directory `/home/jyu/.kpatch/obj'
  CC [M]  /home/jyu/ft-kpatch/kmod/patch/kpatch-patch-hook.o
  LD [M]  /home/jyu/ft-kpatch/kmod/patch/kpatch-patch.o
ld: warning: /home/jyu/ft-kpatch/kmod/patch/kpatch.lds contains output sections; did you forget -T?
  MODPOST 1 modules
WARNING: "kpatch_unregister" [/home/jyu/ft-kpatch/kmod/patch/kpatch-patch.ko] undefined!
WARNING: "kpatch_patches_kobj" [/home/jyu/ft-kpatch/kmod/patch/kpatch-patch.ko] undefined!
WARNING: "kpatch_register" [/home/jyu/ft-kpatch/kmod/patch/kpatch-patch.ko] undefined!
  CC      /home/jyu/ft-kpatch/kmod/patch/kpatch-patch.mod.o
  LD [M]  /home/jyu/ft-kpatch/kmod/patch/kpatch-patch.ko
make[1]: Leaving directory '/home/jyu/.kpatch/obj'
<snip>
insmod: ERROR: could not insert module kpatch-patch.ko: Invalid parameters
[ 1644.560248] kpatch_patch: no symbol version for kpatch_register
[ 1644.560252] kpatch_patch: Unknown symbol kpatch_register (err -22)
[ 1644.560255] kpatch_patch: no symbol version for kpatch_patches_kobj
[ 1644.560257] kpatch_patch: Unknown symbol kpatch_patches_kobj (err -22)
[ 1644.560263] kpatch_patch: no symbol version for kpatch_unregister
[ 1644.560265] kpatch_patch: Unknown symbol kpatch_unregister (err -22)
```

Setting KBUILD_EXTRA_SYMBOLS did the trick; tested on Ubuntu 14.04 and Arch.
