### PR TITLE
readme: add support for Fedora 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ Installation
 
 ###Prerequisites
 
+####Fedora 23
+
+*NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in
+`~/.kpatch` and for ccache.*
+
+Install the dependencies for compiling kpatch:
+
+```bash
+sudo dnf install gcc kernel-devel elfutils elfutils-devel
+```
+
+Install the dependencies for the "kpatch-build" command:
+
+```bash
+sudo dnf install rpmdevtools pesign yum-utils openssl wget numactl-devel
+sudo dnf builddep kernel
+sudo dnf debuginfo-install kernel
+
+# optional, but highly recommended
+sudo dnf install ccache
+ccache --max-size=5G
+```
+
 ####Fedora 21
 
 *NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in
@@ -265,7 +288,7 @@ Quick start
 
 > NOTE: While kpatch is designed to work with any recent Linux
 kernel on any distribution, the `kpatch-build` command has **ONLY** been tested
-and confirmed to work on Fedora 20, RHEL 7, Oracle Linux 7, CentOS 7 and Ubuntu 14.04.
+and confirmed to work on Fedora {20,21,23}, RHEL 7, Oracle Linux 7, CentOS 7 and Ubuntu 14.04.
 
 First, make a source code patch against the kernel tree using diff, git, or
 quilt.

--- a/README.md
+++ b/README.md
@@ -48,29 +48,6 @@ sudo dnf install ccache
 ccache --max-size=5G
 ```
 
-####Fedora 21
-
-*NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in
-`~/.kpatch` and for ccache.*
-
-Install the dependencies for compiling kpatch:
-
-```bash
-sudo yum install gcc kernel-devel elfutils elfutils-devel
-```
-
-Install the dependencies for the "kpatch-build" command:
-
-```bash
-sudo yum install rpmdevtools pesign yum-utils openssl wget numactl-devel
-sudo yum-builddep kernel
-sudo debuginfo-install kernel
-
-# optional, but highly recommended
-sudo yum install ccache
-ccache --max-size=5G
-```
-
 ####RHEL 7
 
 *NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Quick start
 
 > NOTE: While kpatch is designed to work with any recent Linux
 kernel on any distribution, the `kpatch-build` command has **ONLY** been tested
-and confirmed to work on Fedora {20,21,23}, RHEL 7, Oracle Linux 7, CentOS 7 and Ubuntu 14.04.
+and confirmed to work on Fedora 20 and later, RHEL 7, Oracle Linux 7, CentOS 7 and Ubuntu 14.04.
 
 First, make a source code patch against the kernel tree using diff, git, or
 quilt.


### PR DESCRIPTION
Add support for Fedora 23, `dnf` finally replaced `yum` as the default package manager.

Tested and confirmed to work on Fedora 23 x86_64 (Server Edition).

> BTW: should we remove Fedora 21 or leave it?