### PR TITLE
fix regression in user-specified source RPM

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -321,8 +321,8 @@ else
 				rpm -q --quiet yum-utils || die "yum-utils not installed"
 				yumdownloader --source --destdir "$TEMPDIR" "kernel-$ARCHVERSION" >> "$LOGFILE" 2>&1 || die
 			fi
+			SRCRPM="$TEMPDIR/kernel-$KVER-$KREL.src.rpm"
 		fi
-		SRCRPM="$TEMPDIR/kernel-$KVER-$KREL.src.rpm"
 
 		echo "Unpacking kernel source"
 		rpmdev-setuptree >> "$LOGFILE" 2>&1 || die


### PR DESCRIPTION
A recent commit 74316588e is unconditionally setting the SRCRPM path
overwriting a user specified path.

Only set SRCRPM if SRCRPM is not already set.

Signed-off-by: Seth Jennings sjenning@redhat.com
