### PR TITLE
check that logfile exists before printing message

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -60,7 +60,11 @@ die() {
 		msg="$1"
 	fi
 
-	warn "$msg. Check $LOGFILE for more details."
+	if [[ -e $LOGFILE ]]; then
+		warn "$msg. Check $LOGFILE for more details."
+	else
+		warn "$msg."
+	fi
 
 	exit 1
 }


### PR DESCRIPTION
Don't tell the user to check a log file that doesn't exist
