### PR TITLE
Add new r_info field to kpatch_patch_dynrela and rela structs

### DIFF
--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -35,6 +35,7 @@ struct kpatch_patch_dynrela {
 	unsigned long dest;
 	unsigned long src;
 	unsigned long type;
+	unsigned long r_info;
 	char *name;
 	char *objname;
 	int external;

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -252,6 +252,7 @@ static int __init patch_init(void)
 			lreloc->loc = reloc->kdynrela->dest;
 			lreloc->val = reloc->kdynrela->src;
 			lreloc->type = reloc->kdynrela->type;
+			lreloc->r_info = reloc->kdynrela->r_info;
 			lreloc->name = reloc->kdynrela->name;
 			lreloc->addend = reloc->kdynrela->addend;
 			lreloc->external = reloc->kdynrela->external;

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -134,6 +134,7 @@ struct rela {
 	GElf_Rela rela;
 	struct symbol *sym;
 	unsigned int type;
+	unsigned long r_info;
 	int addend;
 	int offset;
 	char *string;
@@ -307,6 +308,7 @@ void kpatch_create_rela_list(struct kpatch_elf *kelf, struct section *sec)
 		index++;
 
 		rela->type = GELF_R_TYPE(rela->rela.r_info);
+		rela->r_info = rela->rela.r_info;
 		rela->addend = rela->rela.r_addend;
 		rela->offset = rela->rela.r_offset;
 		symndx = GELF_R_SYM(rela->rela.r_info);
@@ -2473,6 +2475,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				dynrelas[index].src = 0;
 			dynrelas[index].addend = rela->addend;
 			dynrelas[index].type = rela->type;
+			dynrelas[index].r_info = rela->r_info;
 			dynrelas[index].external = external;
 
 			/* add rela to fill in dest field */


### PR DESCRIPTION
Save the `r_info` field in create-diff-object to pass into `klp_write_module_reloc()`.