### PR TITLE
kpatch-build: fix tree-wide rebuild on RHEL 7

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -541,6 +541,12 @@ declare -a objnames
 CHANGED=0
 ERROR=0
 for i in $FILES; do
+	# In RHEL 7 based kernels, copy_user_64.o misuses the .fixup section,
+	# which confuses create-diff-object.  It's fine to skip it, it's an
+	# assembly file anyway.
+	[[ $DISTRO = rhel ]] || [[ $DISTRO = centos ]] || [[ $DISTRO = ol ]] && \
+		[[ $i = arch/x86/lib/copy_user_64.o ]] && continue
+
 	mkdir -p "output/$(dirname $i)"
 	cd "$OBJDIR"
 	find_kobj $i


### PR DESCRIPTION
On RHEL 7 based kernels, copy_user_64.o misuses the .fixup section by
placing a normal function in it.  That confuses create-diff-object.

Work around it by just skipping the file altogether, which is fine to do
because it's an assembly file which should never change anyway.

Fixes #625.