### PR TITLE
contrib/service: allow to turn the service off at boot time

### DIFF
--- a/contrib/kpatch.service
+++ b/contrib/kpatch.service
@@ -1,5 +1,6 @@
 [Unit]
 Description="Apply kpatch kernel patches"
+ConditionKernelCommandLine=!kpatch.enable=0
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
It may be convenient to be able to turn off the automatic loading of
the patches that kpatch.service does. This helps, for example, if a
buggy patch is installed and crashes the system at boot.

This commit allows to specify kpatch.enable=0 in the kernel command
line. In this case, the binary patches will not be loaded automatically,
and the users should be able to remove or replace the offending patches
after the system boots.

Signed-off-by: Evgenii Shatokhin <eshatokhin@virtuozzo.com>