### PR TITLE
allow shadow functions to be called from modules

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -444,10 +444,11 @@ export TEMPDIR
 # module gets moved to the kernel tree
 CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " \
 	LDFLAGS_vmlinux="--warn-unresolved-symbols" \
-	LDFLAGS_MODULE="--warn-unresolved-symbols" \
+	KBUILD_MODPOST_WARN=1 \
 	make "-j$CPUS" $TARGETS "O=$OBJDIR"  >> "$LOGFILE" 2>&1 || die
 [[ "${PIPESTATUS[0]}" -eq 0 ]] || die
 grep -q "undefined reference" "$LOGFILE" | grep -qv kpatch_shadow && die
+grep -q "undefined!" "$LOGFILE" |grep -qv kpatch_shadow && die
 
 if [[ ! -e "$TEMPDIR/changed_objs" ]]; then
 	die "no changed objects found"

--- a/test/integration/module-shadow.patch
+++ b/test/integration/module-shadow.patch
@@ -1,0 +1,25 @@
+Index: src/arch/x86/kvm/vmx.c
+===================================================================
+--- src.orig/arch/x86/kvm/vmx.c
++++ src/arch/x86/kvm/vmx.c
+@@ -8758,10 +8758,20 @@ static void vmx_leave_nested(struct kvm_
+  * It should only be called before L2 actually succeeded to run, and when
+  * vmcs01 is current (it doesn't leave_guest_mode() or switch vmcss).
+  */
++#include "kpatch.h"
+ static void nested_vmx_entry_failure(struct kvm_vcpu *vcpu,
+ 			struct vmcs12 *vmcs12,
+ 			u32 reason, unsigned long qualification)
+ {
++	int *kpatch;
++
++	kpatch = kpatch_shadow_alloc(vcpu, "kpatch", sizeof(*kpatch),
++				     GFP_KERNEL);
++	if (kpatch) {
++		kpatch_shadow_get(vcpu, "kpatch");
++		kpatch_shadow_free(vcpu, "kpatch");
++	}
++
+ 	load_vmcs12_host_state(vcpu, vmcs12);
+ 	vmcs12->vm_exit_reason = reason | VMX_EXIT_REASONS_FAILED_VMENTRY;
+ 	vmcs12->exit_qualification = qualification;


### PR DESCRIPTION
Fixes an issue where attempting to call the shadow functions from a
module results in modpost failures:

```
ERROR: "kpatch_shadow_get" [net/mac80211/mac80211.ko] undefined!
ERROR: "kpatch_shadow_alloc" [net/mac80211/mac80211.ko] undefined!
```

LDFLAGS_MODULE is apparently not really needed.
