### PR TITLE
kpatch-patch-hook: fix incorrect old_offsets for loadable modules

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -711,16 +711,15 @@ static int kpatch_link_object(struct kpatch_module *kpmod,
 		goto err_unlink;
 
 	list_for_each_entry(func, &object->funcs, list) {
-		unsigned long old_addr;
 
 		/* calculate actual old location */
 		if (vmlinux) {
-			old_addr = func->old_offset;
 			ret = kpatch_verify_symbol_match(func->name,
-							 old_addr);
+							 func->old_addr);
 			if (ret)
 				goto err_unlink;
 		} else {
+			unsigned long old_addr;
 			old_addr = kpatch_find_module_symbol(mod, func->name);
 			if (!old_addr) {
 				pr_err("unable to find symbol '%s' in module '%s\n",
@@ -728,14 +727,14 @@ static int kpatch_link_object(struct kpatch_module *kpmod,
 				ret = -EINVAL;
 				goto err_unlink;
 			}
+			func->old_addr = old_addr;
 		}
 
 		/* add to ftrace filter and register handler if needed */
-		ret = kpatch_ftrace_add_func(old_addr);
+		ret = kpatch_ftrace_add_func(func->old_addr);
 		if (ret)
 			goto err_unlink;
 
-		func->old_addr = old_addr;
 	}
 
 	return 0;

--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -36,7 +36,7 @@ struct kpatch_func {
 	/* public */
 	unsigned long new_addr;
 	unsigned long new_size;
-	unsigned long old_offset;
+	unsigned long old_addr;
 	unsigned long old_size;
 	const char *name;
 	struct list_head list;
@@ -44,7 +44,6 @@ struct kpatch_func {
 
 	/* private */
 	struct hlist_node node;
-	unsigned long old_addr;
 	enum kpatch_op op;
 };
 

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -257,9 +257,8 @@ static int patch_make_funcs_list(struct list_head *objects)
 		func->new_addr = p_func->new_addr;
 		func->new_size = p_func->new_size;
 
-		/* find correct func->old_offset */
 		if (!strcmp("vmlinux", object->name))
-			func->old_offset = p_func->old_offset;
+			func->old_addr = p_func->old_addr;
 		else
 			func->old_addr = 0x0;
 

--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -25,7 +25,7 @@
 struct kpatch_patch_func {
 	unsigned long new_addr;
 	unsigned long new_size;
-	unsigned long old_offset;
+	unsigned long old_addr;
 	unsigned long old_size;
 	char *name;
 	char *objname;

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1983,7 +1983,7 @@ void kpatch_create_patches_sections(struct kpatch_elf *kelf,
 			          sym->name, result.value, result.size);
 
 			/* add entry in text section */
-			funcs[index].old_offset = result.value;
+			funcs[index].old_addr = result.value;
 			funcs[index].old_size = result.size;
 			funcs[index].new_size = sym->sym.st_size;
 


### PR DESCRIPTION
This PR attempts to fix issue #356.

To summarize the changeset:
1) A sysfs hook will be created if the module is not loaded by the time the patch module is loaded. This hook will be called by `kpatch_module_notify`.

sysfs file creation was taken out of `patch_make_funcs_list` and put into a separate function named `patch_create_func_sysfs`. `kpmod.add_sysfs_func` will be set to point to this function if we need to delay sysfs initialization. I feel like this is a bit hacky, but I used a hook because I wanted to preserve existing scope boundaries as much as possible, without porting any of the local structs and functions used solely in kpatch-patch-hook during sysfs initialization (for example, `kpatch_func_object` used in kobject creation is local to kpatch-patch-hook only, and we wouldn't have access to that in the core module if we wanted to create the sysfs files then and there.)

2) `kpatch_func_obj`, the struct that contains the kobject and is local only to patch module, is set to point to the `kpatch_func` struct instead of the `kpatch_patch_func` struct (which is local to the patch module). I did this so that the core module could call the sysfs hook and pass to it a `kpatch_func` struct, as it does _not_ have access to the `kpatch_patch_func` struct. (`kpatch_func` and `kpatch_patch_func` both contain the same information, so I think this change should be safe)

3) Lastly, if the module is already loaded, `patch_make_funcs_list` will now resolve old_addr using `kpatch_find_module_symbol`. I had to export it to make it available to the patch module...

Tested on Ubuntu 14.04 and Arch with the ext4 patch in #356 and the btrfs patch below (both compiled as modules), though I'd like verification that it works for other people. `old_addr` and `new_addr` were verified by cross-checking with `/proc/kallsyms`. 

```
diff --git a/fs/btrfs/sysfs.c b/fs/btrfs/sysfs.c
index 7869936..890f8f9 100644
--- a/fs/btrfs/sysfs.c
+++ b/fs/btrfs/sysfs.c
@@ -92,6 +92,7 @@ static int can_modify_feature(struct btrfs_feature_attr *fa)
 static ssize_t btrfs_feature_attr_show(struct kobject *kobj,
                                       struct kobj_attribute *a, char *buf)
 {
+       pr_info("btrfs_feature_attr_show");
        int val = 0;
        struct btrfs_fs_info *fs_info = to_fs_info(kobj);
        struct btrfs_feature_attr *fa = to_btrfs_feature_attr(a);
```

If anyone thinks I should take a different approach, I'm all ears.This is an initial version of the fix and I suspect there are mistakes and better ways of solving this issue, so feedback is more than welcome.
