### PR TITLE
create-diff-object: allow new data to be included

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1122,7 +1122,7 @@ void kpatch_verify_patchability(struct kpatch_elf *kelf)
 		}
 
 		/* ensure we aren't including .data.* or .bss.* */
-		if (sec->include &&
+		if (sec->include && sec->status != NEW &&
 		    (!strncmp(sec->name, ".data", 5) ||
 		     !strncmp(sec->name, ".bss", 4))) {
 			log_normal("data section %s selected for inclusion\n",

--- a/test/integration/data-new-LOADED.test
+++ b/test/integration/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch: 5" /proc/meminfo

--- a/test/integration/data-new.patch
+++ b/test/integration/data-new.patch
@@ -1,0 +1,29 @@
+Index: src/fs/proc/meminfo.c
+===================================================================
+--- src.orig/fs/proc/meminfo.c
++++ src/fs/proc/meminfo.c
+@@ -20,6 +20,8 @@ void __attribute__((weak)) arch_report_m
+ {
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -138,6 +140,7 @@ static int meminfo_proc_show(struct seq_
+ #ifdef CONFIG_TRANSPARENT_HUGEPAGE
+ 		"AnonHugePages:  %8lu kB\n"
+ #endif
++		"kpatch: %d"
+ 		,
+ 		K(i.totalram),
+ 		K(i.freeram),
+@@ -193,6 +196,7 @@ static int meminfo_proc_show(struct seq_
+ 		,K(global_page_state(NR_ANON_TRANSPARENT_HUGEPAGES) *
+ 		   HPAGE_PMD_NR)
+ #endif
++		,foo
+ 		);
+ 
+ 	hugetlb_report_meminfo(m);


### PR DESCRIPTION
Allow the inclusion of new global variables.
