### PR TITLE
kpatch-build: verify bss/data/init section change properly

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2934,6 +2934,9 @@ int main(int argc, char *argv[])
 	kpatch_print_changes(kelf_patched);
 	kpatch_dump_kelf(kelf_patched);
 
+	kpatch_process_special_sections(kelf_patched);
+	kpatch_verify_patchability(kelf_patched);
+
 	if (!num_changed && !new_globals_exist) {
 		if (hooks_exist)
 			log_debug("no changed functions were found, but hooks exist\n");
@@ -2942,9 +2945,6 @@ int main(int argc, char *argv[])
 			return 3; /* 1 is ERROR, 2 is DIFF_FATAL */
 		}
 	}
-
-	kpatch_process_special_sections(kelf_patched);
-	kpatch_verify_patchability(kelf_patched);
 
 	/* this is destructive to kelf_patched */
 	kpatch_migrate_included_elements(kelf_patched, &kelf_out);


### PR DESCRIPTION
kpatch_verify_patchability can detect the change of .bss or .data or
.init section, but it must be processed before verify num_changed.
Otherwise, for example, if only .init section changed, it will fail
with 'no changed functions were found', but not 'unsupported section
change(s)'.

With this patch,
for .init section: .init section will not a bundled section, so if
the section changed, not sync the function status, kpatch_verify_patchability
will give 'changed section <secname> not selected for inclusion' and
'unsupported section change(s)' error.

for .bss/.data section: kpatch_verify_patchability will ensure not
including .data or .bss section, otherwise it will give 'data section
<secname> selected for inclusion' and 'unsupported section change(s)'
error.

Signed-off-by: Li Bin <huawei.libin@huawei.com>