### PR TITLE
die on gcc/kernel version mismatch only

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -60,7 +60,8 @@ die() {
 		msg="$1"
 	fi
 
-	echo "ERROR: $msg. Check $LOGFILE for more details." >&2
+	echo "ERROR: $msg." >&2
+	[[ -e $LOGFILE ]] && echo "Check $LOGFILE for more details." >&2
 
 	exit 1
 }


### PR DESCRIPTION
Right now, unless the entire gcc version string, including build date
and package version, matches the distro kernel exactly, kpatch-build
won't proceed.  While we do want the gcc version to match, the build
date and package level don't necessarily need to match.

This commit allows the build to proceed if the gcc versions match and
produces a non-fatal warning if the build date or package level don't
match.

Fixes #431 
