### PR TITLE
kpatch-build: cleanup on SIGHUP

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -278,7 +278,7 @@ mkdir -p "$TEMPDIR" || die "Couldn't create $TEMPDIR"
 rm -rf "$TEMPDIR"/*
 rm -f "$LOGFILE"
 
-trap cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM HUP
 
 KVER=${ARCHVERSION%%-*}
 if [[ $ARCHVERSION =~ - ]]; then


### PR DESCRIPTION
Fix an issue where kpatch-build fails to clean up after hitting CTRL-C
during a remote integration test (make remote).