### PR TITLE
allow patched modules to call external functions

### DIFF
--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -53,7 +53,7 @@ struct kpatch_dynrela {
 	unsigned long type;
 	const char *name;
 	int addend;
-	int exported;
+	int external;
 	struct list_head list;
 };
 

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -318,7 +318,7 @@ static int patch_make_dynrelas_list(struct list_head *objects)
 		dynrela->src = p_dynrela->src;
 		dynrela->type = p_dynrela->type;
 		dynrela->name = p_dynrela->name;
-		dynrela->exported = p_dynrela->exported;
+		dynrela->external = p_dynrela->external;
 		dynrela->addend = p_dynrela->addend;
 		list_add_tail(&dynrela->list, &object->dynrelas);
 	}

--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -37,7 +37,7 @@ struct kpatch_patch_dynrela {
 	unsigned long type;
 	char *name;
 	char *objname;
-	int exported;
+	int external;
 	int addend;
 };
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2213,7 +2213,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 	struct symbol *strsym;
 	struct lookup_result result;
 	struct kpatch_patch_dynrela *dynrelas;
-	int vmlinux, exported;
+	int vmlinux, external;
 
 	vmlinux = !strcmp(objname, "vmlinux");
 
@@ -2261,7 +2261,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 			if (kpatch_is_core_module_symbol(rela->sym->name))
 				continue;
 
-			exported = 0;
+			external = 0;
 
 			if (rela->sym->bind == STB_LOCAL) {
 				/* An unchanged local symbol */
@@ -2310,10 +2310,11 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				if (lookup_global_symbol(table, rela->sym->name,
 							 &result))
 					/*
-					 * Not there, assume it's exported by
-					 * another object.
+					 * Not there, assume it's either an
+					 * exported symbol or provided by
+					 * another .o in the patch module.
 					 */
-					exported = 1;
+					external = 1;
 			}
 			log_debug("lookup for %s @ 0x%016lx len %lu\n",
 			          rela->sym->name, result.value, result.size);
@@ -2326,7 +2327,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				dynrelas[index].src = 0;
 			dynrelas[index].addend = rela->addend;
 			dynrelas[index].type = rela->type;
-			dynrelas[index].exported = exported;
+			dynrelas[index].external = external;
 
 			/* add rela to fill in dest field */
 			ALLOC_LINK(dynrela, &relasec->relas);

--- a/test/integration/module-call-external.patch
+++ b/test/integration/module-call-external.patch
@@ -1,0 +1,35 @@
+Index: src/fs/nfsd/export.c
+===================================================================
+--- src.orig/fs/nfsd/export.c
++++ src/fs/nfsd/export.c
+@@ -1241,6 +1241,8 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+@@ -1250,6 +1252,7 @@ static int e_show(struct seq_file *m, vo
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+Index: src/net/netlink/af_netlink.c
+===================================================================
+--- src.orig/net/netlink/af_netlink.c
++++ src/net/netlink/af_netlink.c
+@@ -3228,4 +3228,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);


### PR DESCRIPTION
When patching a kernel module, if we can't find a needed dynrela symbol,
we currently assume it's exported.  However, it's also possible that
it's provided by another .o in the patch module.  Add support for that.

Fixes #445.
