### PR TITLE
.fixup special section fixes

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -154,7 +154,7 @@ struct kpatch_elf {
 
 struct special_section {
 	char *name;
-	int (*group_size)(struct section *sec, int offset);
+	int (*group_size)(struct kpatch_elf *kelf, int offset);
 	int align;
 };
 
@@ -1530,30 +1530,47 @@ void kpatch_reindex_elements(struct kpatch_elf *kelf)
 }
 
 
-int bug_table_group_size(struct section *sec, int offset) { return 12; }
-int smp_locks_group_size(struct section *sec, int offset) { return 4; }
-int parainstructions_group_size(struct section *sec, int offset) { return 16; }
-int ex_table_group_size(struct section *sec, int offset) { return 8; }
-int altinstructions_group_size(struct section *sec, int offset) { return 12; }
+int bug_table_group_size(struct kpatch_elf *kelf, int offset) { return 12; }
+int smp_locks_group_size(struct kpatch_elf *kelf, int offset) { return 4; }
+int parainstructions_group_size(struct kpatch_elf *kelf, int offset) { return 16; }
+int ex_table_group_size(struct kpatch_elf *kelf, int offset) { return 8; }
+int altinstructions_group_size(struct kpatch_elf *kelf, int offset) { return 12; }
 
-int fixup_group_size(struct section *sec, int offset)
+/*
+ * The rela groups in the .fixup section vary in size.  The beginning of each
+ * .fixup rela group is referenced by the __ex_table section. To find the size
+ * of a .fixup rela group, we have to traverse the __ex_table relas.
+ */
+int fixup_group_size(struct kpatch_elf *kelf, int offset)
 {
-	unsigned char *insn, *start, *end;
+	static struct rela *rela = NULL;
+	static struct section *sec;
 
-	/*
-	 * Each fixup group is a collection of instructions.  The last
-	 * instruction is always 'jmpq'.
-	 */
-	start = sec->data->d_buf + offset;
-	end = start + sec->sh.sh_size;
-	for (insn = start; insn < end; insn++) {
-		/* looking for the pattern "e9 00 00 00 00" */
-		if (*insn == 0xe9 && *(uint32_t *)(insn + 1) == 0)
-			return insn + 5 - start;
+	if (!rela) {
+		sec = find_section_by_name(&kelf->sections, ".rela__ex_table");
+		if (!sec)
+			ERROR("missing .rela__ex_table section");
+
+		list_for_each_entry(rela, &sec->relas, list)
+			if (!strcmp(rela->sym->name, ".fixup"))
+				break;
 	}
 
-	ERROR("can't find jump instruction in .fixup section");
-	return 0;
+	if (rela->addend != offset)
+		ERROR("unexpected .fixup rela offset");
+
+	list_for_each_entry_continue(rela, &sec->relas, list)
+		if (!strcmp(rela->sym->name, ".fixup"))
+			break;
+
+	if (&rela->list == &sec->relas) {
+		/* reached the end of the list (last group) */
+		struct section *fixupsec;
+		fixupsec = find_section_by_name(&kelf->sections, ".fixup");
+		return fixupsec->sh.sh_size - offset;
+	}
+
+	return rela->addend - offset;
 }
 
 struct special_section special_sections[] = {
@@ -1570,17 +1587,17 @@ struct special_section special_sections[] = {
 		.group_size	= parainstructions_group_size,
 	},
 	{
+		.name		= ".fixup",
+		.group_size	= fixup_group_size,
+		.align		= 1,
+	},
+	{
 		.name		= "__ex_table",
 		.group_size	= ex_table_group_size,
 	},
 	{
 		.name		= ".altinstructions",
 		.group_size	= altinstructions_group_size,
-	},
-	{
-		.name		= ".fixup",
-		.group_size	= fixup_group_size,
-		.align		= 1,
 	},
 	{},
 };
@@ -1605,7 +1622,8 @@ int should_keep_rela_group(struct section *sec, int start, int size)
 	return found;
 }
 
-void kpatch_regenerate_special_section(struct special_section *special,
+void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
+				       struct special_section *special,
 				       struct section *sec)
 {
 	struct rela *rela, *safe;
@@ -1625,7 +1643,7 @@ void kpatch_regenerate_special_section(struct special_section *special,
 	dest_offset = 0;
 	for ( ; src_offset < sec->base->sh.sh_size; src_offset += group_size) {
 
-		group_size = special->group_size(sec->base, src_offset);
+		group_size = special->group_size(kelf, src_offset);
 		include = should_keep_rela_group(sec, src_offset, group_size);
 
 		if (!include)
@@ -1813,7 +1831,7 @@ void kpatch_process_special_sections(struct kpatch_elf *kelf)
 		if (!sec)
 			continue;
 
-		kpatch_regenerate_special_section(special, sec);
+		kpatch_regenerate_special_section(kelf, special, sec);
 	}
 
 	/*

--- a/kpatch-build/list.h
+++ b/kpatch-build/list.h
@@ -173,6 +173,14 @@ static inline void list_replace(struct list_head *old,
 	list_entry((ptr)->next, type, member)
 
 /**
+ * list_next_entry - get the next element in list
+ * @pos:	the type * to cursor
+ * @member:	the name of the list_struct within the struct.
+ */
+#define list_next_entry(pos, member) \
+	list_entry((pos)->member.next, typeof(*(pos)), member)
+
+/**
  * list_for_each_entry	-	iterate over list of given type
  * @pos:	the type * to use as a loop counter.
  * @head:	the head for your list.
@@ -182,6 +190,20 @@ static inline void list_replace(struct list_head *old,
 	for (pos = list_entry((head)->next, typeof(*pos), member);	\
 	     &pos->member != (head);					\
 	     pos = list_entry(pos->member.next, typeof(*pos), member))
+
+/**
+ * list_for_each_entry_continue - continue iteration over list of given type
+ * @pos:	the type * to use as a loop cursor.
+ * @head:	the head for your list.
+ * @member:	the name of the list_struct within the struct.
+ *
+ * Continue to iterate over list of given type, continuing after
+ * the current position.
+ */
+#define list_for_each_entry_continue(pos, head, member) 		\
+	for (pos = list_next_entry(pos, member);			\
+	     &pos->member != (head);					\
+	     pos = list_next_entry(pos, member))
 
 /**
  * list_for_each_entry_safe - iterate over list of given type safe against removal of list entry

--- a/test/integration/module-kvm-fixup.patch
+++ b/test/integration/module-kvm-fixup.patch
@@ -1,0 +1,13 @@
+Index: src/arch/x86/kvm/vmx.c
+===================================================================
+--- src.orig/arch/x86/kvm/vmx.c
++++ src/arch/x86/kvm/vmx.c
+@@ -8687,6 +8687,8 @@ static int vmx_check_intercept(struct kv
+ 			       struct x86_instruction_info *info,
+ 			       enum x86_intercept_stage stage)
+ {
++	if (!jiffies)
++		printk("kpatch vmx_check_intercept\n");
+ 	return X86EMUL_CONTINUE;
+ }
+ 


### PR DESCRIPTION
These are some fixes with the .fixup handling which I discovered in my attempt to add an integration test which modifies `include/linux/kernel.h` and causes create-diff-object to run on every object file.
