### PR TITLE
remove "no changed functions" messages

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2790,9 +2790,9 @@ int main(int argc, char *argv[])
 
 	if (!num_changed && !new_globals_exist) {
 		if (hooks_exist)
-			log_normal("no changed functions were found, but hooks exist\n");
+			log_debug("no changed functions were found, but hooks exist\n");
 		else {
-			log_normal("no changed functions were found\n");
+			log_debug("no changed functions were found\n");
 			return 3; /* 1 is ERROR, 2 is DIFF_FATAL */
 		}
 	}


### PR DESCRIPTION
When patching a shared header file, don't spam the user with hundreds of
lines of "no changed functions" messages.  We expect the user to be
proactive with verifying that the right functions are being patched
anyway, so this message isn't strictly necessary.
