### PR TITLE
Inform the user of the new function at build time

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2155,8 +2155,10 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				 * patch module.
 				 */
 				if (lookup_global_symbol(table, rela->sym->name,
-							 &result))
+							 &result)) {
+					log_normal("new function: %s\n", rela->sym->name);
 					continue;
+				}
 			} else {
 				/*
 				 * We have a patch to a module which references


### PR DESCRIPTION
We are informed when a function changes, we should also get told
when we get a new fucntion;

vmlinux: new function: &lt;function name&gt;

Signed-off-by: Corey Henderson corman@cormander.com
