### PR TITLE
kpatch-build: do not clobber ~/rpmbuild directory

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -44,6 +44,7 @@ CPUS="$(getconf _NPROCESSORS_ONLN)"
 CACHEDIR="$HOME/.kpatch"
 SRCDIR="$CACHEDIR/src"
 OBJDIR="$CACHEDIR/obj"
+TMPSRCDIR="$CACHEDIR/tempsrc"
 VERSIONFILE="$CACHEDIR/version"
 TEMPDIR=
 APPLIEDPATCHFILE="kpatch.patch"
@@ -358,14 +359,24 @@ else
 		fi
 
 		echo "Unpacking kernel source"
-		rpmdev-setuptree >> "$LOGFILE" 2>&1 || die
-		rpm -ivh "$SRCRPM" >> "$LOGFILE" 2>&1 || die
-		rpmbuild -bp "--target=$(uname -m)" "$(rpm --eval %{_specdir})"/kernel.spec >> "$LOGFILE" 2>&1 ||
-			die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
+		(
+			clean_cache
 
-		clean_cache
+			# By default, rpmdev-setuptree and rpmbuild use
+			# ~/rpmbuild/ tree. However, this could clobber its
+			# existing contents, so let us use a fake home directory
+			# here to avoid that.
+			mkdir -p $TMPSRCDIR
+			HOME=$TMPSRCDIR
 
-		mv "$(rpm --eval %{_builddir})"/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
+			rpmdev-setuptree >> "$LOGFILE" 2>&1 || die
+			rpm -ivh "$SRCRPM" >> "$LOGFILE" 2>&1 || die
+			rpmbuild -bp "--target=$(uname -m)" "$(rpm --eval %{_specdir})"/kernel.spec >> "$LOGFILE" 2>&1 ||
+				die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
+
+			RPM_BUILD_DIR=$(rpm --eval %{_builddir})
+			mv "$RPM_BUILD_DIR"/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
+		)
 
 		cp "$SRCDIR/.config" "$OBJDIR" || die
 		if [[ "$ARCHVERSION" == *-* ]]; then


### PR DESCRIPTION
If a source RPM is used to obtain the kernel sources, kpatch-build
executes rpmdev-setuptree to prepare ~/rpmbuild directory tree, installs
the source RPM there. Then it calls 'rpmbuild -bp' to prepare the
kernel source tree.

All this, however, may clobber the existing contents of ~/rpmbuild,
which is very inconvenient if one uses rpmbuild to build other packages.

To avoid that, I could not find a better way than to specify a fake home
directory (~/.kpatch/tempsrc) for that portion of kpatch-build. It seems,
neither rpmdev-setuptree nor rpm have appropriate options for that.

I put the affected commands into a subshell so that the changes in $HOME
could not propagate to other parts of kpatch-build.