### PR TITLE
Fix kpatch-build failure with srpm on centos

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -365,7 +365,7 @@ else
 
 		clean_cache
 
-		mv "$(rpm --eval %{_builddir})"/kernel-*/linux-"$ARCHVERSION" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
+		mv "$(rpm --eval %{_builddir})"/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
 
 		cp "$SRCDIR/.config" "$OBJDIR" || die
 		if [[ "$ARCHVERSION" == *-* ]]; then


### PR DESCRIPTION
kpatch-build was failing on centos7 with

    mv: cannot stat '/home/vagrant/rpmbuild/BUILD/kernel-*/linux-3.10.0-229.el7.x86_64': No such file or directory

in the error log. This was due to the actual directory being named
linux-3.10.0-229.el7.centos.x86_64. This patch avoids this failure by
adding a wildcard before the arch.

Signed-off-by: Louis Taylor <louis@kragniz.eu>