### PR TITLE
kpatch-build: Add "CONFIG_DEBUG_KERNEL" kernel config checking

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -448,6 +448,8 @@ else
 	fi
 fi
 
+# kernel option checking: CONFIG_DEBUG_KERNEL and CONFIG_LIVEPATCH
+grep -q "CONFIG_DEBUG_KERNEL=y" "$OBJDIR/.config" || die "kernel doesn't have 'CONFIG_DEBUG_KERNEL' enabled"
 if grep "CONFIG_LIVEPATCH=y" "$OBJDIR/.config" > /dev/null; then
 	# The kernel supports livepatch.
 	KBUILD_EXTRA_SYMBOLS=""


### PR DESCRIPTION
While the officially supported distributions all have CONFIG_DEBUG_KERNEL enabled, this is not true for some other distributions.  This option is necessary when kpatch-build retrieves the SPECIAL_VARS using readelf command.

Signed-off-by: Quey-Liang Kao <s101062801@m101.nthu.edu.tw>