### PR TITLE
wait for outstanding shadow variables free requests in kpatch_exit

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -1084,6 +1084,8 @@ err_root_kobj:
 
 static void kpatch_exit(void)
 {
+	rcu_barrier();
+
 	WARN_ON(kpatch_num_patched != 0);
 	WARN_ON(unregister_module_notifier(&kpatch_module_nb));
 	kobject_put(kpatch_patches_kobj);


### PR DESCRIPTION
Unload of kpatch module (and kpatch_shadow_hash table) before
all shadow variables free requests are processed can lead to
kernel crash.

Add rcu_barrier() to kpatch_exit() to wait for all outstanding
RCU callbacks to complete.

Resolves #468 
Signed-off-by: Jan Stancek jstancek@redhat.com
