### PR TITLE
improve kpatch-build Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.ko.cmd
 *.mod.c
 *.swp
+*.d
 .tmp_versions
 Module.symvers
 kpatch-build/lookup

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -4,13 +4,18 @@ CFLAGS  += -I../kmod/patch -Iinsn -Wall -g
 LDFLAGS = -lelf
 
 TARGETS = create-diff-object
+OBJS = create-diff-object.o lookup.o insn/insn.o insn/inat.o
+SOURCES = create-diff-object.c lookup.c insn/insn.c insn/inat.c
 
 all: $(TARGETS)
 
-create-diff-object: create-diff-object.c list.h lookup.c lookup.h insn/insn.c \
-		    insn/inat.c insn/inat-tables.c insn/asm/inat.h \
-		    insn/asm/insn.h insn/asm/inat_types.h
-	$(CC) $(CFLAGS) create-diff-object.c lookup.c insn/insn.c insn/inat.c -o $@ $(LDFLAGS)
+-include $(SOURCES:.c=.d)
+
+%.o : %.c
+	$(CC) -MMD -MP $(CFLAGS) -c -o $@ $<
+
+create-diff-object: $(OBJS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 install: all
 	$(INSTALL) -d $(LIBEXECDIR)
@@ -23,4 +28,4 @@ uninstall:
 	$(RM) $(BINDIR)/kpatch-build
 
 clean:
-	$(RM) $(TARGETS)
+	$(RM) $(TARGETS) $(OBJS) *.d insn/*.d


### PR DESCRIPTION
Right now, the makefile has one target, create-diff-object, which
contains all the source/headers as one long list and all the source
files compiled in one command to make create-diff-object.

This doesn't scale well and doesn't accurately portray the dependencies
of each object that contribute to the final binary.

This commit renames create-diff-object.c to main.c so that it can be
compiled and linked seperately and cleanly in Make and autogenerates
dependencies for each .o.  This should make it easier to add additional
object files, or refactor the very large create-diff-object.o into seperate object
file, later.
