### PR TITLE
Only include .altinstr_replacement if .altinstructions is also included

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2218,6 +2218,7 @@ void kpatch_process_special_sections(struct kpatch_elf *kelf)
 	struct section *sec;
 	struct symbol *sym;
 	struct rela *rela;
+	int altinstr = 0;
 
 	for (special = special_sections; special->name; special++) {
 		sec = find_section_by_name(&kelf->sections, special->name);
@@ -2229,6 +2230,9 @@ void kpatch_process_special_sections(struct kpatch_elf *kelf)
 			continue;
 
 		kpatch_regenerate_special_section(kelf, special, sec);
+
+		if (!strcmp(special->name, ".altinstructions") && sec->base->include)
+			altinstr = 1;
 	}
 
 	/*
@@ -2238,6 +2242,12 @@ void kpatch_process_special_sections(struct kpatch_elf *kelf)
 	list_for_each_entry(sec, &kelf->sections, list) {
 		if (strcmp(sec->name, ".altinstr_replacement"))
 			continue;
+		/*
+		 * Only include .altinstr_replacement if .altinstructions
+		 * is also included.
+		 */
+		if (!altinstr)
+			break;
 
 		/* include base section */
 		sec->include = 1;


### PR DESCRIPTION
While looking into #580, I noticed that create-diff-object would automatically include `.altinstr_replacement` if it exists in the object it is handling, even if `.altinstructions` isn't included. It doesn't make sense to include `.altinstr_replacement` by itself, since this section only works in conjunction with `.altinstructions` and only serves to be a memory area for replacement instructions that will be copied when alternatives are applied. So, only include `.altinstr_replacement` if `.altinstructions` is included.

One very simple solution (solution 1) would be to just check if `.altinstructions` is included, and if so, simply include `.altinstr_replacement` in its entirety. One slight issue with this is that we might end up including a bunch of extraneous/unused instructions that the changed functions never needed in the first place. Plus, when a patch module loads, `.altinstr_replacement` is kept in memory and left executable, so it feels kind of iffy if we didn't regenerate that section and include only the instructions the changed functions need.

So solution 2 would be to regenerate `.altinstr_replacement`. Unfortunately the regeneration code is complicated, because each instruction is of variable length (there is no "group size"). Thus `kpatch_regenerate_altinstr_repl` reads each `struct alt_instr` in `.altinstructions` to find the length of the instruction we want to copy from `.altinstr_replacement`...which is really hacky and brittle IMO. It is still a WIP, but it currently works, and produces the right sections and regenerates the correct rela offsets and addends. I also disassembled the resulting regenerated `.altinstr_replacement` to make sure instructions were copied over correctly. Comments are very verbose and only there to aid review, I'll remove unnecessary comments if we decide to keep the code.

But before I continue to work on this code even more, I'd like to know if we just want to go with solution 1 instead, if the regeneration code is too ugly and cumbersome.