### PR TITLE
kpatch-build: a couple of symvers-related fixes

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -103,7 +103,7 @@ find_dirs() {
 		# installation path
 		TOOLSDIR="$(readlink -f $SCRIPTDIR/../libexec/kpatch)"
 		DATADIR="$(readlink -f $SCRIPTDIR/../share/kpatch)"
-		SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/kpatch/$(uname -r)/Module.symvers)"
+		SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/kpatch/$ARCHVERSION/Module.symvers)"
 		return
 	fi
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -103,7 +103,14 @@ find_dirs() {
 		# installation path
 		TOOLSDIR="$(readlink -f $SCRIPTDIR/../libexec/kpatch)"
 		DATADIR="$(readlink -f $SCRIPTDIR/../share/kpatch)"
-		SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/kpatch/$ARCHVERSION/Module.symvers)"
+		if [[ -e $SCRIPTDIR/../lib/kpatch/$ARCHVERSION/Module.symvers ]]; then
+			SYMVERSFILE="$(readlink -f $SCRIPTDIR/../lib/kpatch/$ARCHVERSION/Module.symvers)"
+		elif [[ -e /lib/modules/$ARCHVERSION/extra/kpatch/Module.symvers ]]; then
+			SYMVERSFILE="$(readlink -f /lib/modules/$ARCHVERSION/extra/kpatch/Module.symvers)"
+		else
+			warn "unable to find Module.symvers for kpatch core module"
+			return 1
+		fi
 		return
 	fi
 
@@ -300,10 +307,6 @@ fi
 # kernel's 56-byte module name array.
 PATCHNAME=$(echo ${PATCHNAME//[^a-zA-Z0-9_-]/-} |cut -c 1-48)
 
-find_dirs || die "can't find supporting tools"
-
-[[ -e "$SYMVERSFILE" ]] || die "can't find core module Module.symvers"
-
 source /etc/os-release
 DISTRO=$ID
 if [[ $DISTRO = fedora ]] || [[ $DISTRO = rhel ]] || [[ $DISTRO = ol ]] || [[ $DISTRO = centos ]]; then
@@ -324,6 +327,11 @@ elif [[ $DISTRO = ubuntu ]] || [[ $DISTRO = debian ]]; then
 
 	export PATH=/usr/lib/ccache:$PATH
 fi
+
+find_dirs || die "can't find supporting tools"
+
+[[ -e "$SYMVERSFILE" ]] || die "can't find core module Module.symvers"
+
 
 if [[ $SKIPGCCCHECK -eq 0 ]]; then
 	gcc_version_check || die


### PR DESCRIPTION
The first commit ensures kpatch-build looks for Module.symvers for the core module in the directory corresponding to the target kernel rather than for the currently running one.

The second one handles the case when Kpatch tools are distributed in a package and the core module is installed to /lib/modules/<kernel_version>/extra/kpatch/