### PR TITLE
support for calling a new function in another object

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2106,11 +2106,15 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				 */
 				if (lookup_is_exported_symbol(table, rela->sym->name))
 					continue;
+
+				/*
+				 * If lookup_global_symbol() fails, assume the
+				 * symbol is defined in another object in the
+				 * patch module.
+				 */
 				if (lookup_global_symbol(table, rela->sym->name,
 							 &result))
-					ERROR("lookup_global_symbol failed for %s, needed for %s\n",
-					      rela->sym->name,
-					      sec->base->name);
+					continue;
 			} else {
 				/*
 				 * We have a patch to a module which references


### PR DESCRIPTION
If a patch adds a new function in foo.c, and calls that function from
bar.c, currently it fails with something like:

```
kpatch_create_dynamic_rela_sections: 2115: lookup_global_symbol failed for tpe_allow_file, needed for .text.do_mmap_pgoff
```

This (crudely) fixes the issue by assuming that if we can't find the
global symbol in the original vmlinux, that it will be provided by
another object in the patch module.  If that assumption is incorrect,
the module will fail to load due to the missing symbol dependency.

A (perhaps) better way to fix this is to search for the symbol in the
patched version of the vmlinux.  But I think this approach is good
enough, for now at least.

Fixes #388.
