### PR TITLE
kpatch-build: remove ~/.kpatch/src/.git dir on Fedora

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -394,6 +394,7 @@ else
 
 		mv "$RPMTOPDIR"/BUILD/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" >> "$LOGFILE" 2>&1 || die
 		rm -rf "$RPMTOPDIR"
+		rm -rf "$SRCDIR/.git"
 
 		cp "$SRCDIR/.config" "$OBJDIR" || die
 		if [[ "$ARCHVERSION" == *-* ]]; then


### PR DESCRIPTION
Source RPMs for recent Fedora kernels have a '.git' subdirectory, which
causes '+' to be appended to the module version magic, causing the
module to fail to load:

  kpatch_readdir: version magic '4.8.6-201.fc24.x86_64+ SMP mod_unload ' should be '4.8.6-201.fc24.x86_64 SMP mod_unload '