### PR TITLE
livepatch-patch-hook: check for object->name before calling strcmp

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -91,7 +91,7 @@ static struct patch_object *patch_find_object_by_name(const char *name)
 
 	list_for_each_entry(object, &patch_objects, list)
 		if ((!strcmp(name, "vmlinux") && !object->name) ||
-		    !strcmp(object->name, name))
+		    (object->name && !strcmp(object->name, name)))
 			return object;
 	return patch_alloc_new_object(name);
 }


### PR DESCRIPTION
Fixes issue #494. A null pointer dereference can result with patch modules for multiple objects since the "vmlinux" patch object's "name" field is null. strcmp therefore crashes trying to compare object->name if the current object is vmlinux and the supplied "name" argument is not. 
Check that object->name is not null before invoking strcmp.