### PR TITLE
always include .rodata.str1.* sections

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1179,9 +1179,13 @@ void kpatch_include_standard_elements(struct kpatch_elf *kelf)
 	list_for_each_entry(sec, &kelf->sections, list) {
 		/* include these sections even if they haven't changed */
 		if (!strcmp(sec->name, ".shstrtab") ||
-		     !strcmp(sec->name, ".strtab") ||
-		     !strcmp(sec->name, ".symtab"))
+		    !strcmp(sec->name, ".strtab") ||
+		    !strcmp(sec->name, ".symtab") ||
+		    !strncmp(sec->name, ".rodata.str1.", 13)) {
 			sec->include = 1;
+			if (sec->secsym)
+				sec->secsym->include = 1;
+		}
 	}
 
 	/* include the NULL symbol */


### PR DESCRIPTION
Fixes #359
