### PR TITLE
kpatch-build: do not assume that TEMPDIR is unexported on entry to script

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -495,12 +495,14 @@ done
 echo "Building original kernel"
 ./scripts/setlocalversion --save-scmversion || die
 make mrproper >> "$LOGFILE" 2>&1 || die
+unset KPATCH_GCC_TEMPDIR
 CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
 
 echo "Building patched kernel"
 patch -N -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die
 mkdir -p "$TEMPDIR/orig" "$TEMPDIR/patched"
-export TEMPDIR
+KPATCH_GCC_TEMPDIR=$TEMPDIR
+export KPATCH_GCC_TEMPDIR
 # TODO: remove custom LDFLAGS and ugly "undefined reference" grep when core
 # module gets moved to the kernel tree
 CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " \

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -5,7 +5,7 @@ set -x
 TOOLCHAINCMD="$1"
 shift
 
-if [[ -z "$TEMPDIR" ]]; then
+if [[ -z "$KPATCH_GCC_TEMPDIR" ]]; then
     exec "$TOOLCHAINCMD" "$@"
 fi
 
@@ -36,9 +36,9 @@ if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
 					break
 					;;
 				*.o)
-					mkdir -p "$TEMPDIR/orig/$(dirname $obj)"
-					[[ -e $obj ]] && cp -f "$obj" "$TEMPDIR/orig/$obj"
-					echo "$obj" >> "$TEMPDIR/changed_objs"
+					mkdir -p "$KPATCH_GCC_TEMPDIR/orig/$(dirname $obj)"
+					[[ -e $obj ]] && cp -f "$obj" "$KPATCH_GCC_TEMPDIR/orig/$obj"
+					echo "$obj" >> "$KPATCH_GCC_TEMPDIR/changed_objs"
 					break
 					;;
 				*)
@@ -54,8 +54,8 @@ elif [[ "$TOOLCHAINCMD" = "ld" ]] ; then
 			obj=$2
 			case "$obj" in
 				*.ko)
-					mkdir -p "$TEMPDIR/module/$(dirname $obj)"
-					cp -f "$obj" "$TEMPDIR/module/$obj"
+					mkdir -p "$KPATCH_GCC_TEMPDIR/module/$(dirname $obj)"
+					cp -f "$obj" "$KPATCH_GCC_TEMPDIR/module/$obj"
 					break
 					;;
 				*)


### PR DESCRIPTION
The user's environment might have TEMPDIR exported.  If so, then kpatch-build
dies with a bogus "invalid ancestor" error. If you turn those bogus errors into
warnings, then the script goes on to incorrectly put into the generated .ko file
every single function that was compiled in the *original* kernel build, thereby
producing an immense .ko file with more than 64k sections that the linux kernel
cannot load.  This fix makes sure that TEMPDIR is unexported on the build of the
original kernel.  Actually, this fix uses a separate KPATCH_GCC_TEMPDIR variable,
so that if the kernel build is interrupted, the cleanup function in the kpatch-kbuild
script will still have TEMPDIR set correctly.

Signed-off-by: Martin Carroll <martin.carroll@alcatel-lucent.com>