### PR TITLE
livepatch-patch-hook: add support for livepatch sympos structures

### DIFF
--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -27,6 +27,7 @@ struct kpatch_patch_func {
 	unsigned long new_size;
 	unsigned long old_addr;
 	unsigned long old_size;
+	unsigned long sympos;
 	char *name;
 	char *objname;
 };
@@ -35,6 +36,7 @@ struct kpatch_patch_dynrela {
 	unsigned long dest;
 	unsigned long src;
 	unsigned long type;
+	unsigned long sympos;
 	char *name;
 	char *objname;
 	int external;

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -24,6 +24,7 @@
 #include <linux/module.h>
 #include <linux/list.h>
 #include <linux/slab.h>
+#include <linux/version.h>
 
 #include <linux/livepatch.h>
 
@@ -237,7 +238,11 @@ static int __init patch_init(void)
 			lfunc = &lfuncs[j];
 			lfunc->old_name = func->kfunc->name;
 			lfunc->new_func = (void *)func->kfunc->new_addr;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+			lfunc->old_sympos = func->kfunc->sympos;
+#else
 			lfunc->old_addr = func->kfunc->old_addr;
+#endif
 			j++;
 		}
 
@@ -250,7 +255,11 @@ static int __init patch_init(void)
 		list_for_each_entry(reloc, &object->relocs, list) {
 			lreloc = &lrelocs[j];
 			lreloc->loc = reloc->kdynrela->dest;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+			lreloc->sympos = reloc->kdynrela->sympos;
+#else
 			lreloc->val = reloc->kdynrela->src;
+#endif
 			lreloc->type = reloc->kdynrela->type;
 			lreloc->name = reloc->kdynrela->name;
 			lreloc->addend = reloc->kdynrela->addend;

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2539,6 +2539,7 @@ void kpatch_create_patches_sections(struct kpatch_elf *kelf,
 			funcs[index].old_addr = result.value;
 			funcs[index].old_size = result.size;
 			funcs[index].new_size = sym->sym.st_size;
+			funcs[index].sympos = result.pos;
 
 			/*
 			 * Add a relocation that will populate
@@ -2715,6 +2716,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 			dynrelas[index].addend = rela->addend;
 			dynrelas[index].type = rela->type;
 			dynrelas[index].external = external;
+			dynrelas[index].sympos = result.pos;
 
 			/* add rela to fill in dest field */
 			ALLOC_LINK(dynrela, &relasec->relas);

--- a/kpatch-build/lookup.h
+++ b/kpatch-build/lookup.h
@@ -6,6 +6,7 @@ struct lookup_table;
 struct lookup_result {
 	unsigned long value;
 	unsigned long size;
+	unsigned long pos;
 };
 
 struct lookup_table *lookup_open(char *path);


### PR DESCRIPTION
Support for patching objects that have duplicated function names will be
introduced upstream in v4.5. This structure change needs to be handled by
the livepatch patch hook.

In addition, we need to be able to look up the symbol position in order to
populate old_sympos and sympos fields in klp_object and klp_reloc
respectively.

Fixes: #493

Signed-off-by: Chris J Arges <chris.j.arges@canonical.com>