### PR TITLE
kpatch-gcc: fix for .tmp_* objects on RHEL 7

### DIFF
--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -13,7 +13,9 @@ declare -a args=($@)
 
 while [ "$#" -gt 0 ]; do
 	if [ "$1" = "-o" ]; then
-		case "$2" in
+		obj=$2
+		[[ $2 = */.tmp_*.o ]] && obj=${2/.tmp_/}
+		case "$obj" in
 			*.mod.o|\
 			*built-in.o|\
 			vmlinux.o|\
@@ -27,12 +29,13 @@ while [ "$#" -gt 0 ]; do
 			arch/x86/boot/compressed/piggy.o|\
 			kernel/system_certificates.o|\
 			.*.o)
-			break;
+			break
 			;;
 		*.o)
-			mkdir -p "$TEMPDIR/orig/$(dirname $2)"
-			cp -f "$2" "$TEMPDIR/orig/$2"
-			echo "$2" >> "$TEMPDIR/changed_objs"
+			mkdir -p "$TEMPDIR/orig/$(dirname $obj)"
+			cp -f "$obj" "$TEMPDIR/orig/$obj"
+			echo "$obj" >> "$TEMPDIR/changed_objs"
+			break
 			;;
 		*)
 			break


### PR DESCRIPTION
On RHEL 7 I see the following error when trying to patch meminfo.o:

```
cp: cannot stat ‘/home/user/.kpatch/obj/fs/proc/.tmp_meminfo.o’: No such file or directory
```

It turns out that on RHEL 7, a given object foo.o is compiled as
.tmp_foo.o before then being linked as foo.o.  I have no idea why.  The
fix is to record .tmp_foo.o as foo.o in the changed_objs file.
