### PR TITLE
kpatch-build: detect special section group sizes

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1680,11 +1680,70 @@ void kpatch_reindex_elements(struct kpatch_elf *kelf)
 }
 
 
-int bug_table_group_size(struct kpatch_elf *kelf, int offset) { return 12; }
-int smp_locks_group_size(struct kpatch_elf *kelf, int offset) { return 4; }
-int parainstructions_group_size(struct kpatch_elf *kelf, int offset) { return 16; }
-int ex_table_group_size(struct kpatch_elf *kelf, int offset) { return 8; }
-int altinstructions_group_size(struct kpatch_elf *kelf, int offset) { return 12; }
+int bug_table_group_size(struct kpatch_elf *kelf, int offset)
+{
+	static int size = 0;
+	char *str;
+
+	if (!size) {
+		str = getenv("BUG_STRUCT_SIZE");
+		if (!str)
+			ERROR("BUG_STRUCT_SIZE not set");
+		size = atoi(str);
+	}
+
+	return size;
+}
+
+int parainstructions_group_size(struct kpatch_elf *kelf, int offset)
+{
+	static int size = 0;
+	char *str;
+
+	if (!size) {
+		str = getenv("PARA_STRUCT_SIZE");
+		if (!str)
+			ERROR("PARA_STRUCT_SIZE not set");
+		size = atoi(str);
+	}
+
+	return size;
+}
+
+int ex_table_group_size(struct kpatch_elf *kelf, int offset)
+{
+	static int size = 0;
+	char *str;
+
+	if (!size) {
+		str = getenv("EX_STRUCT_SIZE");
+		if (!str)
+			ERROR("EX_STRUCT_SIZE not set");
+		size = atoi(str);
+	}
+
+	return size;
+}
+
+int altinstructions_group_size(struct kpatch_elf *kelf, int offset)
+{
+	static int size = 0;
+	char *str;
+
+	if (!size) {
+		str = getenv("ALT_STRUCT_SIZE");
+		if (!str)
+			ERROR("ALT_STRUCT_SIZE not set");
+		size = atoi(str);
+	}
+
+	return size;
+}
+
+int smp_locks_group_size(struct kpatch_elf *kelf, int offset)
+{
+	return 4;
+}
 
 /*
  * The rela groups in the .fixup section vary in size.  The beginning of each
@@ -1752,7 +1811,7 @@ struct special_section special_sections[] = {
 		.group_size	= fixup_group_size,
 	},
 	{
-		.name		= "__ex_table",
+		.name		= "__ex_table", /* must come after .fixup */
 		.group_size	= ex_table_group_size,
 	},
 	{

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -452,6 +452,32 @@ cp "$PATCHFILE" "$APPLIEDPATCHFILE" || die
 cp -LR "$DATADIR/patch" "$TEMPDIR" || die
 export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections"
 
+echo "Reading special section data"
+SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
+	       gawk --non-decimal-data '
+	       BEGIN { a = b = p = e = 0 }
+	       a == 0 && /DW_AT_name.* alt_instr$/ {a = 1; next}
+	       b == 0 && /DW_AT_name.* bug_entry$/ {b = 1; next}
+	       p == 0 && /DW_AT_name.* paravirt_patch_site$/ {p = 1; next}
+	       e == 0 && /DW_AT_name.* exception_table_entry$/ {e = 1; next}
+	       a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
+	       b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
+	       p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}
+	       e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
+	       a == 2 && b == 2 && p == 2 && e == 2 {exit}')
+
+[[ -n $SPECIAL_VARS ]] && eval "$SPECIAL_VARS"
+
+if [[ -z $ALT_STRUCT_SIZE ]] || [[ -z $BUG_STRUCT_SIZE ]] ||
+   [[ -z $PARA_STRUCT_SIZE ]] || [[ -z $EX_STRUCT_SIZE ]]; then
+	die "can't find special struct size"
+fi
+for i in $ALT_STRUCT_SIZE $BUG_STRUCT_SIZE $PARA_STRUCT_SIZE $EX_STRUCT_SIZE; do
+	if [[ ! $i -gt 0 ]] || [[ ! $i -le 16 ]]; then
+		die "invalid special struct size $i"
+	fi
+done
+
 echo "Building original kernel"
 ./scripts/setlocalversion --save-scmversion || die
 make mrproper >> "$LOGFILE" 2>&1 || die


### PR DESCRIPTION
Hard-coding the special section group sizes is unreliable.  Instead,
determine them dynamically by finding the related struct definitions in
the DWARF metadata.

Fixes #517.
Fixes #523.