### PR TITLE
bugfix: correlate the rela sections of bundled static variables

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1170,6 +1170,11 @@ void kpatch_correlate_static_local_variables(struct kpatch_elf *base,
 		if (bundled) {
 			sym->sec->twin = basesym->sec;
 			basesym->sec->twin = sym->sec;
+
+			if (sym->sec->rela && basesym->sec->rela) {
+				sym->sec->rela->twin = basesym->sec->rela;
+				basesym->sec->rela->twin = sym->sec->rela;
+			}
 		}
 	}
 }


### PR DESCRIPTION
If a static variable is a pointer, it has rela section.

Example:
	static int *p = &a;
changed to:
	static int *p = &b;
so its rela section has changed.

Then this change of data should be found and report error.
But if we don't correlate its rela section, we won't
find this change.

Signed-off-by: Zhou ChengMing <zhouchengming1@outlook.com>