### PR TITLE
kpatch-build: fix gcc_version_check: both "GNU" and "GCC" are possible

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -119,8 +119,8 @@ find_dirs() {
 
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
-	local gccver=$(gcc --version |head -n1 |cut -d' ' -f2-)
-	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f5-)
+	local gccver=$(gcc --version | head -n1 | cut -d' ' -f2- | sed 's/GNU/GCC/g')
+	local kgccver=$(readelf -p .comment $VMLINUX | grep GCC: | tr -s ' ' | cut -d ' ' -f5- | sed 's/GNU/GCC/g')
 	if [[ "$gccver" != "$kgccver" ]]; then
 		warn "gcc/kernel version mismatch"
 		echo "gcc version:    $gccver"


### PR DESCRIPTION
This fix is an addition to 9fedd0d283 "kpatch-build: fix
gcc_version_check".

On some systems, the GCC version stored in vmlinux may have the
following format:
  (GNU) 4.8.3 20140911 (Red Hat 4.8.3-9)
while GCC returns
  (GCC) 4.8.3 20140911 (Red Hat 4.8.3-9)

As a result, binary patches cannot be built, although the compiler is
the same.

gcc_version_check() now takes this into account.

Signed-off-by: Evgenii Shatokhin <eshatokhin@odin.com>