### PR TITLE
4.7 changes (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ Module.symvers
 kpatch-build/lookup
 kpatch-build/create-diff-object
 kpatch-build/create-klp-module
+kpatch-build/create-kpatch-module
 man/kpatch.1.gz
 man/kpatch-build.1.gz

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 Module.symvers
 kpatch-build/lookup
 kpatch-build/create-diff-object
+kpatch-build/create-klp-module
 man/kpatch.1.gz
 man/kpatch-build.1.gz

--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -1,6 +1,7 @@
 KPATCH_NAME ?= patch
 KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
 KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD)
+LDFLAGS += $(KPATCH_LDFLAGS)
 
 obj-m += kpatch-$(KPATCH_NAME).o
 

--- a/kmod/patch/kpatch.lds.S
+++ b/kmod/patch/kpatch.lds.S
@@ -1,8 +1,12 @@
 __kpatch_funcs = ADDR(.kpatch.funcs);
 __kpatch_funcs_end = ADDR(.kpatch.funcs) + SIZEOF(.kpatch.funcs);
+
+#ifdef __KPATCH_MODULE__
 __kpatch_dynrelas = ADDR(.kpatch.dynrelas);
 __kpatch_dynrelas_end = ADDR(.kpatch.dynrelas) + SIZEOF(.kpatch.dynrelas);
 __kpatch_checksum = ADDR(.kpatch.checksum);
+#endif
+
 SECTIONS
 {
   .kpatch.hooks.load : {

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -3,9 +3,10 @@ include ../Makefile.inc
 CFLAGS  += -I../kmod/patch -Iinsn -Wall -g -Werror
 LDFLAGS += -lelf
 
-TARGETS = create-diff-object create-klp-module
+TARGETS = create-diff-object create-klp-module create-kpatch-module
 SOURCES = create-diff-object.c kpatch-elf.c \
 		  create-klp-module.c \
+		  create-kpatch-module.c \
 		  lookup.c insn/insn.c insn/inat.c
 
 all: $(TARGETS)
@@ -18,6 +19,7 @@ all: $(TARGETS)
 create-diff-object: create-diff-object.o kpatch-elf.o \
 					lookup.o insn/insn.o insn/inat.o
 create-klp-module: create-klp-module.o kpatch-elf.o
+create-kpatch-module: create-kpatch-module.o kpatch-elf.o
 
 $(TARGETS):
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -3,10 +3,9 @@ include ../Makefile.inc
 CFLAGS  += -I../kmod/patch -Iinsn -Wall -g -Werror
 LDFLAGS += -lelf
 
-TARGETS = create-diff-object
-OBJS = create-diff-object.o kpatch-elf.o \
-	   lookup.o insn/insn.o insn/inat.o
+TARGETS = create-diff-object create-klp-module
 SOURCES = create-diff-object.c kpatch-elf.c \
+		  create-klp-module.c \
 		  lookup.c insn/insn.c insn/inat.c
 
 all: $(TARGETS)
@@ -16,7 +15,11 @@ all: $(TARGETS)
 %.o : %.c
 	$(CC) -MMD -MP $(CFLAGS) -c -o $@ $<
 
-create-diff-object: $(OBJS)
+create-diff-object: create-diff-object.o kpatch-elf.o \
+					lookup.o insn/insn.o insn/inat.o
+create-klp-module: create-klp-module.o kpatch-elf.o
+
+$(TARGETS):
 	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 install: all
@@ -30,4 +33,4 @@ uninstall:
 	$(RM) $(BINDIR)/kpatch-build
 
 clean:
-	$(RM) $(TARGETS) $(OBJS) *.d insn/*.d
+	$(RM) $(TARGETS) *.o *.d insn/*.d

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2246,11 +2246,11 @@ static void kpatch_build_strings_section_data(struct kpatch_elf *kelf)
 }
 
 struct arguments {
-	char *args[4];
+	char *args[5];
 	int debug;
 };
 
-static char args_doc[] = "original.o patched.o kernel-object output.o";
+static char args_doc[] = "original.o patched.o kernel-object output.o Module.symvers";
 
 static struct argp_option options[] = {
 	{"debug", 'd', NULL, 0, "Show debug output" },
@@ -2269,13 +2269,13 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 			arguments->debug = 1;
 			break;
 		case ARGP_KEY_ARG:
-			if (state->arg_num >= 4)
+			if (state->arg_num >= 5)
 				/* Too many arguments. */
 				argp_usage (state);
 			arguments->args[state->arg_num] = arg;
 			break;
 		case ARGP_KEY_END:
-			if (state->arg_num < 4)
+			if (state->arg_num < 5)
 				/* Not enough arguments. */
 				argp_usage (state);
 			break;
@@ -2296,6 +2296,7 @@ int main(int argc, char *argv[])
 	struct section *sec, *symtab;
 	struct symbol *sym;
 	char *hint = NULL, *objname, *pos;
+	char *mod_symvers_path;
 
 	arguments.debug = 0;
 	argp_parse (&argp, argc, argv, 0, NULL, &arguments);
@@ -2305,6 +2306,8 @@ int main(int argc, char *argv[])
 	elf_version(EV_CURRENT);
 
 	childobj = basename(arguments.args[0]);
+
+	mod_symvers_path = arguments.args[4];
 
 	kelf_base = kpatch_elf_open(arguments.args[0]);
 	kelf_patched = kpatch_elf_open(arguments.args[1]);
@@ -2378,7 +2381,7 @@ int main(int argc, char *argv[])
 		ERROR("FILE symbol not found in output. Stripped?\n");
 
 	/* create symbol lookup table */
-	lookup = lookup_open(arguments.args[2]);
+	lookup = lookup_open(arguments.args[2], mod_symvers_path);
 
 	/* extract module name (destructive to arguments.modulefile) */
 	objname = basename(arguments.args[2]);

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2295,7 +2295,7 @@ int main(int argc, char *argv[])
 	struct lookup_table *lookup;
 	struct section *sec, *symtab;
 	struct symbol *sym;
-	char *hint = NULL, *name, *pos;
+	char *hint = NULL, *objname, *pos;
 
 	arguments.debug = 0;
 	argp_parse (&argp, argc, argv, 0, NULL, &arguments);
@@ -2381,15 +2381,15 @@ int main(int argc, char *argv[])
 	lookup = lookup_open(arguments.args[2]);
 
 	/* extract module name (destructive to arguments.modulefile) */
-	name = basename(arguments.args[2]);
-	if (!strncmp(name, "vmlinux-", 8))
-		name = "vmlinux";
+	objname = basename(arguments.args[2]);
+	if (!strncmp(objname, "vmlinux-", 8))
+		objname = "vmlinux";
 	else {
-		pos = strchr(name,'.');
+		pos = strchr(objname,'.');
 		if (pos) {
 			/* kernel module */
 			*pos = '\0';
-			pos = name;
+			pos = objname;
 			while ((pos = strchr(pos, '-')))
 				*pos++ = '_';
 		}
@@ -2397,9 +2397,9 @@ int main(int argc, char *argv[])
 
 	/* create strings, patches, and dynrelas sections */
 	kpatch_create_strings_elements(kelf_out);
-	kpatch_create_patches_sections(kelf_out, lookup, hint, name);
-	kpatch_create_dynamic_rela_sections(kelf_out, lookup, hint, name);
-	kpatch_create_hooks_objname_rela(kelf_out, name);
+	kpatch_create_patches_sections(kelf_out, lookup, hint, objname);
+	kpatch_create_dynamic_rela_sections(kelf_out, lookup, hint, objname);
+	kpatch_create_hooks_objname_rela(kelf_out, objname);
 	kpatch_build_strings_section_data(kelf_out);
 
 	kpatch_create_mcount_sections(kelf_out);

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1311,26 +1311,6 @@ static void kpatch_reorder_symbols(struct kpatch_elf *kelf)
 	list_replace(&symbols, &kelf->symbols);
 }
 
-static void kpatch_reindex_elements(struct kpatch_elf *kelf)
-{
-	struct section *sec;
-	struct symbol *sym;
-	int index;
-
-	index = 1; /* elf write function handles NULL section 0 */
-	list_for_each_entry(sec, &kelf->sections, list)
-		sec->index = index++;
-
-	index = 0;
-	list_for_each_entry(sym, &kelf->symbols, list) {
-		sym->index = index++;
-		if (sym->sec)
-			sym->sym.st_shndx = sym->sec->index;
-		else if (sym->sym.st_shndx != SHN_ABS)
-			sym->sym.st_shndx = SHN_UNDEF;
-	}
-}
-
 static int bug_table_group_size(struct kpatch_elf *kelf, int offset)
 {
 	static int size = 0;
@@ -2263,38 +2243,6 @@ static void kpatch_build_strings_section_data(struct kpatch_elf *kelf)
 		strcpy(strtab, string->name);
 		strtab += strlen(string->name) + 1;
 	}
-}
-
-static void kpatch_rebuild_rela_section_data(struct section *sec)
-{
-	struct rela *rela;
-	int nr = 0, index = 0, size;
-	GElf_Rela *relas;
-
-	list_for_each_entry(rela, &sec->relas, list)
-		nr++;
-
-	size = nr * sizeof(*relas);
-	relas = malloc(size);
-	if (!relas)
-		ERROR("malloc");
-
-	sec->data->d_buf = relas;
-	sec->data->d_size = size;
-	/* d_type remains ELF_T_RELA */
-
-	sec->sh.sh_size = size;
-
-	list_for_each_entry(rela, &sec->relas, list) {
-		relas[index].r_offset = rela->offset;
-		relas[index].r_addend = rela->addend;
-		relas[index].r_info = GELF_R_INFO(rela->sym->index, rela->type);
-		index++;
-	}
-
-	/* sanity check, index should equal nr */
-	if (index != nr)
-		ERROR("size mismatch in rebuilt rela section");
 }
 
 struct arguments {

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -51,6 +51,7 @@
 #include "asm/insn.h"
 #include "kpatch-patch.h"
 #include "kpatch-elf.h"
+#include "kpatch-intermediate.h"
 
 #define DIFF_FATAL(format, ...) \
 ({ \
@@ -1887,17 +1888,20 @@ static int kpatch_is_core_module_symbol(char *name)
 		!strcmp(name, "kpatch_shadow_get"));
 }
 
-static void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
-						struct lookup_table *table, char *hint,
-						char *objname)
+static void kpatch_create_intermediate_sections(struct kpatch_elf *kelf,
+						struct lookup_table *table,
+						char *hint, char *objname,
+						char *pmod_name)
 {
-	int nr, index, objname_offset;
-	struct section *sec, *dynsec, *relasec;
-	struct rela *rela, *dynrela, *safe;
-	struct symbol *strsym;
+	int nr, index;
+	struct section *sec, *ksym_sec, *krela_sec;
+	struct rela *rela, *rela2, *safe;
+	struct symbol *strsym, *ksym_sec_sym;
+	struct kpatch_symbol *ksyms;
+	struct kpatch_relocation *krelas;
 	struct lookup_result result;
-	struct kpatch_patch_dynrela *dynrelas;
-	int vmlinux, external, ret;
+	char *sym_objname;
+	int ret, vmlinux, external;
 
 	vmlinux = !strcmp(objname, "vmlinux");
 
@@ -1909,21 +1913,29 @@ static void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 		if (!strcmp(sec->name, ".rela.kpatch.funcs"))
 			continue;
 		list_for_each_entry(rela, &sec->relas, list)
-			nr++; /* upper bound on number of dynrelas */
+			nr++; /* upper bound on number of kpatch relas and symbols */
 	}
 
-	/* create text/rela section pair */
-	dynsec = create_section_pair(kelf, ".kpatch.dynrelas", sizeof(*dynrelas), nr);
-	relasec = dynsec->rela;
-	dynrelas = dynsec->data->d_buf;
+	/* create .kpatch.relocations text/rela section pair */
+	krela_sec = create_section_pair(kelf, ".kpatch.relocations", sizeof(*krelas), nr);
+	krelas = krela_sec->data->d_buf;
+
+	/* create .kpatch.symbols text/rela section pair */
+	ksym_sec = create_section_pair(kelf, ".kpatch.symbols", sizeof(*ksyms), nr);
+	ksyms = ksym_sec->data->d_buf;
+
+	/* create .kpatch.symbols section symbol (to set rela->sym later) */
+	ALLOC_LINK(ksym_sec_sym, &kelf->symbols);
+	ksym_sec_sym->sec = ksym_sec;
+	ksym_sec_sym->sym.st_info = GELF_ST_INFO(STB_LOCAL, STT_SECTION);
+	ksym_sec_sym->type = STT_SECTION;
+	ksym_sec_sym->bind = STB_LOCAL;
+	ksym_sec_sym->name = ".kpatch.symbols";
 
 	/* lookup strings symbol */
 	strsym = find_symbol_by_name(&kelf->symbols, ".kpatch.strings");
 	if (!strsym)
 		ERROR("can't find .kpatch.strings symbol");
-
-	/* add objname to strings */
-	objname_offset = offset_of_string(&kelf->strings, objname);
 
 	/* populate sections */
 	index = 0;
@@ -1946,6 +1958,17 @@ static void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				continue;
 
 			external = 0;
+			/*
+			 * sym_objname is the name of the object to which
+			 * rela->sym belongs. We'll need this to build
+			 * ".klp.sym." symbol names later on.
+			 *
+			 * By default sym_objname is the name of the
+			 * component being patched (vmlinux or module).
+			 * If it's an external symbol, sym_objname
+			 * will get reassigned appropriately.
+			 */
+			sym_objname = objname;
 
 			if (rela->sym->bind == STB_LOCAL) {
 				/* An unchanged local symbol */
@@ -1997,56 +2020,89 @@ static void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 				 * patched.
 				 */
 				if (lookup_global_symbol(table, rela->sym->name,
-							 &result))
+							 &result)) {
 					/*
-					 * Not there, assume it's either an
-					 * exported symbol or provided by
-					 * another .o in the patch module.
+					 * Not there, see if the symbol is
+					 * exported, and set sym_objname to the
+					 * object the exported symbol belongs
+					 * to. If it's not exported, assume sym
+					 * is provided by another .o in the
+					 * patch module.
 					 */
+					sym_objname = lookup_exported_symbol_objname(table, rela->sym->name);
+
+					/* Not exported, must be in another .o in patch module */
+					if (!sym_objname)
+						sym_objname = pmod_name;
+
 					external = 1;
+				}
 			}
 			log_debug("lookup for %s @ 0x%016lx len %lu\n",
 			          rela->sym->name, result.value, result.size);
 
-			/* dest filed in by rela entry below */
+			/* Fill in ksyms[index] */
 			if (vmlinux)
-				dynrelas[index].src = result.value;
+				ksyms[index].src = result.value;
 			else
 				/* for modules, src is discovered at runtime */
-				dynrelas[index].src = 0;
-			dynrelas[index].addend = rela->addend;
-			dynrelas[index].type = rela->type;
-			dynrelas[index].external = external;
-			dynrelas[index].sympos = result.pos;
+				ksyms[index].src = 0;
+			ksyms[index].pos = result.pos;
+			ksyms[index].type = rela->sym->type;
+			ksyms[index].bind = rela->sym->bind;
 
-			/* add rela to fill in dest field */
-			ALLOC_LINK(dynrela, &relasec->relas);
+			/* add rela to fill in ksyms[index].name field */
+			ALLOC_LINK(rela2, &ksym_sec->rela->relas);
+			rela2->sym = strsym;
+			rela2->type = R_X86_64_64;
+			rela2->addend = offset_of_string(&kelf->strings, rela->sym->name);
+			rela2->offset = index * sizeof(*ksyms) + \
+					offsetof(struct kpatch_symbol, name);
+
+			/* add rela to fill in ksyms[index].objname field */
+			ALLOC_LINK(rela2, &ksym_sec->rela->relas);
+			rela2->sym = strsym;
+			rela2->type = R_X86_64_64;
+			rela2->addend = offset_of_string(&kelf->strings, sym_objname);
+			rela2->offset = index * sizeof(*ksyms) + \
+					offsetof(struct kpatch_symbol, objname);
+
+			/* Fill in krelas[index] */
+			krelas[index].addend = rela->addend;
+			krelas[index].type = rela->type;
+			krelas[index].external = external;
+			krelas[index].offset = rela->offset;
+
+			/* add rela to fill in krelas[index].dest field */
+			ALLOC_LINK(rela2, &krela_sec->rela->relas);
 			if (sec->base->sym)
-				dynrela->sym = sec->base->sym;
+				rela2->sym = sec->base->sym;
 			else if (sec->base->secsym)
-				dynrela->sym = sec->base->secsym;
+				rela2->sym = sec->base->secsym;
 			else
 				ERROR("can't create dynrela for section %s (symbol %s): no bundled section or section symbol",
 				      sec->name, rela->sym->name);
 
-			dynrela->type = R_X86_64_64;
-			dynrela->addend = rela->offset;
-			dynrela->offset = index * sizeof(*dynrelas);
+			rela2->type = R_X86_64_64;
+			rela2->addend = rela->offset;
+			rela2->offset = index * sizeof(*krelas) + \
+					offsetof(struct kpatch_relocation, dest);
 
-			/* add rela to fill in name field */
-			ALLOC_LINK(dynrela, &relasec->relas);
-			dynrela->sym = strsym;
-			dynrela->type = R_X86_64_64;
-			dynrela->addend = offset_of_string(&kelf->strings, rela->sym->name);
-			dynrela->offset = index * sizeof(*dynrelas) + offsetof(struct kpatch_patch_dynrela, name);
+			/* add rela to fill in krelas[index].objname field */
+			ALLOC_LINK(rela2, &krela_sec->rela->relas);
+			rela2->sym = strsym;
+			rela2->type = R_X86_64_64;
+			rela2->addend = offset_of_string(&kelf->strings, objname);
+			rela2->offset = index * sizeof(*krelas) + \
+				offsetof(struct kpatch_relocation, objname);
 
-			/* add rela to fill in objname field */
-			ALLOC_LINK(dynrela, &relasec->relas);
-			dynrela->sym = strsym;
-			dynrela->type = R_X86_64_64;
-			dynrela->addend = objname_offset;
-			dynrela->offset = index * sizeof(*dynrelas) +
-				offsetof(struct kpatch_patch_dynrela, objname);
+			/* add rela to fill in krelas[index].ksym field */
+			ALLOC_LINK(rela2, &krela_sec->rela->relas);
+			rela2->sym = ksym_sec_sym;
+			rela2->type = R_X86_64_64;
+			rela2->addend = index * sizeof(*ksyms);
+			rela2->offset = index * sizeof(*krelas) + \
+				offsetof(struct kpatch_relocation, ksym);
 
 			rela->sym->strip = 1;
 			list_del(&rela->list);
@@ -2056,9 +2112,12 @@ static void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 		}
 	}
 
-	/* set size to actual number of dynrelas */
-	dynsec->data->d_size = index * sizeof(struct kpatch_patch_dynrela);
-	dynsec->sh.sh_size = dynsec->data->d_size;
+	/* set size to actual number of ksyms/krelas */
+	ksym_sec->data->d_size = index * sizeof(struct kpatch_symbol);
+	ksym_sec->sh.sh_size = ksym_sec->data->d_size;
+
+	krela_sec->data->d_size = index * sizeof(struct kpatch_relocation);
+	krela_sec->sh.sh_size = krela_sec->data->d_size;
 }
 
 static void kpatch_create_hooks_objname_rela(struct kpatch_elf *kelf, char *objname)
@@ -2246,11 +2305,11 @@ static void kpatch_build_strings_section_data(struct kpatch_elf *kelf)
 }
 
 struct arguments {
-	char *args[5];
+	char *args[6];
 	int debug;
 };
 
-static char args_doc[] = "original.o patched.o kernel-object output.o Module.symvers";
+static char args_doc[] = "original.o patched.o kernel-object output.o Module.symvers patch-module-name";
 
 static struct argp_option options[] = {
 	{"debug", 'd', NULL, 0, "Show debug output" },
@@ -2269,13 +2328,13 @@ static error_t parse_opt (int key, char *arg, struct argp_state *state)
 			arguments->debug = 1;
 			break;
 		case ARGP_KEY_ARG:
-			if (state->arg_num >= 5)
+			if (state->arg_num >= 6)
 				/* Too many arguments. */
 				argp_usage (state);
 			arguments->args[state->arg_num] = arg;
 			break;
 		case ARGP_KEY_END:
-			if (state->arg_num < 5)
+			if (state->arg_num < 6)
 				/* Not enough arguments. */
 				argp_usage (state);
 			break;
@@ -2296,7 +2355,7 @@ int main(int argc, char *argv[])
 	struct section *sec, *symtab;
 	struct symbol *sym;
 	char *hint = NULL, *objname, *pos;
-	char *mod_symvers_path;
+	char *mod_symvers_path, *pmod_name;
 
 	arguments.debug = 0;
 	argp_parse (&argp, argc, argv, 0, NULL, &arguments);
@@ -2308,6 +2367,7 @@ int main(int argc, char *argv[])
 	childobj = basename(arguments.args[0]);
 
 	mod_symvers_path = arguments.args[4];
+	pmod_name = arguments.args[5];
 
 	kelf_base = kpatch_elf_open(arguments.args[0]);
 	kelf_patched = kpatch_elf_open(arguments.args[1]);
@@ -2401,7 +2461,7 @@ int main(int argc, char *argv[])
 	/* create strings, patches, and dynrelas sections */
 	kpatch_create_strings_elements(kelf_out);
 	kpatch_create_patches_sections(kelf_out, lookup, hint, objname);
-	kpatch_create_dynamic_rela_sections(kelf_out, lookup, hint, objname);
+	kpatch_create_intermediate_sections(kelf_out, lookup, hint, objname, pmod_name);
 	kpatch_create_hooks_objname_rela(kelf_out, objname);
 	kpatch_build_strings_section_data(kelf_out);
 

--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -1,0 +1,477 @@
+/*
+ * create-klp-module.c
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA,
+ * 02110-1301, USA.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <argp.h>
+
+#include "log.h"
+#include "kpatch-elf.h"
+#include "kpatch-intermediate.h"
+
+/* For log.h */
+char *childobj;
+enum loglevel loglevel = NORMAL;
+
+/*
+ * Add a symbol from .kpatch.symbols to the symbol table
+ *
+ * If a symbol matching the .kpatch.symbols entry already
+ * exists, return it.
+ */
+static struct symbol *find_or_add_ksym_to_symbols(struct kpatch_elf *kelf,
+						  struct section *ksymsec,
+						  char *strings, int offset)
+{
+	struct kpatch_symbol *ksyms, *ksym;
+	struct symbol *sym;
+	struct rela *rela;
+	char *objname, *name;
+	char pos[32], buf[256];
+	int index;
+
+	ksyms = ksymsec->data->d_buf;
+	index = offset / sizeof(*ksyms);
+	ksym = &ksyms[index];
+
+	/* Get name of ksym */
+	rela = find_rela_by_offset(ksymsec->rela,
+				   offset + offsetof(struct kpatch_symbol, name));
+	if (!rela)
+		ERROR("name of ksym not found?");
+
+	name = strdup(strings + rela->addend);
+	if (!name)
+		ERROR("strdup");
+
+	/* Get objname of ksym */
+	rela = find_rela_by_offset(ksymsec->rela,
+				   offset + offsetof(struct kpatch_symbol, objname));
+	if (!rela)
+		ERROR("objname of ksym not found?");
+
+	objname = strdup(strings + rela->addend);
+	if (!objname)
+		ERROR("strdup");
+
+	snprintf(pos, 32, "%lu", ksym->pos);
+	/* .klp.sym.objname.name,pos */
+	snprintf(buf, 256, KLP_SYM_PREFIX "%s.%s,%s", objname, name, pos);
+
+	/* Look for an already allocated symbol */
+	list_for_each_entry(sym, &kelf->symbols, list) {
+		if (!strcmp(buf, sym->name))
+			return sym;
+	}
+
+	ALLOC_LINK(sym, &kelf->symbols);
+	sym->name = strdup(buf);
+	if (!sym->name)
+		ERROR("strdup");
+	sym->type = ksym->type;
+	sym->bind = ksym->bind;
+	/*
+	 * Note that st_name will be set in kpatch_create_strtab(),
+	 * and sym->index is set in kpatch_reindex_elements()
+	 */
+	sym->sym.st_shndx = SHN_LIVEPATCH;
+	sym->sym.st_info = GELF_ST_INFO(sym->bind, sym->type);
+
+	return sym;
+}
+
+/*
+ * Create a klp rela section given the base section and objname
+ *
+ * If a klp rela section matching the base section and objname
+ * already exists, return it.
+ */
+static struct section *find_or_add_klp_relasec(struct kpatch_elf *kelf,
+					       struct section *base,
+					       char *objname)
+{
+	struct section  *sec;
+	char buf[256];
+
+	/* .klp.rela.objname.secname */
+	snprintf(buf, 256, KLP_RELASEC_PREFIX "%s.%s", objname, base->name);
+
+	list_for_each_entry(sec, &kelf->sections, list) {
+		if (!strcmp(sec->name, buf))
+			return sec;
+	}
+
+	ALLOC_LINK(sec, &kelf->sections);
+	sec->name = strdup(buf);
+	if (!sec->name)
+		ERROR("strdup");
+	sec->base = base;
+
+	INIT_LIST_HEAD(&sec->relas);
+
+	sec->data = malloc(sizeof(*sec->data));
+	if (!sec->data)
+		ERROR("malloc");
+	sec->data->d_type = ELF_T_RELA;
+
+	/* sh_info and sh_link are set when rebuilding rela sections */
+	sec->sh.sh_type = SHT_RELA;
+	sec->sh.sh_entsize = sizeof(GElf_Rela);
+	sec->sh.sh_addralign = 8;
+	sec->sh.sh_flags = SHF_RELA_LIVEPATCH | SHF_INFO_LINK | SHF_ALLOC;
+
+	return sec;
+}
+
+/*
+ * Create klp relocation sections and klp symbols from .kpatch.relocations
+ * and .kpatch.symbols sections
+ *
+ * For every entry in .kpatch.relocations:
+ *   1) Allocate a symbol for the corresponding .kpatch.symbols entry if
+ *      it doesn't already exist (find_or_add_ksym_to_symbols())
+ *      This is the symbol that the relocation points to (rela->sym)
+ *   2) Allocate a rela, and add it to the corresponding .klp.rela. section. If
+ *      the matching .klp.rela. section (given the base section and objname)
+ *      doesn't exist yet, create it (find_or_add_klp_relasec())
+ */
+static void create_klp_relasecs_and_syms(struct kpatch_elf *kelf, struct section *krelasec,
+					 struct section *ksymsec, char *strings)
+{
+	struct section *base, *klp_relasec;
+	struct kpatch_relocation *krelas;
+	struct symbol *sym;
+	struct rela *rela;
+	char *objname;
+	int nr, index, offset;
+
+	krelas = krelasec->data->d_buf;
+	nr = krelasec->data->d_size / sizeof(*krelas);
+
+	for (index = 0; index < nr; index++) {
+		offset = index * sizeof(*krelas);
+
+		/* Get the base section to which the rela applies */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, dest));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		base = rela->sym->sec;
+		if (!base)
+			ERROR("base sec of krela not found");
+
+		/* Get the name of the object the rela belongs to */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, objname));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		objname = strdup(strings + rela->addend);
+		if (!objname)
+			ERROR("strdup");
+
+		/* Get the corresponding .kpatch.symbol entry */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, ksym));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		/* Create (or find) a real symbol out of the .kpatch.symbol entry */
+		sym = find_or_add_ksym_to_symbols(kelf, ksymsec, strings, rela->addend);
+		if (!sym)
+			ERROR("error finding or adding ksym to symtab");
+
+		/* Create (or find) the .klp.rela. section for this base sec and object */
+		klp_relasec = find_or_add_klp_relasec(kelf, base, objname);
+		if (!klp_relasec)
+			ERROR("error finding or adding klp relasec");
+
+		/* Add the rela to the .klp.rela. section */
+		ALLOC_LINK(rela, &klp_relasec->relas);
+		rela->sym = sym;
+		rela->type = krelas[index].type;
+		rela->offset = krelas[index].offset;
+		rela->addend = krelas[index].addend;
+	}
+}
+
+/*
+ * Create .klp.arch. sections by iterating through the .kpatch.arch section
+ *
+ * A .kpatch.arch section is just an array of kpatch_arch structs:
+ *
+ * struct kpatch_arch {
+ *   unsigned long sec;
+ *   char *objname;
+ * };
+ *
+ * There are two relas associated with each kpatch arch entry, one that points
+ * to the section of interest (.parainstructions or .altinstructions), and one
+ * rela points to the name of the object the section belongs to in
+ * .kpatch.strings. This gives us the necessary information to create .klp.arch
+ * sections, which use the '.klp.arch.objname.secname' name format.
+ */
+static void create_klp_arch_sections(struct kpatch_elf *kelf, char *strings)
+{
+	struct section *karch, *sec, *base = NULL;
+	struct kpatch_arch *entries;
+	struct rela *rela, *rela2;
+	char *secname, *objname = NULL;
+	char buf[256];
+	int nr, index, offset, old_size, new_size;
+
+	karch = find_section_by_name(&kelf->sections, ".kpatch.arch");
+	if (!karch)
+		return;
+
+	entries = karch->data->d_buf;
+	nr = karch->data->d_size / sizeof(*entries);
+
+	for (index = 0; index < nr; index++) {
+		offset = index * sizeof(*entries);
+
+		/* Get the base section (.parainstructions or .altinstructions) */
+		rela = find_rela_by_offset(karch->rela,
+					   offset + offsetof(struct kpatch_arch, sec));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		base = rela->sym->sec;
+		if (!base)
+			ERROR("base sec of kpatch_arch entry not found");
+
+		/* Get the name of the object the base section belongs to */
+		rela = find_rela_by_offset(karch->rela,
+					   offset + offsetof(struct kpatch_arch, objname));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		objname = strdup(strings + rela->addend);
+		if (!objname)
+			ERROR("strdup");
+
+		/* Example: .klp.arch.vmlinux..parainstructions */
+		snprintf(buf, 256, "%s%s.%s", KLP_ARCH_PREFIX, objname, base->name);
+
+		/* Check if the .klp.arch. section already exists */
+		sec = find_section_by_name(&kelf->sections, buf);
+		if (!sec) {
+			secname = strdup(buf);
+			if (!secname)
+				ERROR("strdup");
+
+			/* Start with a new section with size 0 first */
+			sec = create_section_pair(kelf, secname, 1, 0);
+		}
+
+		/*
+		 * Merge .klp.arch. sections if necessary
+		 *
+		 * Example:
+		 * If there are multiple .parainstructions sections for vmlinux
+		 * (this can happen when, using the --unique option for ld,
+		 * we've linked together multiple .o's with .parainstructions
+		 * sections for the same object), they will be merged under a
+		 * single .klp.arch.vmlinux..parainstructions section
+		 */
+		old_size = sec->data->d_size;
+		new_size = old_size + base->data->d_size;
+		sec->data->d_buf = realloc(sec->data->d_buf, new_size);
+		sec->data->d_size = new_size;
+		sec->sh.sh_size = sec->data->d_size;
+		memcpy(sec->data->d_buf + old_size,
+		       base->data->d_buf, base->data->d_size);
+
+		list_for_each_entry(rela, &base->rela->relas, list) {
+			ALLOC_LINK(rela2, &sec->rela->relas);
+			rela2->sym = rela->sym;
+			rela2->type = rela->type;
+			rela2->addend = rela->addend;
+			rela2->offset = old_size + rela->offset;
+		}
+	}
+}
+
+/*
+ * We can't keep these sections since the module loader will apply them before
+ * the patch module gets a chance to load (that's why we copied these sections
+ * into .klp.arch. sections. Hence we remove them here.
+ */
+static void remove_arch_sections(struct kpatch_elf *kelf)
+{
+	int i;
+	char *arch_sections[] = {
+		".parainstructions",
+		".rela.parainstructions",
+		".altinstructions",
+		".rela.altinstructions"
+	};
+
+	for (i = 0; i < sizeof(arch_sections)/sizeof(arch_sections[0]); i++)
+		kpatch_remove_and_free_section(kelf, arch_sections[i]);
+
+}
+
+static void remove_intermediate_sections(struct kpatch_elf *kelf)
+{
+	int i;
+	char *intermediate_sections[] = {
+		".kpatch.symbols",
+		".rela.kpatch.symbols",
+		".kpatch.relocations",
+		".rela.kpatch.relocations",
+		".kpatch.arch",
+		".rela.kpatch.arch"
+	};
+
+	for (i = 0; i < sizeof(intermediate_sections)/sizeof(intermediate_sections[0]); i++)
+		kpatch_remove_and_free_section(kelf, intermediate_sections[i]);
+}
+
+struct arguments {
+	char *args[2];
+	int debug;
+	int no_klp_arch;
+};
+
+static char args_doc[] = "input.ko output.ko";
+
+static struct argp_option options[] = {
+	{"debug", 'd', 0, 0, "Show debug output" },
+	{"no-klp-arch-sections", 'n', 0, 0, "Do not output .klp.arch.* sections" },
+	{ 0 }
+};
+
+static error_t parse_opt (int key, char *arg, struct argp_state *state)
+{
+	/* Get the input argument from argp_parse, which we
+	   know is a pointer to our arguments structure. */
+	struct arguments *arguments = state->input;
+
+	switch (key)
+	{
+		case 'd':
+			arguments->debug = 1;
+			break;
+		case 'n':
+			arguments->no_klp_arch = 1;
+			break;
+		case ARGP_KEY_ARG:
+			if (state->arg_num >= 2)
+				/* Too many arguments. */
+				argp_usage (state);
+			arguments->args[state->arg_num] = arg;
+			break;
+		case ARGP_KEY_END:
+			if (state->arg_num < 2)
+				/* Not enough arguments. */
+				argp_usage (state);
+			break;
+		default:
+			return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static struct argp argp = { options, parse_opt, args_doc, 0 };
+
+int main(int argc, char *argv[])
+{
+	struct kpatch_elf *kelf;
+	struct section *symtab, *sec;
+	struct section *ksymsec, *krelasec, *strsec;
+	struct arguments arguments;
+	char *strings;
+	int ksyms_nr, krelas_nr;
+
+	arguments.debug = 0;
+	argp_parse (&argp, argc, argv, 0, 0, &arguments);
+	if (arguments.debug)
+		loglevel = DEBUG;
+
+	elf_version(EV_CURRENT);
+
+	childobj = basename(arguments.args[0]);
+
+	kelf = kpatch_elf_open(arguments.args[0]);
+
+	/*
+	 * Sanity checks:
+	 * - Make sure all the required sections exist
+	 * - Make sure that the number of entries in
+	 *   .kpatch.{symbols,relocations} match
+	 */
+	strsec = find_section_by_name(&kelf->sections, ".kpatch.strings");
+	if (!strsec)
+		ERROR("missing .kpatch.strings");
+	strings = strsec->data->d_buf;
+
+	ksymsec = find_section_by_name(&kelf->sections, ".kpatch.symbols");
+	if (!ksymsec)
+		ERROR("missing .kpatch.symbols section");
+	ksyms_nr = ksymsec->data->d_size / sizeof(struct kpatch_symbol);
+
+	krelasec = find_section_by_name(&kelf->sections, ".kpatch.relocations");
+	if (!krelasec)
+		ERROR("missing .kpatch.relocations section");
+	krelas_nr = krelasec->data->d_size / sizeof(struct kpatch_relocation);
+
+	if (krelas_nr != ksyms_nr)
+		ERROR("number of krelas and ksyms do not match");
+
+	/*
+	 * Create klp rela sections and klp symbols from
+	 * .kpatch.{relocations,symbols} sections
+	 */
+	create_klp_relasecs_and_syms(kelf, krelasec, ksymsec, strings);
+
+	/*
+	 * If --no-klp-arch-sections wasn't set, additionally
+	 * create .klp.arch. sections
+	 */
+	if (!arguments.no_klp_arch) {
+		create_klp_arch_sections(kelf, strings);
+		remove_arch_sections(kelf);
+	}
+
+	remove_intermediate_sections(kelf);
+	kpatch_reindex_elements(kelf);
+
+	/* Rebuild rela sections, new klp rela sections will be rebuilt too. */
+	symtab = find_section_by_name(&kelf->sections, ".symtab");
+	list_for_each_entry(sec, &kelf->sections, list) {
+		if (!is_rela_section(sec))
+			continue;
+		sec->sh.sh_link = symtab->index;
+		sec->sh.sh_info = sec->base->index;
+		kpatch_rebuild_rela_section_data(sec);
+	}
+
+	kpatch_create_shstrtab(kelf);
+	kpatch_create_strtab(kelf);
+	kpatch_create_symtab(kelf);
+
+	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1]);
+	kpatch_elf_teardown(kelf);
+	kpatch_elf_free(kelf);
+
+	return 0;
+}

--- a/kpatch-build/create-kpatch-module.c
+++ b/kpatch-build/create-kpatch-module.c
@@ -1,0 +1,253 @@
+/*
+ * create-kpatch-module.c
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA,
+ * 02110-1301, USA.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <libgen.h>
+#include <argp.h>
+
+#include "log.h"
+#include "kpatch-elf.h"
+#include "kpatch-intermediate.h"
+#include "kpatch-patch.h"
+
+/* For log.h */
+char *childobj;
+enum loglevel loglevel = NORMAL;
+
+/*
+ * Create .kpatch.dynrelas from .kpatch.relocations and .kpatch.symbols sections
+ *
+ * Iterate through .kpatch.relocations and fill in the corresponding dynrela
+ * entry using information from .kpatch.relocations and .kpatch.symbols
+ */
+static void create_dynamic_rela_sections(struct kpatch_elf *kelf, struct section *krelasec,
+					 struct section *ksymsec, struct section *strsec)
+{
+	struct kpatch_patch_dynrela *dynrelas;
+	struct kpatch_relocation *krelas;
+	struct kpatch_symbol *ksym, *ksyms;
+	struct section *base, *dynsec;
+	struct rela *rela;
+	int index, nr, offset, dest_offset, objname_offset, name_offset;
+
+	ksyms = ksymsec->data->d_buf;
+	krelas = krelasec->data->d_buf;
+	nr = krelasec->data->d_size / sizeof(*krelas);
+
+	dynsec = create_section_pair(kelf, ".kpatch.dynrelas", sizeof(*dynrelas), nr);
+	dynrelas = dynsec->data->d_buf;
+
+	for (index = 0; index < nr; index++) {
+		offset = index * sizeof(*krelas);
+
+		/*
+		 * To fill in each dynrela entry, find base section (dest),
+		 * objname offset, ksym, and symbol name offset
+		 */
+
+		/* Get base section */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, dest));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+
+		base = rela->sym->sec;
+		if (!base)
+			ERROR("base sec of krela not found");
+		dest_offset = rela->addend;
+
+		/* Get objname offset */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, objname));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+		objname_offset = rela->addend;
+
+		/* Get ksym (.kpatch.symbols entry) and symbol name offset */
+		rela = find_rela_by_offset(krelasec->rela,
+					   offset + offsetof(struct kpatch_relocation, ksym));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+		ksym = ksyms + (rela->addend / sizeof(*ksyms));
+
+		offset = index * sizeof(*ksyms);
+		rela = find_rela_by_offset(ksymsec->rela,
+					   offset + offsetof(struct kpatch_symbol, name));
+		if (!rela)
+			ERROR("find_rela_by_offset");
+		name_offset = rela->addend;
+
+		/* Fill in dynrela entry */
+		dynrelas[index].src = ksym->src;
+		dynrelas[index].addend = krelas[index].addend;
+		dynrelas[index].type = krelas[index].type;
+		dynrelas[index].external = krelas[index].external;
+		dynrelas[index].sympos = ksym->pos;
+
+		/* dest */
+		ALLOC_LINK(rela, &dynsec->rela->relas);
+		rela->sym = base->sym ? base->sym : base->secsym;
+		rela->type = R_X86_64_64;
+		rela->addend = dest_offset;
+		rela->offset = index * sizeof(*dynrelas);
+
+		/* name */
+		ALLOC_LINK(rela, &dynsec->rela->relas);
+		rela->sym = strsec->secsym;
+		rela->type = R_X86_64_64;
+		rela->addend = name_offset;
+		rela->offset = index * sizeof(*dynrelas) + \
+			       offsetof(struct kpatch_patch_dynrela, name);
+
+		/* objname */
+		ALLOC_LINK(rela, &dynsec->rela->relas);
+		rela->sym = strsec->secsym;
+		rela->type = R_X86_64_64;
+		rela->addend = objname_offset;
+		rela->offset = index * sizeof(*dynrelas) + \
+			       offsetof(struct kpatch_patch_dynrela, objname);
+	}
+}
+
+static void remove_intermediate_sections(struct kpatch_elf *kelf)
+{
+	int i;
+	char *intermediate_sections[] = {
+		".kpatch.symbols",
+		".rela.kpatch.symbols",
+		".kpatch.relocations",
+		".rela.kpatch.relocations",
+		".kpatch.arch",
+		".rela.kpatch.arch"
+	};
+
+	for (i = 0; i < sizeof(intermediate_sections)/sizeof(intermediate_sections[0]); i++)
+		kpatch_remove_and_free_section(kelf, intermediate_sections[i]);
+}
+
+struct arguments {
+	char *args[2];
+	int debug;
+};
+
+static char args_doc[] = "input.o output.o";
+
+static struct argp_option options[] = {
+	{"debug", 'd', 0, 0, "Show debug output" },
+	{ 0 }
+};
+
+static error_t parse_opt (int key, char *arg, struct argp_state *state)
+{
+	/* Get the input argument from argp_parse, which we
+	   know is a pointer to our arguments structure. */
+	struct arguments *arguments = state->input;
+
+	switch (key)
+	{
+		case 'd':
+			arguments->debug = 1;
+			break;
+		case ARGP_KEY_ARG:
+			if (state->arg_num >= 2)
+				/* Too many arguments. */
+				argp_usage (state);
+			arguments->args[state->arg_num] = arg;
+			break;
+		case ARGP_KEY_END:
+			if (state->arg_num < 2)
+				/* Not enough arguments. */
+				argp_usage (state);
+			break;
+		default:
+			return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static struct argp argp = { options, parse_opt, args_doc, 0 };
+
+int main(int argc, char *argv[])
+{
+	struct kpatch_elf *kelf;
+	struct section *symtab, *sec;
+	struct section *ksymsec, *krelasec, *strsec;
+	struct arguments arguments;
+	int ksyms_nr, krelas_nr;
+
+	arguments.debug = 0;
+	argp_parse (&argp, argc, argv, 0, 0, &arguments);
+	if (arguments.debug)
+		loglevel = DEBUG;
+
+	elf_version(EV_CURRENT);
+
+	childobj = basename(arguments.args[0]);
+
+	kelf = kpatch_elf_open(arguments.args[0]);
+
+	/*
+	 * Sanity checks:
+	 * - Make sure all the required sections exist
+	 * - Make sure that the number of entries in
+	 *   .kpatch.{symbols,relocations} match
+	 */
+	strsec = find_section_by_name(&kelf->sections, ".kpatch.strings");
+	if (!strsec)
+		ERROR("missing .kpatch.strings");
+
+	ksymsec = find_section_by_name(&kelf->sections, ".kpatch.symbols");
+	if (!ksymsec)
+		ERROR("missing .kpatch.symbols section");
+	ksyms_nr = ksymsec->data->d_size / sizeof(struct kpatch_symbol);
+
+	krelasec = find_section_by_name(&kelf->sections, ".kpatch.relocations");
+	if (!krelasec)
+		ERROR("missing .kpatch.relocations section");
+	krelas_nr = krelasec->data->d_size / sizeof(struct kpatch_relocation);
+
+	if (krelas_nr != ksyms_nr)
+		ERROR("number of krelas and ksyms do not match");
+
+	/* Create dynrelas from .kpatch.{relocations,symbols} sections */
+	create_dynamic_rela_sections(kelf, krelasec, ksymsec, strsec);
+	remove_intermediate_sections(kelf);
+
+	kpatch_reindex_elements(kelf);
+
+	symtab = find_section_by_name(&kelf->sections, ".symtab");
+	list_for_each_entry(sec, &kelf->sections, list) {
+		if (!is_rela_section(sec))
+			continue;
+		sec->sh.sh_link = symtab->index;
+		sec->sh.sh_info = sec->base->index;
+		kpatch_rebuild_rela_section_data(sec);
+	}
+
+	kpatch_create_shstrtab(kelf);
+	kpatch_create_strtab(kelf);
+	kpatch_create_symtab(kelf);
+
+	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1]);
+	kpatch_elf_teardown(kelf);
+	kpatch_elf_free(kelf);
+
+	return 0;
+}

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -557,7 +557,7 @@ for i in $FILES; do
 	fi
 	cd $TEMPDIR
 	if [[ -e "orig/$i" ]]; then
-		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" "$OBJDIR/Module.symvers" 2>&1 |tee -a "$LOGFILE"
 		rc="${PIPESTATUS[0]}"
 		if [[ $rc = 139 ]]; then
 			warn "create-diff-object SIGSEGV"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -665,8 +665,8 @@ if ! $KPATCH_MODULE; then
 	if [[ -z "$KPATCH_LDFLAGS" ]]; then
 		extra_flags="--no-klp-arch-sections"
 	fi
-	cp $TEMPDIR/patch/kpatch-$PATCHNAME.ko $TEMPDIR/patch/kpatch-tmp.ko || die
-	"$TOOLSDIR"/create-klp-module $extra_flags $TEMPDIR/patch/kpatch-tmp.ko $TEMPDIR/patch/kpatch-$PATCHNAME.ko 2>&1 |tee -a "$LOGFILE"
+	cp $TEMPDIR/patch/kpatch-$PATCHNAME.ko $TEMPDIR/patch/tmp.ko || die
+	"$TOOLSDIR"/create-klp-module $extra_flags $TEMPDIR/patch/tmp.ko $TEMPDIR/patch/kpatch-$PATCHNAME.ko 2>&1 |tee -a "$LOGFILE"
 	check_pipe_status create-klp-module
 fi
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -557,7 +557,9 @@ for i in $FILES; do
 	fi
 	cd $TEMPDIR
 	if [[ -e "orig/$i" ]]; then
-		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" "$OBJDIR/Module.symvers" 2>&1 |tee -a "$LOGFILE"
+		# create-diff-object orig.o patched.o kernel-object output.o Module.symvers patch-mod-name
+		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" \
+			"output/$i" "$OBJDIR/Module.symvers" "kpatch_${PATCHNAME//-/_}" 2>&1 |tee -a "$LOGFILE"
 		rc="${PIPESTATUS[0]}"
 		if [[ $rc = 139 ]]; then
 			warn "create-diff-object SIGSEGV"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -88,12 +88,33 @@ cleanup() {
 	[[ "$DEBUG" -eq 0 ]] && rm -rf "$TEMPDIR"
 	rm -rf "$RPMTOPDIR"
 	unset KCFLAGS
+	unset KCPPFLAGS
 }
 
 clean_cache() {
 	[[ -z $USERSRCDIR ]] && rm -rf "$SRCDIR"
 	rm -rf "$OBJDIR" "$VERSIONFILE"
 	mkdir -p "$OBJDIR"
+}
+
+check_pipe_status() {
+	rc="${PIPESTATUS[0]}"
+	if [[ $rc = 139 ]]; then
+		# There doesn't seem to be a consistent/portable way of
+		# accessing the last executed command in bash, so just
+		# pass in the script name for now..
+		warn "$1 SIGSEGV"
+		if ls core* &> /dev/null; then
+			cp core* /tmp
+			die "core file at /tmp/$(ls core*)"
+		fi
+		die "no core file found, run 'ulimit -c unlimited' and try to recreate"
+	fi
+}
+
+# $1 >= $2
+function version_gte {
+	[  "$1" = "`echo -e "$1\n$2" | sort -rV | head -n1`" ]
 }
 
 find_dirs() {
@@ -461,11 +482,23 @@ else
 	fi
 fi
 
+# Build variables - Set some defaults, then adjust features
+# according to .config and kernel version
+KBUILD_EXTRA_SYMBOLS=""
+KPATCH_LDFLAGS=""
+KPATCH_MODULE=true
+
 # kernel option checking: CONFIG_DEBUG_KERNEL and CONFIG_LIVEPATCH
 grep -q "CONFIG_DEBUG_KERNEL=y" "$OBJDIR/.config" || die "kernel doesn't have 'CONFIG_DEBUG_KERNEL' enabled"
 if grep "CONFIG_LIVEPATCH=y" "$OBJDIR/.config" > /dev/null; then
 	# The kernel supports livepatch.
-	KBUILD_EXTRA_SYMBOLS=""
+	if version_gte ${ARCHVERSION//-*/} 4.7.0; then
+		# Use new .klp.rela. sections
+		KPATCH_MODULE=false
+		if version_gte ${ARCHVERSION//-*/} 4.9.0; then
+			KPATCH_LDFLAGS="--unique=.parainstructions --unique=.altinstructions"
+		fi
+	fi
 else
 	# No support for livepatch in the kernel. Kpatch core module is needed.
 	find_core_symvers || die "unable to find Module.symvers for kpatch core module"
@@ -560,15 +593,7 @@ for i in $FILES; do
 		# create-diff-object orig.o patched.o kernel-object output.o Module.symvers patch-mod-name
 		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" \
 			"output/$i" "$OBJDIR/Module.symvers" "kpatch_${PATCHNAME//-/_}" 2>&1 |tee -a "$LOGFILE"
-		rc="${PIPESTATUS[0]}"
-		if [[ $rc = 139 ]]; then
-			warn "create-diff-object SIGSEGV"
-			if ls core* &> /dev/null; then
-				cp core* /tmp
-				die "core file at /tmp/$(ls core*)"
-			fi
-			die "no core file found, run 'ulimit -c unlimited' and try to recreate"
-		fi
+		check_pipe_status create-diff-object
 		# create-diff-object returns 3 if no functional change is found
 		[[ $rc -eq 0 ]] || [[ $rc -eq 3 ]] || ERROR=$(expr $ERROR "+" 1)
 		if [[ $rc -eq 0 ]]; then
@@ -598,6 +623,9 @@ done
 echo
 
 export KCFLAGS="-I$DATADIR/patch"
+if $KPATCH_MODULE; then
+	export KCPPFLAGS="-D__KPATCH_MODULE__"
+fi
 
 echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"
@@ -612,13 +640,35 @@ if [[ ! -z $UBUNTU_KERNEL ]]; then
 fi
 
 cd "$TEMPDIR/output"
-ld -r -o ../patch/output.o $(find . -name "*.o") >> "$LOGFILE" 2>&1 || die
-md5sum ../patch/output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die
-objcopy --add-section .kpatch.checksum=checksum.tmp --set-section-flags .kpatch.checksum=alloc,load,contents,readonly  ../patch/output.o || die
-rm -f checksum.tmp
+ld -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") >> "$LOGFILE" 2>&1 || die
+
+if $KPATCH_MODULE; then
+	# Add .kpatch.checksum for kpatch script
+	md5sum ../patch/tmp_output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die
+	objcopy --add-section .kpatch.checksum=checksum.tmp --set-section-flags .kpatch.checksum=alloc,load,contents,readonly  ../patch/tmp_output.o || die
+	rm -f checksum.tmp
+	"$TOOLSDIR"/create-kpatch-module $TEMPDIR/patch/tmp_output.o $TEMPDIR/patch/output.o 2>&1 |tee -a "$LOGFILE"
+	check_pipe_status create-kpatch-module
+else
+	cp $TEMPDIR/patch/tmp_output.o $TEMPDIR/patch/output.o || die
+
+ fi
+
 cd "$TEMPDIR/patch"
-KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$PATCHNAME" KBUILD_EXTRA_SYMBOLS="$KBUILD_EXTRA_SYMBOLS" \
+
+KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$PATCHNAME" \
+KBUILD_EXTRA_SYMBOLS="$KBUILD_EXTRA_SYMBOLS" \
+KPATCH_LDFLAGS="$KPATCH_LDFLAGS" \
 	make "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
+
+if ! $KPATCH_MODULE; then
+	if [[ -z "$KPATCH_LDFLAGS" ]]; then
+		extra_flags="--no-klp-arch-sections"
+	fi
+	cp $TEMPDIR/patch/kpatch-$PATCHNAME.ko $TEMPDIR/patch/kpatch-tmp.ko || die
+	"$TOOLSDIR"/create-klp-module $extra_flags $TEMPDIR/patch/kpatch-tmp.ko $TEMPDIR/patch/kpatch-$PATCHNAME.ko 2>&1 |tee -a "$LOGFILE"
+	check_pipe_status create-klp-module
+fi
 
 cp -f "$TEMPDIR/patch/kpatch-$PATCHNAME.ko" "$BASE" || die
 

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -144,7 +144,7 @@ void kpatch_create_rela_list(struct kpatch_elf *kelf, struct section *sec)
 	unsigned int symndx;
 
 	/* find matching base (text/data) section */
-	sec->base = find_section_by_name(&kelf->sections, sec->name + 5);
+	sec->base = find_section_by_index(&kelf->sections, sec->sh.sh_info);
 	if (!sec->base)
 		ERROR("can't find base section for rela section %s", sec->name);
 

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -341,7 +341,7 @@ static void kpatch_find_fentry_calls(struct kpatch_elf *kelf)
 	struct symbol *sym;
 	struct rela *rela;
 	list_for_each_entry(sym, &kelf->symbols, list) {
-		if (sym->type != STT_FUNC || !sym->sec->rela)
+		if (sym->type != STT_FUNC || !sym->sec || !sym->sec->rela)
 			continue;
 
 		rela = list_first_entry(&sym->sec->rela->relas, struct rela,

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -118,6 +118,18 @@ struct symbol *find_symbol_by_name(struct list_head *list, const char *name)
 	return NULL;
 }
 
+struct rela *find_rela_by_offset(struct section *relasec, unsigned int offset)
+{
+	struct rela *rela;
+
+	list_for_each_entry(rela, &relasec->relas, list) {
+		if (rela->offset == offset)
+			return rela;
+	}
+
+	return NULL;
+}
+
 /* returns the offset of the string in the string table */
 int offset_of_string(struct list_head *list, char *name)
 {

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -686,7 +686,8 @@ void kpatch_reindex_elements(struct kpatch_elf *kelf)
 		sym->index = index++;
 		if (sym->sec)
 			sym->sym.st_shndx = sym->sec->index;
-		else if (sym->sym.st_shndx != SHN_ABS)
+		else if (sym->sym.st_shndx != SHN_ABS &&
+			 sym->sym.st_shndx != SHN_LIVEPATCH)
 			sym->sym.st_shndx = SHN_UNDEF;
 	}
 }

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -150,6 +150,7 @@ void kpatch_create_strtab(struct kpatch_elf *kelf);
 void kpatch_create_symtab(struct kpatch_elf *kelf);
 struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
                                     int entsize, int nr);
+void kpatch_remove_and_free_section(struct kpatch_elf *kelf, char *secname);
 void kpatch_reindex_elements(struct kpatch_elf *kelf);
 void kpatch_rebuild_rela_section_data(struct section *sec);
 void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile);

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -117,6 +117,7 @@ struct section *find_section_by_index(struct list_head *list, unsigned int index
 struct section *find_section_by_name(struct list_head *list, const char *name);
 struct symbol *find_symbol_by_index(struct list_head *list, size_t index);
 struct symbol *find_symbol_by_name(struct list_head *list, const char *name);
+struct rela *find_rela_by_offset(struct section *relasec, unsigned int offset);
 
 #define ALLOC_LINK(_new, _list) \
 { \

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -24,6 +24,12 @@
 #include "list.h"
 #include "log.h"
 
+#define KLP_SYM_PREFIX		".klp.sym."
+#define KLP_RELASEC_PREFIX	".klp.rela."
+#define KLP_ARCH_PREFIX 	".klp.arch."
+#define SHF_RELA_LIVEPATCH	0x00100000
+#define SHN_LIVEPATCH		0xff20
+
 /*******************
  * Data structures
  * ****************/

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -150,6 +150,8 @@ void kpatch_create_strtab(struct kpatch_elf *kelf);
 void kpatch_create_symtab(struct kpatch_elf *kelf);
 struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
                                     int entsize, int nr);
+void kpatch_reindex_elements(struct kpatch_elf *kelf);
+void kpatch_rebuild_rela_section_data(struct section *sec);
 void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile);
 void kpatch_elf_teardown(struct kpatch_elf *kelf);
 void kpatch_elf_free(struct kpatch_elf *kelf);

--- a/kpatch-build/kpatch-intermediate.h
+++ b/kpatch-build/kpatch-intermediate.h
@@ -22,6 +22,8 @@
 #ifndef _KPATCH_INTERMEDIATE_H_
 #define _KPATCH_INTERMEDIATE_H_
 
+/* For .kpatch.{symbols,relocations,arch} sections */
+
 struct kpatch_symbol {
 	unsigned long src;
 	unsigned long pos;
@@ -30,7 +32,6 @@ struct kpatch_symbol {
 	char *objname; /* object to which this sym belongs */
 };
 
-/* For .kpatch.{symbols,relocations,arch} sections */
 struct kpatch_relocation {
 	unsigned long dest;
 	unsigned int type;
@@ -45,4 +46,4 @@ struct kpatch_arch {
         unsigned long sec;
         char *objname;
 };
-#endif /* _KPATCH_ELF_H_ */
+#endif /* _KPATCH_INTERMEDIATE_H_ */

--- a/kpatch-build/kpatch-intermediate.h
+++ b/kpatch-build/kpatch-intermediate.h
@@ -40,4 +40,9 @@ struct kpatch_relocation {
 	char *objname; /* object to which this rela applies to */
 	struct kpatch_symbol *ksym;
 };
+
+struct kpatch_arch {
+        unsigned long sec;
+        char *objname;
+};
 #endif /* _KPATCH_ELF_H_ */

--- a/kpatch-build/kpatch-intermediate.h
+++ b/kpatch-build/kpatch-intermediate.h
@@ -1,0 +1,43 @@
+/*
+ * kpatch-intermediate.h
+ *
+ * Structures for intermediate .kpatch.* sections
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA,
+ * 02110-1301, USA.
+ */
+
+#ifndef _KPATCH_INTERMEDIATE_H_
+#define _KPATCH_INTERMEDIATE_H_
+
+struct kpatch_symbol {
+	unsigned long src;
+	unsigned long pos;
+	unsigned char bind, type;
+	char *name;
+	char *objname; /* object to which this sym belongs */
+};
+
+/* For .kpatch.{symbols,relocations,arch} sections */
+struct kpatch_relocation {
+	unsigned long dest;
+	unsigned int type;
+	int addend;
+	int offset;
+	int external;
+	char *objname; /* object to which this rela applies to */
+	struct kpatch_symbol *ksym;
+};
+#endif /* _KPATCH_ELF_H_ */

--- a/kpatch-build/log.h
+++ b/kpatch-build/log.h
@@ -1,6 +1,8 @@
 #ifndef _LOG_H_
 #define _LOG_H_
 
+#include <error.h>
+
 /* Files that include log.h must define loglevel and childobj */
 extern enum loglevel loglevel;
 extern char *childobj;

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -5,6 +5,7 @@
  * the symbol table of an ELF object.
  *
  * Copyright (C) 2014 Seth Jennings <sjenning@redhat.com>
+ * Copyright (C) 2014 Josh Poimboeuf <jpoimboe@redhat.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,6 +25,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
+#include <ctype.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -31,29 +34,38 @@
 #include <error.h>
 #include <gelf.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include "lookup.h"
 
 #define ERROR(format, ...) \
 	error(1, 0, "%s: %d: " format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
-struct symbol {
+struct object_symbol {
 	unsigned long value;
 	unsigned long size;
 	char *name;
 	int type, bind, skip;
 };
 
-struct lookup_table {
-	int fd, nr;
-	Elf *elf;
-	struct symbol *syms;
+struct export_symbol {
+	char *name;
+	char *objname;
 };
 
-#define for_each_symbol(ndx, iter, table) \
-	for (ndx = 0, iter = table->syms; ndx < table->nr; ndx++, iter++)
+struct lookup_table {
+	int obj_nr, exp_nr;
+	struct object_symbol *obj_syms;
+	struct export_symbol *exp_syms;
+};
 
-struct lookup_table *lookup_open(char *path)
+#define for_each_obj_symbol(ndx, iter, table) \
+	for (ndx = 0, iter = table->obj_syms; ndx < table->obj_nr; ndx++, iter++)
+
+#define for_each_exp_symbol(ndx, iter, table) \
+	for (ndx = 0, iter = table->exp_syms; ndx < table->exp_nr; ndx++, iter++)
+
+static void obj_read(struct lookup_table *table, char *path)
 {
 	Elf *elf;
 	int fd, i, len;
@@ -62,8 +74,7 @@ struct lookup_table *lookup_open(char *path)
 	GElf_Sym sym;
 	Elf_Data *data;
 	char *name;
-	struct lookup_table *table;
-	struct symbol *mysym;
+	struct object_symbol *mysym;
 	size_t shstrndx;
 
 	if ((fd = open(path, O_RDONLY, 0)) < 0)
@@ -102,18 +113,13 @@ struct lookup_table *lookup_open(char *path)
 
 	len = sh.sh_size / sh.sh_entsize;
 
-	table = malloc(sizeof(*table));
-	if (!table)
-		ERROR("malloc table");
-	table->syms = malloc(len * sizeof(struct symbol));
-	if (!table->syms)
-		ERROR("malloc table.syms");
-	memset(table->syms, 0, len * sizeof(struct symbol));
-	table->nr = len;
-	table->fd = fd;
-	table->elf = elf;
+	table->obj_syms = malloc(len * sizeof(*table->obj_syms));
+	if (!table->obj_syms)
+		ERROR("malloc table.obj_syms");
+	memset(table->obj_syms, 0, len * sizeof(*table->obj_syms));
+	table->obj_nr = len;
 
-	for_each_symbol(i, mysym, table) {
+	for_each_obj_symbol(i, mysym, table) {
 		if (!gelf_getsym(data, i, &sym))
 			ERROR("gelf_getsym");
 
@@ -130,29 +136,107 @@ struct lookup_table *lookup_open(char *path)
 		mysym->size = sym.st_size;
 		mysym->type = GELF_ST_TYPE(sym.st_info);
 		mysym->bind = GELF_ST_BIND(sym.st_info);
-		mysym->name = name;
+		mysym->name = strdup(name);
+		if (!mysym->name)
+			ERROR("strdup");
 	}
+
+	close(fd);
+	elf_end(elf);
+}
+
+/* Strip the path and replace '-' with '_' */
+static char *make_modname(char *modname)
+{
+	char *cur;
+
+	if (!modname)
+		return NULL;
+
+	cur = modname;
+	while (*cur != '\0') {
+		if (*cur == '-')
+			*cur = '_';
+		cur++;
+	}
+
+	return basename(modname);
+}
+
+static void symvers_read(struct lookup_table *table, char *path)
+{
+	FILE *file;
+	unsigned int crc, i = 0;
+	char name[256], mod[256], export[256];
+	char *objname, *symname;
+
+	if ((file = fopen(path, "r")) < 0)
+		ERROR("fopen");
+
+	while (fscanf(file, "%x %s %s %s\n",
+		      &crc, name, mod, export) != EOF)
+		table->exp_nr++;
+
+	table->exp_syms = malloc(table->exp_nr * sizeof(*table->exp_syms));
+	if (!table->exp_syms)
+		ERROR("malloc table.exp_syms");
+	memset(table->exp_syms, 0,
+	       table->exp_nr * sizeof(*table->exp_syms));
+
+	rewind(file);
+
+	while (fscanf(file, "%x %s %s %s\n",
+		      &crc, name, mod, export) != EOF) {
+		symname = strdup(name);
+		if (!symname)
+			perror("strdup");
+
+		objname = strdup(mod);
+		if (!objname)
+			perror("strdup");
+		/* Modifies objname in-place */
+		objname = make_modname(objname);
+
+		table->exp_syms[i].name = symname;
+		table->exp_syms[i].objname = objname;
+		i++;
+	}
+
+	fclose(file);
+}
+
+struct lookup_table *lookup_open(char *obj_path, char *symvers_path)
+{
+	struct lookup_table *table;
+
+	table = malloc(sizeof(*table));
+	if (!table)
+		ERROR("malloc table");
+	memset(table, 0, sizeof(*table));
+
+	obj_read(table, obj_path);
+	symvers_read(table, symvers_path);
 
 	return table;
 }
 
 void lookup_close(struct lookup_table *table)
 {
-	elf_end(table->elf);
-	close(table->fd);
+	free(table->obj_syms);
+	free(table->exp_syms);
 	free(table);
 }
 
 int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
                         struct lookup_result *result)
 {
-	struct symbol *sym, *match = NULL;
+	struct object_symbol *sym, *match = NULL;
 	int i;
 	unsigned long pos = 0;
 	char *curfile = NULL;
 
 	memset(result, 0, sizeof(*result));
-	for_each_symbol(i, sym, table) {
+	for_each_obj_symbol(i, sym, table) {
 		if (sym->type == STT_FILE) {
 			if (!strcmp(sym->name, hint)) {
 				curfile = sym->name;
@@ -192,11 +276,11 @@ int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
 int lookup_global_symbol(struct lookup_table *table, char *name,
                          struct lookup_result *result)
 {
-	struct symbol *sym;
+	struct object_symbol *sym;
 	int i;
 
 	memset(result, 0, sizeof(*result));
-	for_each_symbol(i, sym, table)
+	for_each_obj_symbol(i, sym, table) {
 		if (!sym->skip && (sym->bind == STB_GLOBAL || sym->bind == STB_WEAK) &&
 		    !strcmp(sym->name, name)) {
 			result->value = sym->value;
@@ -204,24 +288,49 @@ int lookup_global_symbol(struct lookup_table *table, char *name,
 			result->pos = 0; /* always 0 for global symbols */
 			return 0;
 		}
+	}
 
 	return 1;
 }
 
 int lookup_is_exported_symbol(struct lookup_table *table, char *name)
 {
-	struct symbol *sym;
+	struct export_symbol *sym, *match = NULL;
 	int i;
-	char export[255] = "__ksymtab_";
 
-	strncat(export, name, 254);
+	for_each_exp_symbol(i, sym, table) {
+		if (!strcmp(sym->name, name)) {
+			if (match)
+				ERROR("duplicate exported symbol found for %s", name);
+			match = sym;
+		}
+	}
 
-	for_each_symbol(i, sym, table)
-		if (!sym->skip && !strcmp(sym->name, export))
-			return 1;
-
-	return 0;
+	return !!match;
 }
+
+/*
+ * lookup_exported_symbol_objname - find the object/module an exported
+ * symbol belongs to.
+ */
+char *lookup_exported_symbol_objname(struct lookup_table *table, char *name)
+{
+	struct export_symbol *sym, *match = NULL;
+	int i;
+
+	for_each_exp_symbol(i, sym, table) {
+		if (!strcmp(sym->name, name)) {
+			if (match)
+				ERROR("duplicate exported symbol found for %s", name);
+			match = sym;
+		}
+	}
+
+	if (match)
+		return match->objname;
+
+	return NULL;
+ }
 
 #if 0 /* for local testing */
 static void find_this(struct lookup_table *table, char *sym, char *hint)

--- a/kpatch-build/lookup.h
+++ b/kpatch-build/lookup.h
@@ -9,12 +9,13 @@ struct lookup_result {
 	unsigned long pos;
 };
 
-struct lookup_table *lookup_open(char *path);
+struct lookup_table *lookup_open(char *obj_path, char *symvers_path);
 void lookup_close(struct lookup_table *table);
 int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
                         struct lookup_result *result);
 int lookup_global_symbol(struct lookup_table *table, char *name,
                          struct lookup_result *result);
 int lookup_is_exported_symbol(struct lookup_table *table, char *name);
+char *lookup_exported_symbol_objname(struct lookup_table *table, char *name);
 
 #endif /* _LOOKUP_H_ */


### PR DESCRIPTION
This pull request attempts to bridge the two ways we have of building "dynamic relocations" i.e. dynrelas and klp relas.

I had to scrap the first implementation I had which tried to have create-diff-object create intermediary, implementation-neutral `.kpatch.symbols` and `.kpatch.relocations` sections, which we agreed seemed like the most "correct" way to go about it. But unfortunately I later bumped into a unresolvable limitation: After the final object.o is linked, there was no deterministic way to figure out which entry belonged to which target section just from looking at each entry in `.kpatch.relocations`. The target section is needed to fill in the sh_info field for klp rela sections. Storing the section name in `.kpatch.relocations` wouldn't work since names aren't required to be unique, and section indices are jumbled in linking the final object, so we can't use that either.

So a new approach was needed, and I'll try to describe it as succinctly as possible...

Currently, create-diff-object strips relas and symbols that are replaced by dynrelas. Instead, we're going to have create-diff-object not only create `.kpatch.dynrela` sections but also keep these relas and symbols, and additionally rename these symbols with the ".klp.sym." prefix so after the objects are linked they remain identifiable. The relas that refer to these symbols are also identifiable in this way (just check if they refer to a .klp.sym symbol). In addition, create-diff-object must tack on the objname to the name of each section (in the form of ".klp.objname.secname") that refers to klp relas because we will need to know the objname when building .klp.rela sections. These modified section names are only temporary and their original section names are restored in "phase 2".

Thus that concludes "phase 1", the intermediary objects produced by create-diff-object will contain `.kpatch.dynrelas` sections and retain the formerly stripped symbols and relas.

After the intermediary objects are linked, we have then move to phase 2 and we have two options depending on the kernel version we are dealing with. We either (1) strip all klp elements or (2) further refine the klp symbols and relas (actually create the klp rela sections) and strip the dynrela sections. We do option (1) if kernel version < 4.7.0 and option (2) otherwise.

Option (1) - strip all klp elements is pretty straightforward; free all the relas that refer to symbols prefixed with .klp.sym. and free the corresponding symbols. Restore any sections with the intermediary .klp.objname prefix back to their original section name.

Option (2) - further build upon the klp symbols and relas. This involves iterating through each rela section, sorting out the ones that refer to .klp.sym. symbols, and moving those relas to new .klp.rela sections (these are the ones marked `SHF_RELA_LIVEPATCH` and `SHT_RELA`). We also mark those .klp.syms. with `SHN_LIVEPATCH`. We have to wait until _after_ the patch module is linked to apply any special livepatch-specific elf flags because the linker tends to throw these values away. The `.kpatch.dynrelas` section is discarded via kpatch.lds.

Other notable changes, and things worth noting:
- kpatch.lds -> kpatch.lds.S: The kbuild system lets us run .lds.S linker scripts under the preprocessor before generating the corresponding .lds script. This is handy since we can use one linker script to include or discard certain sections (i.e. .kpatch.dynrelas) based on a variable we set in kpatch-build (`KCPPFLAGS="-D__KPATCH_DYNRELAS__"`)
- I only discard `.kpatch.dynrelas` but I think we can also extend that to discarding `.kpatch.hooks.*` and `.kpatch.force` sections for livepatch modules, since these sections aren't used in livepatch.

UPDATE 8/29/16:
Commits are still in a rough state in that they need to be better split up and reorganized; nonetheless the groundwork implementation is there and general comments on this approach are welcome.
