### PR TITLE
Add CONFIG_RANDOMIZE_BASE KASLR support

### DIFF
--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -38,6 +38,7 @@ struct kpatch_func {
 	unsigned long new_size;
 	unsigned long old_addr;
 	unsigned long old_size;
+	unsigned long sympos;
 	const char *name;
 	struct list_head list;
 	int force;
@@ -51,6 +52,7 @@ struct kpatch_dynrela {
 	unsigned long dest;
 	unsigned long src;
 	unsigned long type;
+	unsigned long sympos;
 	const char *name;
 	int addend;
 	int external;

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -271,13 +271,8 @@ static int patch_make_funcs_list(struct list_head *objects)
 
 		func->new_addr = p_func->new_addr;
 		func->new_size = p_func->new_size;
-
-		if (!strcmp("vmlinux", object->name))
-			func->old_addr = p_func->old_addr;
-		else
-			func->old_addr = 0x0;
-
 		func->old_size = p_func->old_size;
+		func->sympos = p_func->sympos;
 		func->name = p_func->name;
 		func->force = patch_is_func_forced(func->new_addr);
 		list_add_tail(&func->list, &object->funcs);
@@ -315,8 +310,8 @@ static int patch_make_dynrelas_list(struct list_head *objects)
 			return -ENOMEM;
 
 		dynrela->dest = p_dynrela->dest;
-		dynrela->src = p_dynrela->src;
 		dynrela->type = p_dynrela->type;
+		dynrela->sympos = p_dynrela->sympos;
 		dynrela->name = p_dynrela->name;
 		dynrela->external = p_dynrela->external;
 		dynrela->addend = p_dynrela->addend;


### PR DESCRIPTION
Backport the symbol lookup and checking code from upstream livepatch
code that relies on a symbol position enumeration rather than a fixed
memory address.  Kpatch only verifies symbol matches for symbols found
in vmlinux, so drop the parts that deal with module symbols.

Fixes #617.