### PR TITLE
Give objname on build error

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -52,10 +52,7 @@
 #include "kpatch-patch.h"
 
 #define ERROR(format, ...) \
-({ \
-	fprintf(stderr, "%s: ", objname); \
-	error(1, 0, "%s: %d: " format, __FUNCTION__, __LINE__, ##__VA_ARGS__); \
-})
+	error(1, 0, "%s: %s: %d: " format, objname, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define DIFF_FATAL(format, ...) \
 ({ \


### PR DESCRIPTION
On certain failures, `create-diff-object` reports the symbol name but if it's a static local variable, there's no other indication of where the problem is at. This makes finding the issue on larger patches a problem. This commit prepends the current `objname` to the `ERROR` output, just like it does for `DIFF_FATAL`.

Additionally, send all error output from these macros to `STDERR`, since that's where output from `error` goes.
