### PR TITLE
fix dracut dependencies (and "kpatch install")

### DIFF
--- a/contrib/module-setup.sh
+++ b/contrib/module-setup.sh
@@ -20,7 +20,7 @@ install() {
     inst_any -d /usr/sbin/kpatch /usr/local/sbin/kpatch /usr/sbin/kpatch
 
     # install kpatch script dependencies
-    inst_symlink /usr/sbin/insmod
+    inst /usr/sbin/insmod
     inst /usr/bin/dirname
     inst /usr/bin/readelf
     inst /usr/bin/awk


### PR DESCRIPTION
The "kpatch install" command is broken because the kpatch script has
some missing dependencies in the initramfs.  Make sure the new
dependencies (readelf and awk) are added to the initramfs.
