### PR TITLE
kpatch-build: fix gcc_version_check

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -119,9 +119,9 @@ find_dirs() {
 
 gcc_version_check() {
 	# ensure gcc version matches that used to build the kernel
-	local gccver=$(gcc --version |head -n1 |cut -d' ' -f3-)
-	local kgccver=$(readelf -p .comment $VMLINUX |grep GCC: | tr -s ' ' | cut -d ' ' -f6-)
-	if [[ $gccver != $kgccver ]]; then
+	local gccver=$(gcc --version | head -n1 | cut -d' ' -f2- | sed 's/GNU/GCC/g')
+	local kgccver=$(readelf -p .comment $VMLINUX | grep GCC: | tr -s ' ' | cut -d ' ' -f5- | sed 's/GNU/GCC/g')
+	if [[ "$gccver" != "$kgccver" ]]; then
 		warn "gcc/kernel version mismatch"
 		echo "gcc version:    $gccver"
 		echo "kernel version: $kgccver"
@@ -130,12 +130,15 @@ gcc_version_check() {
 		return 1
 	fi
 
-	# ensure gcc version is >= 4.8
-	gccver=$(echo $gccver |cut -d'.' -f1,2)
-	if [[ $gccver < 4.8 ]]; then
-		warn "gcc >= 4.8 required"
+	# ensure gcc support -mfentry
+	TMP=".$$$$.tmp"
+	gcc -c -pg -mfentry -x c /dev/null -o $TMP > /dev/null 2>&1
+	if [[ $? -ne 0 ]]; then
+		rm -f "$TMP"
+		warn "gcc doesn't support -mfentry"
 		return 1
 	fi
+	rm -f "$TMP"
 
 	return
 }


### PR DESCRIPTION
gcc version string format may be 'gcc (xxx xxx) x.x.x [xxx]'
fix gcc_version_check to adapt to it.

Signed-off-by: Li Bin huawei.libin@huawei.com
Signed-off-by: Evgenii Shatokhin eshatokhin@odin.com
