### PR TITLE
Flags/variables to help split livepatch and kpatch

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -1,17 +1,18 @@
 KPATCH_NAME ?= patch
 KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
 KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD)
+KPATCH_TYPE ?= kpatch
 
-obj-m += kpatch-$(KPATCH_NAME).o
+obj-m += $(KPATCH_TYPE)-$(KPATCH_NAME).o
 
-kpatch-$(KPATCH_NAME)-objs += patch-hook.o kpatch.lds output.o
+$(KPATCH_TYPE)-$(KPATCH_NAME)-objs += patch-hook.o $(KPATCH_TYPE).lds output.o
 
-all: kpatch-$(KPATCH_NAME).ko
+all: $(KPATCH_TYPE)-$(KPATCH_NAME).ko
 
-kpatch-$(KPATCH_NAME).ko:
-	$(KPATCH_MAKE) kpatch-$(KPATCH_NAME).ko
+$(KPATCH_TYPE)-$(KPATCH_NAME).ko:
+	$(KPATCH_MAKE) $(KPATCH_TYPE)-$(KPATCH_NAME).ko
 
-patch-hook.o: patch-hook.c kpatch-patch-hook.c livepatch-patch-hook.c
+patch-hook.o: patch-hook.c $(KPATCH_TYPE)-patch-hook.c
 	$(KPATCH_MAKE) patch-hook.o
 
 clean:

--- a/kmod/patch/livepatch.lds
+++ b/kmod/patch/livepatch.lds
@@ -1,0 +1,4 @@
+__kpatch_funcs = ADDR(.kpatch.funcs);
+__kpatch_funcs_end = ADDR(.kpatch.funcs) + SIZEOF(.kpatch.funcs);
+__kpatch_dynrelas = ADDR(.kpatch.dynrelas);
+__kpatch_dynrelas_end = ADDR(.kpatch.dynrelas) + SIZEOF(.kpatch.dynrelas);

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -78,6 +78,13 @@ enum loglevel {
 
 static enum loglevel loglevel = NORMAL;
 
+enum patchtype {
+	KPATCH,
+	LIVEPATCH
+};
+
+static enum patchtype patchtype = KPATCH;
+
 /*******************
  * Data structures
  * ****************/
@@ -2802,12 +2809,14 @@ void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile)
 struct arguments {
 	char *args[4];
 	int debug;
+	int livepatch;
 };
 
 static char args_doc[] = "original.o patched.o kernel-object output.o";
 
 static struct argp_option options[] = {
 	{"debug", 'd', 0, 0, "Show debug output" },
+	{"livepatch", 'l', 0, 0, "Use LIVEPATCH mode. Default is KPATCH." },
 	{ 0 }
 };
 
@@ -2821,6 +2830,9 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 	{
 		case 'd':
 			arguments->debug = 1;
+			break;
+		case 'l':
+			arguments->livepatch = 1;
 			break;
 		case ARGP_KEY_ARG:
 			if (state->arg_num >= 4)
@@ -2893,9 +2905,14 @@ int main(int argc, char *argv[])
 	char *hint = NULL, *name, *pos;
 
 	arguments.debug = 0;
+	arguments.livepatch = 0;
 	argp_parse (&argp, argc, argv, 0, 0, &arguments);
 	if (arguments.debug)
 		loglevel = DEBUG;
+
+	/* Detect livepatch mode */
+	if (arguments.livepatch)
+		patchtype = LIVEPATCH;
 
 	elf_version(EV_CURRENT);
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -49,6 +49,7 @@ TEMPDIR=
 APPLIEDPATCHFILE="kpatch.patch"
 DEBUG=0
 SKIPGCCCHECK=0
+PATCHTYPE="kpatch"
 
 warn() {
 	echo "ERROR: $1" >&2
@@ -318,7 +319,7 @@ elif [[ $DISTRO = ubuntu ]] || [[ $DISTRO = debian ]]; then
 	if [[ $DISTRO = ubuntu ]]; then
 		[[ -e "$VMLINUX" ]] || die "linux-image-$ARCHVERSION-dbgsym not installed"
 
-        elif [[ $DISTRO = debian ]]; then
+	elif [[ $DISTRO = debian ]]; then
 		[[ -e "$VMLINUX" ]] || die "linux-image-$ARCHVERSION-dbg not installed"
 	fi
 
@@ -518,19 +519,29 @@ echo -n "Patched objects:"
 for i in "${!objnames[@]}"; do echo -n " $(basename $i)"; done
 echo
 
-echo "Building patch module: kpatch-$PATCHNAME.ko"
+if grep -q "CONFIG_LIVEPATCH=y" "$OBJDIR/.config"; then
+	PATCHTYPE="livepatch"
+fi
+echo "Detected patch type: $PATCHTYPE"
+
+echo "Building patch module: $PATCHTYPE-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"
 cd "$SRCDIR"
 make prepare >> "$LOGFILE" 2>&1 || die
 cd "$TEMPDIR/output"
 ld -r -o ../patch/output.o $(find . -name "*.o") >> "$LOGFILE" 2>&1 || die
-md5sum ../patch/output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die
-objcopy --add-section .kpatch.checksum=checksum.tmp --set-section-flags .kpatch.checksum=alloc,load,contents,readonly  ../patch/output.o || die
-rm -f checksum.tmp
-cd "$TEMPDIR/patch"
-KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$PATCHNAME" KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE" make "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
 
-cp -f "$TEMPDIR/patch/kpatch-$PATCHNAME.ko" "$BASE" || die
+# Create checksum if using kpatch patching.
+if [[ $PATCHTYPE == "kpatch" ]]; then
+	md5sum ../patch/output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die
+	objcopy --add-section .kpatch.checksum=checksum.tmp --set-section-flags .kpatch.checksum=alloc,load,contents,readonly  ../patch/output.o || die
+	rm -f checksum.tmp
+fi
+
+cd "$TEMPDIR/patch"
+KPATCH_TYPE="$PATCHTYPE" KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$PATCHNAME" KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE" make "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
+
+cp -f "$TEMPDIR/patch/$PATCHTYPE-$PATCHNAME.ko" "$BASE" || die
 
 [[ "$DEBUG" -eq 0 ]] && rm -f "$LOGFILE"
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -463,6 +463,12 @@ do
 	cp -f "$OBJDIR/$i" "$TEMPDIR/patched/$i" || die
 done
 
+# Detect patching type
+if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE"; then
+	PATCHTYPE="livepatch"
+fi
+echo "Detected patch type: $PATCHTYPE"
+
 echo "Extracting new and modified ELF sections"
 cd "$TEMPDIR/patched"
 FILES="$(find * -type f)"
@@ -483,8 +489,10 @@ for i in $FILES; do
 	cd $TEMPDIR
 	debugopt=
 	[[ $DEBUG -eq 1 ]] && debugopt=-d
+	livepatchopt=
+	[[ $PATCHTYPE == "livepatch" ]] && livepatchopt=-l
 	if [[ -e "orig/$i" ]]; then
-		"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+		"$TOOLSDIR"/create-diff-object $debugopt $livepatchopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
 		rc="${PIPESTATUS[0]}"
 		if [[ $rc = 139 ]]; then
 			warn "create-diff-object SIGSEGV"
@@ -518,11 +526,6 @@ fi
 echo -n "Patched objects:"
 for i in "${!objnames[@]}"; do echo -n " $(basename $i)"; done
 echo
-
-if grep -q "CONFIG_LIVEPATCH=y" "$OBJDIR/.config"; then
-	PATCHTYPE="livepatch"
-fi
-echo "Detected patch type: $PATCHTYPE"
 
 echo "Building patch module: $PATCHTYPE-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"


### PR DESCRIPTION
These patches will allow for developing features that are specific to livepatch to be exposed in create-diff-object as well as in the kpatch-build script. This is a base for #478, which will use these flags to make the livepatch hook much simpler.