### PR TITLE
kpatch-build: fix searching for the sizes of special structures

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -457,10 +457,10 @@ echo "Reading special section data"
 SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
 	       gawk --non-decimal-data '
 	       BEGIN { a = b = p = e = 0 }
-	       a == 0 && /DW_AT_name.* alt_instr$/ {a = 1; next}
-	       b == 0 && /DW_AT_name.* bug_entry$/ {b = 1; next}
-	       p == 0 && /DW_AT_name.* paravirt_patch_site$/ {p = 1; next}
-	       e == 0 && /DW_AT_name.* exception_table_entry$/ {e = 1; next}
+	       a == 0 && /DW_AT_name.* alt_instr\s*$/ {a = 1; next}
+	       b == 0 && /DW_AT_name.* bug_entry\s*$/ {b = 1; next}
+	       p == 0 && /DW_AT_name.* paravirt_patch_site\s*$/ {p = 1; next}
+	       e == 0 && /DW_AT_name.* exception_table_entry\s*$/ {e = 1; next}
 	       a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
 	       b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
 	       p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}


### PR DESCRIPTION
readelf -wi may output trailing spaces in the lines with section names ('alt_instr', etc.). 

The regexps should take this into account, otherwise kpatch-build may fail with error:
    "can't find special struct size"