### PR TITLE
kpatch-build: process the patch name correctly

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -308,7 +308,7 @@ fi
 [[ -z $TARGETS ]] && TARGETS="vmlinux modules"
 
 PATCHNAME=$(basename "$PATCHFILE")
-if [[ "$PATCHNAME" =~ \.patch ]] || [[ "$PATCHNAME" =~ \.diff ]]; then
+if [[ "$PATCHNAME" =~ \.patch$ ]] || [[ "$PATCHNAME" =~ \.diff$ ]]; then
 	PATCHNAME="${PATCHNAME%.*}"
 fi
 


### PR DESCRIPTION
Process the patch name correctly that only concern the fuffix with
.patch or .diff. Otherwise if the patch name is not end with .patch
or .diff but has it as substring, the fuffix will be removed
unreasonably.

Signed-off-by: Li Bin <huawei.libin@huawei.com>