### PR TITLE
kpatch-build: do not use -ffunction-sections for a patch module itself

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -537,6 +537,8 @@ echo -n "Patched objects:"
 for i in "${!objnames[@]}"; do echo -n " $(basename $i)"; done
 echo
 
+export KCFLAGS="-I$DATADIR/patch"
+
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"
 cd "$SRCDIR"


### PR DESCRIPTION
-ffunction-sections and -fdata-sections are needed when building the
original and the patched kernels.

It is not necessary, however, to use these options when building a
patch module itself, its functions and data are OK in the sections they
are.

Let us remove these options from KCGLAGS after the kernels have been
built.