### PR TITLE
kpatch-build: support adding new files in patch

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -463,7 +463,7 @@ do
 done
 
 echo "Extracting new and modified ELF sections"
-cd "$TEMPDIR/orig"
+cd "$TEMPDIR/patched"
 FILES="$(find * -type f)"
 cd "$TEMPDIR"
 mkdir output
@@ -482,6 +482,7 @@ for i in $FILES; do
 	cd $TEMPDIR
 	debugopt=
 	[[ $DEBUG -eq 1 ]] && debugopt=-d
+	[[ ! -e "orig/$i" ]] && cp -f "patched/$i" "output/$i" && continue
 	"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
 	rc="${PIPESTATUS[0]}"
 	if [[ $rc = 139 ]]; then


### PR DESCRIPTION
Geting the changed objects from the patched dir, in order to support
adding new files in patch.

The reason that not using 'cat $TEMPDIR/changed_objs' to get the
changed objects is to avoid following case:
arch/x86/kvm/../../../virt/kvm/kvm_main.o
that find_parent_obj will fail with "two parent matches for *.o".

Signed-off-by: Li Bin <huawei.libin@huawei.com>