### PR TITLE
allow the user to ignore a rela section

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1673,6 +1673,8 @@ void kpatch_mark_ignored_sections(struct kpatch_elf *kelf)
 		if (!ignoresec)
 			ERROR("KPATCH_IGNORE_SECTION: can't find %s", name);
 		log_normal("ignoring section: %s\n", name);
+		if (is_rela_section(ignoresec))
+			ignoresec = ignoresec->base;
 		ignoresec->ignore = 1;
 		if (ignoresec->twin)
 			ignoresec->twin->ignore = 1;


### PR DESCRIPTION
If the user specifies KPATCH_IGNORE_SECTION for a rela section, ignore
the corresponding text section instead of corrupting memory.

Fixes #381.
