### PR TITLE
kpatch-build: fix tree-wide rebuild

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -199,6 +199,8 @@ find_kobj() {
 				*/built-in.o|\
 				arch/x86/lib/lib.a|\
 				arch/x86/kernel/head*.o|\
+				arch/x86/kernel/ebda.o|\
+				arch/x86/kernel/platform-quirks.o|\
 				lib/lib.a)
 					KOBJFILE=vmlinux
 					return


### PR DESCRIPTION
For newer kernels, some new objects have been added to the 'head-y'
build target.  These objects aren't directly traceable to vmlinux so
they have to be added manually.

Fixes #626.