### PR TITLE
report what the bad first instruction actually is

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2325,7 +2325,7 @@ void kpatch_create_mcount_sections(struct kpatch_elf *kelf)
 		sym->sec->data->d_buf = newdata;
 		insn = newdata;
 		if (insn[0] != 0xf)
-			ERROR("bad first instruction in %s", sym->name);
+			ERROR("bad first instruction '0x%x' in %s, should be 0xf", insn[0], sym->name);
 		insn[0] = 0xe8;
 		insn[1] = 0;
 		insn[2] = 0;


### PR DESCRIPTION
Not sure why I'm getting this:

`/usr/local/libexec/kpatch/create-diff-object: kpatch_create_mcount_sections: 2343: bad first instruction in generic_write_checks`

But it doesn't actually say what the bad instruction is. It'll now report:

`/usr/local/libexec/kpatch/create-diff-object: kpatch_create_mcount_sections: 2343: bad first instruction '0x55' in generic_write_checks, should be 0xf`

For what it's worth, this is a simple function call added to `generic_write_checks` out of `mm/filemap.c`
