### PR TITLE
kpatch-build: refresh git index during cleanup if $SRCDIR was a git repository

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -75,6 +75,9 @@ cleanup() {
 	if [[ -e "$SRCDIR/$APPLIEDPATCHFILE" ]]; then
 		patch -p1 -R -d "$SRCDIR" < "$SRCDIR/$APPLIEDPATCHFILE" &> /dev/null
 		rm -f "$SRCDIR/$APPLIEDPATCHFILE"
+		# If $SRCDIR was a git repo, make sure git actually sees that
+		# we've reverted our patch above.
+		[[ -d $SRCDIR/.git ]] && (cd $SRCDIR && git update-index -q --refresh)
 	fi
 	if [[ -n $USERSRCDIR ]]; then
 		# restore original .config and vmlinux since they were removed


### PR DESCRIPTION
I've been noticing that if I reuse the same $SRCDIR for consecutive kpatch-builds, I end up getting '+' appended to the version string, even if kpatch-build leaves $SRCDIR in an ostensibly clean state. It turns out if $SRCDIR is a git repository, `cleanup()` doesn't necessarily leave $SRCDIR in a completely clean state. `scripts/setlocalversion` sees the dirty index (it uses `git diff-index`) and appends the '+' and thus subsequent kpatch-builds end up with the dirty version string. 

This issue can be seen by running the following commands:
```
# starting with a clean repository
~/linux $ patch -p < kpatch.patch
~/linux $ git status --short
M       include/linux/module.h
~/linux $ patch -p -R < kpatch.patch
~/linux $ git diff-index --name-status HEAD
M       include/linux/module.h  # hmm...index *still* shows module.h is modified
~/linux $ git status # index doesn't update until I run git status or git diff...
~/linux $
```

Note: The behavior of `git diff-index` is explained in the man page: https://git-scm.com/docs/git-diff-index
>As with other commands of this type, git diff-index does not actually look at the contents of the file at all. So maybe kernel/sched.c hasn’t actually changed, and it’s just that you touched it. In either case, it’s a note that you need to git update-index it to make the index be in sync. 