### PR TITLE
include symbol section if section contains strings

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1519,6 +1519,10 @@ void kpatch_regenerate_special_section(struct special_section *special,
 				rela->rela.r_offset = rela->offset;
 
 				rela->sym->include = 1;
+				if (rela->sym->sec &&
+				    (rela->sym->sec->sh.sh_flags & SHF_STRINGS))
+					rela->sym->sec->include = 1;
+					rela->sym->sec->secsym->include = 1;
 			}
 		}
 


### PR DESCRIPTION
In issue #359, a lookup is performed on .LC1 when it shouldn't be.  This
is because the .LC1 symbol is being included by
kpatch_regenerate_special_section() but, because the .rodata.str1.8
section is unchanged, the underlying section is not included and
kpatch_create_dynamic_rela_sections() treats it as an unchanged local
symbol and tries to look it up in vmlinux which fails.

This commit causes kpatch_regenerate_special_section() to include the
underlying string section.

Fixes #359
