### PR TITLE
kpatch: deprecate the replace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,10 +535,10 @@ and restore the function to its original state.
 **Q. Can you apply multiple patches?**
 
 Yes, but to prevent any unexpected interactions between multiple patch modules,
-it's recommended that you only have a single patch loaded at any given time.
-This can be achieved by combining the new patch with the previous patch using
-`combinediff` before running `kpatch-build`.  You can then the `kpatch replace`
-command to atomically replace the old patch module with the new cumulative one.
+it's recommended that patch upgrades are cumulative, so that each patch is a
+superset of the previous patch.  This can be achieved by combining the new
+patch with the previous patch using `combinediff` before running
+`kpatch-build`.
 
 **Q. Why did kpatch-build detect a changed function that wasn't touched by the
 source patch?**

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -42,7 +42,6 @@ usage () {
 	echo >&2
 	usage_cmd "load --all" "load all installed patch modules into the running kernel"
 	usage_cmd "load <module>" "load patch module into the running kernel"
-	usage_cmd "replace <module>" "load patch module into the running kernel, replacing all other modules"
 	usage_cmd "unload --all" "unload all patch modules from the running kernel"
 	usage_cmd "unload <module>" "unload patch module from the running kernel"
 	echo >&2
@@ -183,14 +182,6 @@ unload_module () {
 	rmmod $PATCH 2> /dev/null || return 0
 }
 
-unload_disabled_modules() {
-	for module in /sys/kernel/kpatch/patches/*; do
-		if [[ $(cat $module/enabled) -eq 0 ]]; then
-			unload_module $(basename $module) || die "failed to unload $module"
-		fi
-	done
-}
-
 get_module_version() {
 	MODVER=$(modinfo -F vermagic "$1") || return 1
 	MODVER=${MODVER/ */}
@@ -214,14 +205,6 @@ case "$1" in
 		load_module "$MODULE" || die "failed to load module $PATCH"
 		;;
 	esac
-	;;
-
-"replace")
-	[[ "$#" -ne 2 ]] && usage
-	PATCH="$2"
-	find_module "$PATCH" || die "can't find $PATCH"
-	load_module "$MODULE" replace=1 || die "failed to load module $PATCH"
-	unload_disabled_modules || die "failed to unload old modules"
 	;;
 
 "unload")

--- a/man/kpatch.1
+++ b/man/kpatch.1
@@ -23,9 +23,6 @@ load --all
 load <module>
        load patch module into the running kernel
 
-replace <module>
-       load patch module into the running kernel, replacing all other modules
-
 unload --all
        unload all patch modules from the running kernel
 


### PR DESCRIPTION
"kpatch replace" is complex, buggy, and probably unnecessary.  And
upstream livepatch has nothing like it.

Remove it from the kpatch utility, but leave the infrastructure in place
in the patch module and the core module for now.

Fixes: #456