### PR TITLE
Use Module.symvers to get rid of "external" dynrelas

### DIFF
--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -37,7 +37,7 @@ struct kpatch_patch_dynrela {
 	unsigned long type;
 	char *name;
 	char *objname;
-	int external;
+	char *sym_objname;
 	int addend;
 };
 

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -254,7 +254,12 @@ static int __init patch_init(void)
 			lreloc->type = reloc->kdynrela->type;
 			lreloc->name = reloc->kdynrela->name;
 			lreloc->addend = reloc->kdynrela->addend;
-			lreloc->external = reloc->kdynrela->external;
+
+			/* For the klp_find_object_symbol() call to work */
+			if (!strcmp(reloc->kdynrela->sym_objname, "vmlinux"))
+				lreloc->sym_objname = NULL;
+			else
+				lreloc->sym_objname = reloc->kdynrela->sym_objname;
 			j++;
 		}
 

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -4,8 +4,8 @@ CFLAGS  += -I../kmod/patch -Iinsn -Wall -g -Werror
 LDFLAGS = -lelf
 
 TARGETS = create-diff-object
-OBJS = create-diff-object.o lookup.o insn/insn.o insn/inat.o
-SOURCES = create-diff-object.c lookup.c insn/insn.c insn/inat.c
+OBJS = create-diff-object.o parse-mod-symvers.o lookup.o insn/insn.o insn/inat.o
+SOURCES = create-diff-object.c parse-mod-symvers.c lookup.c insn/insn.c insn/inat.c
 
 all: $(TARGETS)
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -527,7 +527,10 @@ for i in $FILES; do
 	debugopt=
 	[[ $DEBUG -eq 1 ]] && debugopt=-d
 	if [[ -e "orig/$i" ]]; then
-		"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+		# create-diff-object orig.o patched.o kernel-object Module.symvers patch-mod-name
+		"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" \
+			"patched/$i" "$KOBJFILE" "output/$i" \
+			$OBJDIR/Module.symvers "kpatch_${PATCHNAME//-/_}" 1>&1 |tee -a "$LOGFILE"
 		rc="${PIPESTATUS[0]}"
 		if [[ $rc = 139 ]]; then
 			warn "create-diff-object SIGSEGV"

--- a/kpatch-build/parse-mod-symvers.c
+++ b/kpatch-build/parse-mod-symvers.c
@@ -1,0 +1,133 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+
+/*
+ * parse-mod-symvers.c
+ *
+ * These parsing and file-related functions were largely pilfered
+ * from scripts/mod/modpost.c, with a few modifications.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA,
+ * 02110-1301, USA.
+ */
+
+static void *grab_file(const char *filename, unsigned long *size) {
+	struct stat st;
+	void *map = MAP_FAILED;
+	int fd;
+
+	fd = open(filename, O_RDONLY);
+	if (fd < 0)
+		return NULL;
+	if (fstat(fd, &st))
+		goto failed;
+
+	*size = st.st_size;
+	map = mmap(NULL, *size, PROT_READ|PROT_WRITE, MAP_PRIVATE, fd, 0);
+
+failed:
+	close(fd);
+	if (map == MAP_FAILED)
+		return NULL;
+	return map;
+}
+
+/**
+  * Return a copy of the next line in a mmap'ed file.
+  * spaces in the beginning of the line is trimmed away.
+  * Return a pointer to a static buffer.
+  **/
+static char *get_next_line(unsigned long *pos, void *file, unsigned long size)
+{
+	static char line[4096];
+	int skip = 1;
+	size_t len = 0;
+	signed char *p = (signed char *)file + *pos;
+	char *s = line;
+
+	for (; *pos < size ; (*pos)++) {
+		if (skip && isspace(*p)) {
+			p++;
+			continue;
+		}
+		skip = 0;
+		if (*p != '\n' && (*pos < size)) {
+			len++;
+			*s++ = *p++;
+			if (len > 4095)
+				break; /* Too long, stop */
+		} else {
+			/* End of string */
+			*s = '\0';
+			return line;
+		}
+	}
+	/* End of buffer */
+	return NULL;
+}
+
+static void release_file(void *file, unsigned long size)
+{
+	munmap(file, size);
+}
+
+/*
+ * find_exported_symbol_objname - find the object/module an exported
+ * symbol belongs to.
+ *
+ * Module.symvers line format:
+ * 0x12345678<tab>symbol<tab>module[[<tab>export]<tab>something]
+ */
+char *find_exported_symbol_objname(const char *fname, char *symname)
+{
+	char *s, *m, *modname, *export, *end;
+	unsigned long size, pos = 0;
+	void *file = grab_file(fname, &size);
+	char *line;
+
+	if (!file)
+		goto fail;
+
+	while ((line = get_next_line(&pos, file, size))) {
+		if (!(s = strchr(line, '\t')))
+			goto fail;
+		*s++ = '\0';
+		if (!(m = strchr(s, '\t')))
+			goto fail;
+		*m++ = '\0';
+		if ((export = strchr(m, '\t')) != NULL)
+			*export++ = '\0';
+		if (export && ((end = strchr(export, '\t')) != NULL))
+			*end = '\0';
+		if (*s == '\0' || *m == '\0')
+			goto fail;
+		if (!strcmp(symname, s)) {
+			modname = strdup(m);
+			release_file(file, size);
+			return modname;
+		}
+	}
+fail:
+	release_file(file, size);
+	return NULL;
+}


### PR DESCRIPTION
Use Module.symvers to remove external dynrelas. Instead of using an external flag, the  `kpatch_patch_dynrela` struct has a new field `sym_objname` that will eventually be passed to `klp_find_object_symbol()` (in livepatch) to find the symbol. `sym_objname` is simply the object that the symbol (referenced by the dynrela) belongs to. For what used to be the "external" case, create-diff-object will now call `find_exported_symbol_objname()` which will parse Module.symvers and look for the module/object an exported symbol belongs to. If it is not there, then `sym_objname` will be set to the patch module's name. 

Still a WIP as I haven't checked to see what modifications are still required in the core kpatch module. It works with livepatch, but requires a new upstream patch to remove the external flag check and replace it with a single `klp_find_object_symbol` call (should be sent out soon). So far I've tested it with https://github.com/dynup/kpatch/blob/master/test/integration/f22/module-call-external.patch with the modified livepatch, along with the meminfo and a patch with multiple objs for good measure.

A couple of potential issues:
- create-diff-object now takes 6 arguments, which is a bit yucky. (the new ones being, the path to the Module.symvers file, and the second being the name of the to-be-built patch module)
- The Module.symvers parsing code is based off of `scripts/mod/modpost.c`, with only the parsing functions taken and a few modifications to make them fit create-diff-object's needs. Didn't want to rewrite code that was already there. But I'm not sure how licensing works in this case (i.e. should I retain the original copywrites from modpost.c and append a "Modified by .." statement?)
