### PR TITLE
kpatch-build: fix shadow_get function

### DIFF
--- a/kmod/core/shadow.c
+++ b/kmod/core/shadow.c
@@ -158,6 +158,9 @@ void *kpatch_shadow_get(void *obj, char *var)
 				   (unsigned long)obj) {
 		if (shadow->obj == obj && !strcmp(shadow_var(shadow), var)) {
 			rcu_read_unlock();
+			if (shadow_is_inplace(shadow))
+				return &(shadow->data);
+
 			return shadow->data;
 		}
 	}


### PR DESCRIPTION
The shadow_get function does't consider the case that
'shadow is inpace', and after the shadow->data be set to the data,
it will not be the pointer. This patch fix it.

Signed-off-by: Li Bin <huawei.libin@huawei.com>