### PR TITLE
Fix memory leak on dest buffer on early return path

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1838,6 +1838,7 @@ void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 		/* no changed or global functions referenced */
 		sec->status = sec->base->status = SAME;
 		sec->include = sec->base->include = 0;
+		free(dest);
 		return;
 	}
 


### PR DESCRIPTION
dest is allocated but not freed on an early return path
where dest is not used

Signed-off-by: Colin Ian King colin.king@canonical.com
