### PR TITLE
die on create-diff-object when all objects have processed

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -52,11 +52,11 @@
 #include "kpatch-patch.h"
 
 #define ERROR(format, ...) \
-	error(1, 0, "%s: %s: %d: " format, objname, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+	error(1, 0, "ERROR: %s: %s: %d: " format, objname, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define DIFF_FATAL(format, ...) \
 ({ \
-	fprintf(stderr, "%s: " format "\n", objname, ##__VA_ARGS__); \
+	fprintf(stderr, "ERROR: %s: " format "\n", objname, ##__VA_ARGS__); \
 	error(2, 0, "unreconcilable difference"); \
 })
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -459,7 +459,7 @@ for i in $FILES; do
 done
 
 if [[ $ERROR -ne 0 ]]; then
-	die "create-diff-object failed on $ERROR of the objects"
+	die "$ERROR error(s) encountered"
 fi
 
 if [[ $CHANGED -eq 0 ]]; then


### PR DESCRIPTION
When working on large patches that are bound to have lots of
errors, it can be frustrating to have to re-run the build and wait
after every error you fix. With this patch, you get a chance to see
most (if not all) of the errors you'll be facing, at least across
the different object files.
