### PR TITLE
kpatch-build: fix 'undefined reference to kpatch_shadow_*' errors

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -513,10 +513,7 @@ patch -N -p1 < "$APPLIEDPATCHFILE" >> "$LOGFILE" 2>&1 || die
 mkdir -p "$TEMPDIR/orig" "$TEMPDIR/patched"
 KPATCH_GCC_TEMPDIR=$TEMPDIR
 export KPATCH_GCC_TEMPDIR
-# TODO: remove custom LDFLAGS and ugly "undefined reference" grep when core
-# module gets moved to the kernel tree
 CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " \
-	LDFLAGS_vmlinux="--warn-unresolved-symbols" \
 	KBUILD_MODPOST_WARN=1 \
 	make "-j$CPUS" $TARGETS "O=$OBJDIR"  >> "$LOGFILE" 2>&1 || die
 [[ "${PIPESTATUS[0]}" -eq 0 ]] || die

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -58,6 +58,10 @@ elif [[ "$TOOLCHAINCMD" = "ld" ]] ; then
 					cp -f "$obj" "$KPATCH_GCC_TEMPDIR/module/$obj"
 					break
 					;;
+				.tmp_vmlinux*|vmlinux)
+					args+=(--warn-unresolved-symbols)
+					break
+					;;
 				*)
 					break
 					;;


### PR DESCRIPTION
When building the patched version of the kernel, vmlinux has to be
linked with the '--warn-unresolved-symbols' linker flag.  Otherwise the
link will fail if the patch uses kpatch-specific symbols like
kpatch_shadow_alloc() and friends.

As of upstream Linux commit b36fad65d61f ("kbuild: Initialize exported
variables"), LDFLAGS_vmlinux= no longer works from the command line,
resulting in '--warn-unresolved-symbols' no longer getting set.

Instead we can use kpatch-gcc to pass the flag to the linker.

Fixes #627.