### PR TITLE
kpatch-build: allow to specify the target kernel version

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -206,6 +206,7 @@ usage() {
 	echo "		-r, --sourcerpm	   Specify kernel source RPM" >&2
 	echo "		-s, --sourcedir	   Specify kernel source directory" >&2
 	echo "		-c, --config	   Specify kernel config file" >&2
+	echo "		-k, --kernel-version   Specify target kernel version" >&2
 	echo "		-v, --vmlinux	   Specify original vmlinux" >&2
 	echo "		-t, --target	   Specify custom kernel build targets" >&2
 	echo "		-d, --debug	   Keep scratch files in /tmp" >&2
@@ -213,7 +214,7 @@ usage() {
 	echo "		                   (not recommended)" >&2
 }
 
-options=$(getopt -o hr:s:c:v:t:d -l "help,sourcerpm:,sourcedir:,config:,vmlinux:,target:,debug,skip-gcc-check" -- "$@") || die "getopt failed"
+options=$(getopt -o hr:s:c:k:v:t:d -l "help,sourcerpm:,sourcedir:,config:,kernel-version:,vmlinux:,target:,debug,skip-gcc-check" -- "$@") || die "getopt failed"
 
 eval set -- "$options"
 
@@ -240,6 +241,10 @@ while [[ $# -gt 0 ]]; do
 		CONFIGFILE=$(readlink -f "$2")
 		shift
 		[[ ! -f "$CONFIGFILE" ]] && die "config file $CONFIGFILE not found"
+		;;
+	-k|--kernel-version)
+		ARCHVERSION="$2".$(uname -m)
+		shift
 		;;
 	-v|--vmlinux)
 		VMLINUX=$(readlink -f "$2")

--- a/man/kpatch-build.1
+++ b/man/kpatch-build.1
@@ -28,6 +28,9 @@ to work on other distros.
 -c|--config
    Specify kernel config file
 
+-k|--kernel-version
+   Specify target kernel version
+
 -v|--vmlinux
    Specify original vmlinux
 


### PR DESCRIPTION
If the source tree of the kernel is used rather than its SRPM, the
version of the currently running kernel will be assumed as the version
of the target kernel (ARCHVERSION=$(uname -r)). This can be
inconvenient if the user actually prepares the binary patch for a
different kernel: the paths to some files used in the build contain
$ARCHVERSION, etc.

This patch adds -k|--kernel-version option to kpatch-build, so that it
becomes possible to specify the target kernel version explicitly.

Signed-off-by: Evgenii Shatokhin <eshatokhin@odin.com>