### PR TITLE
Group section support

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1110,7 +1110,7 @@ void kpatch_verify_patchability(struct kpatch_elf *kelf)
 			errs++;
 		}
 
-		if (sec->status == CHANGED && sec->grouped) {
+		if (sec->status != SAME && sec->grouped) {
 			log_normal("changed section %s is part of a section group\n",
 				   sec->name);
 			errs++;


### PR DESCRIPTION
GROUP section are rare and are a mechanism in the ELF to indicated that
certain groups of section must be included or excluded (stripped)
together.

It is valid to have more than one of these section with the same
".group" name.  This currently messes up the section correlation code
with correlates based solely on name.

This commit adds additional correlation criteria for GROUP sections;
namely, the section content must be the same.  Changing of groups
sections (i.e. reindexing of the section indexes the GROUP section
includes in their section data) is not supported and will result in a
"new/changed section not included" error.

Fixes #351 
