### PR TITLE
kpatch-build: support patching weak function

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -185,7 +185,7 @@ int lookup_global_symbol(struct lookup_table *table, char *name,
 
 	memset(result, 0, sizeof(*result));
 	for_each_symbol(i, sym, table)
-		if (!sym->skip && sym->bind == STB_GLOBAL &&
+		if (!sym->skip && (sym->bind == STB_GLOBAL || sym->bind == STB_WEAK) &&
 		    !strcmp(sym->name, name)) {
 			result->value = sym->value;
 			result->size = sym->size;


### PR DESCRIPTION
Before this patch, if changed function is weak symbol, it is not
be allowed to create live patch, and it will trigger the following
error:
/usr/local/libexec/kpatch/create-diff-object: ERROR: ***.o:
kpatch_create_patches_sections: 2294: lookup_global_symbol ***

And if the changed function reference the weak symbol, when loading
the patch module will trigger the following error:
module kpatch-***: overflow in relocation type *** val 0
insmod: can't insert 'kpatch-***.ko': invalid module format

This patch fix it and add support for patching weak function.

Signed-off-by: Li Bin <huawei.libin@huawei.com>