### PR TITLE
Restrict reading old_addr and new_addr to root only

### DIFF
--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -118,10 +118,10 @@ static ssize_t patch_func_new_addr_show(struct kobject *kobj,
 }
 
 static struct kobj_attribute patch_old_addr_attr =
-	__ATTR(old_addr, S_IRUGO, patch_func_old_addr_show, NULL);
+	__ATTR(old_addr, S_IRUSR, patch_func_old_addr_show, NULL);
 
 static struct kobj_attribute patch_new_addr_attr =
-	__ATTR(new_addr, S_IRUGO, patch_func_new_addr_show, NULL);
+	__ATTR(new_addr, S_IRUSR, patch_func_new_addr_show, NULL);
 
 static void patch_func_kobj_free(struct kobject *kobj)
 {


### PR DESCRIPTION
As mentioned on the live-patching mailing list, it is probably a good idea to restrict reading `old_addr` and `new_addr` to root only, to prevent unprivileged users from gaining information about the kernel's address space.

That being said, we could also take this time to double check current permissions in sysfs. Should `checksum` and `enabled` be readable by root only as well? Should the perms on the kpatch directory in sysfs be more stringent?