### PR TITLE
kpatch-build: fixup source package version construction

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -380,7 +380,7 @@ else
 		# The linux-source packages are formatted like the following for:
 		# ubuntu: linux-source-3.13.0_3.13.0-24.46_all.deb
 		# debian: linux-source-3.14_3.14.7-1_all.deb
-		pkgver="$KVER_$(dpkg-query -W -f='${Version}' linux-image-$ARCHVERSION)"
+		pkgver="${KVER}_$(dpkg-query -W -f='${Version}' linux-image-$ARCHVERSION)"
 		pkgname="linux-source-${pkgver}_all"
 
 		cd $TEMPDIR


### PR DESCRIPTION
Bash doesn't correctly format the version string which causes the source
package to not be downloaded correctly.

Signed-off-by: Chris J Arges chris.j.arges@canonical.com
