### PR TITLE
revert gcc check changes

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -119,9 +119,9 @@ find_dirs() {
 
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
-	local gccver=$(gcc --version |head -n1 |cut -d' ' -f2-)
-	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f5-)
-	if [[ "$gccver" != "$kgccver" ]]; then
+	local gccver=$(gcc --version |head -n1 |cut -d' ' -f3-)
+	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f6-)
+	if [[ $gccver != $kgccver ]]; then
 		warn "gcc/kernel version mismatch"
 		echo "gcc version:    $gccver"
 		echo "kernel version: $kgccver"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -119,8 +119,8 @@ find_dirs() {
 
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
-	local gccver=$(gcc --version | head -n1 | cut -d' ' -f2- | sed 's/GNU/GCC/g')
-	local kgccver=$(readelf -p .comment $VMLINUX | grep GCC: | tr -s ' ' | cut -d ' ' -f5- | sed 's/GNU/GCC/g')
+	local gccver=$(gcc --version |head -n1 |cut -d' ' -f2-)
+	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f5-)
 	if [[ "$gccver" != "$kgccver" ]]; then
 		warn "gcc/kernel version mismatch"
 		echo "gcc version:    $gccver"


### PR DESCRIPTION
This reverts #561 and #548, as gcc version checking is still broken.

@libin2015 , can you come up with an approach that works on all supported distros (Fedora, RHEL/CentOS 7, Ubuntu, Debian)?

Fixes #562.