### PR TITLE
replace all unbundled section references with symbols

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1099,17 +1099,9 @@ void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 			}
 
 			/*
-			 * These are special data sections whose data symbols
-			 * aren't bundled with sections when using
-			 * -fdata-sections.  We need to replace the section
-			 * references with their corresponding objects.
+			 * Attempt to replace references to unbundled sections
+			 * with their symbols.
 			 */
-			if (strcmp(rela->sym->name, ".data..percpu") &&
-			    strcmp(rela->sym->name, ".data..read_mostly") &&
-			    strcmp(rela->sym->name, ".data.unlikely") &&
-			    !(rela->sym->type == STT_SECTION && rela->sym->sec &&
-			      is_text_section(rela->sym->sec)))
-				continue;
 			list_for_each_entry(sym, &kelf->symbols, list) {
 
 				if (sym->type == STT_SECTION ||


### PR DESCRIPTION
Currently we're checking for several special cases when deciding whether
to convert unbundled section references to their corresponding symbol
references.  We do it for all unbundled text sections as well as three
specific data sections.

There's no reason I can think of for why we shouldn't just do it for
_all_ unbundled sections.
