### PR TITLE
Fix #430 by copying original modules to TEMPDIR

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -475,7 +475,7 @@ for i in $FILES; do
 	if [[ $KOBJFILE = vmlinux ]]; then
 		KOBJFILE=$VMLINUX
 	else
-		KOBJFILE="$(readlink -f $KOBJFILE)"
+		KOBJFILE="$TEMPDIR/module/$KOBJFILE"
 	fi
 	cd $TEMPDIR
 	debugopt=

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -5,45 +5,64 @@ set -x
 TOOLCHAINCMD="$1"
 shift
 
-if [[ "$TOOLCHAINCMD" != "gcc" ]] || [[ -z "$TEMPDIR" ]]; then
+if [[ -z "$TEMPDIR" ]]; then
     exec "$TOOLCHAINCMD" "$@"
 fi
 
 declare -a args=("$@")
 
-while [ "$#" -gt 0 ]; do
-	if [ "$1" = "-o" ]; then
-		obj=$2
-		[[ $2 = */.tmp_*.o ]] && obj=${2/.tmp_/}
-		case "$obj" in
-			*.mod.o|\
-			*built-in.o|\
-			vmlinux.o|\
-			.tmp_kallsyms1.o|\
-			.tmp_kallsyms2.o|\
-			init/version.o|\
-			arch/x86/boot/version.o|\
-			arch/x86/boot/compressed/eboot.o|\
-			arch/x86/boot/header.o|\
-			arch/x86/boot/compressed/efi_stub_64.o|\
-			arch/x86/boot/compressed/piggy.o|\
-			kernel/system_certificates.o|\
-			arch/x86/vdso/*|\
-			.*.o)
-			break
-			;;
-		*.o)
-			mkdir -p "$TEMPDIR/orig/$(dirname $obj)"
-			cp -f "$obj" "$TEMPDIR/orig/$obj"
-			echo "$obj" >> "$TEMPDIR/changed_objs"
-			break
-			;;
-		*)
-			break
-			;;
-		esac
-	fi
-	shift
-done
+if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
+	while [ "$#" -gt 0 ]; do
+		if [ "$1" = "-o" ]; then
+			obj=$2
+			[[ $2 = */.tmp_*.o ]] && obj=${2/.tmp_/}
+			case "$obj" in
+				*.mod.o|\
+				*built-in.o|\
+				vmlinux.o|\
+				.tmp_kallsyms1.o|\
+				.tmp_kallsyms2.o|\
+				init/version.o|\
+				arch/x86/boot/version.o|\
+				arch/x86/boot/compressed/eboot.o|\
+				arch/x86/boot/header.o|\
+				arch/x86/boot/compressed/efi_stub_64.o|\
+				arch/x86/boot/compressed/piggy.o|\
+				kernel/system_certificates.o|\
+				arch/x86/vdso/*|\
+				.*.o)
+					break
+					;;
+				*.o)
+					mkdir -p "$TEMPDIR/orig/$(dirname $obj)"
+					cp -f "$obj" "$TEMPDIR/orig/$obj"
+					echo "$obj" >> "$TEMPDIR/changed_objs"
+					break
+					;;
+				*)
+					break
+					;;
+			esac
+		fi
+		shift
+	done
+elif [[ "$TOOLCHAINCMD" = "ld" ]] ; then
+	while [ "$#" -gt 0 ]; do
+		if [ "$1" = "-o" ]; then
+			obj=$2
+			case "$obj" in
+				*.ko)
+					mkdir -p "$TEMPDIR/module/$(dirname $obj)"
+					cp -f "$obj" "$TEMPDIR/module/$obj"
+					break
+					;;
+				*)
+					break
+					;;
+			esac
+		fi
+		shift
+	done
+fi
 
 exec "$TOOLCHAINCMD" "${args[@]}"


### PR DESCRIPTION
The diff for kpatch-gcc seems large, but it's really just the gcc/ld cases being wrapped in a conditional. Created a separate case for ld to catch any modules being linked during the second pass. It copies any modules it finds to `TEMPDIR/module`. I created a separate dir for this, but perhaps it makes more sense to put it in `TEMPDIR/orig` instead?

Tested with a few modules and it worked for me, would like confirmation that it works for other people. Let me know if there are issues.

Fixes #430.
