### PR TITLE
kpatch-build: reduce dependency on bash version >4.0

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -506,7 +506,7 @@ cd "$TEMPDIR/patched"
 FILES="$(find * -type f)"
 cd "$TEMPDIR"
 mkdir output
-declare -A objnames
+declare -a objnames
 CHANGED=0
 ERROR=0
 for i in $FILES; do
@@ -537,11 +537,11 @@ for i in $FILES; do
 		if [[ $rc -eq 0 ]]; then
 			[[ -n $ERROR_IF_DIFF ]] && die $ERROR_IF_DIFF
 			CHANGED=1
-			objnames[$KOBJFILE]=1
+			objnames[${#objnames[@]}]=$KOBJFILE
 		fi
 	else
 		cp -f "patched/$i" "output/$i"
-		objnames[$KOBJFILE]=1
+		objnames[${#objnames[@]}]=$KOBJFILE
 	fi
 done
 
@@ -554,7 +554,10 @@ if [[ $CHANGED -eq 0 ]]; then
 fi
 
 echo -n "Patched objects:"
-for i in "${!objnames[@]}"; do echo -n " $(basename $i)"; done
+for i in $(echo "${objnames[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+do
+	echo -n " $(basename $i)"
+done
 echo
 
 export KCFLAGS="-I$DATADIR/patch"


### PR DESCRIPTION
Before this patch, kpatch_build dependends on bash version >4.0
that support declare -A. This patch remove this dependency by
replacing dict(declare -A) with array.

Signed-off-by: Li Bin <huawei.libin@huawei.com>