### PR TITLE
kpatch and patch module builds fail on Ubuntu 16.04 #636

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -46,7 +46,12 @@
 #include <linux/string.h>
 #include <asm/stacktrace.h>
 #include <asm/cacheflush.h>
+#include <generated/utsrelease.h>
 #include "kpatch.h"
+
+#ifndef UTS_UBUNTU_RELEASE_ABI
+#define UTS_UBUNTU_RELEASE_ABI 0
+#endif
 
 #if !defined(CONFIG_FUNCTION_TRACER) || \
 	!defined(CONFIG_HAVE_FENTRY) || \
@@ -676,7 +681,10 @@ static int kpatch_write_relocations(struct kpatch_module *kpmod,
 	int ret, size, readonly = 0, numpages;
 	struct kpatch_dynrela *dynrela;
 	u64 loc, val;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#if (( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) ) || \
+     ( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+      UTS_UBUNTU_RELEASE_ABI >= 7 ) \
+    )
        unsigned long core = (unsigned long)kpmod->mod->core_layout.base;
        unsigned long core_size = kpmod->mod->core_layout.size;
 #else
@@ -746,7 +754,10 @@ static int kpatch_write_relocations(struct kpatch_module *kpmod,
 		}
 
 #ifdef CONFIG_DEBUG_SET_MODULE_RONX
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#if (( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) ) || \
+     ( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+      UTS_UBUNTU_RELEASE_ABI >= 7 ) \
+    )
                if (loc < core + kpmod->mod->core_layout.ro_size)
 #else
                if (loc < core + kpmod->mod->core_ro_size)

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -25,10 +25,15 @@
 #include <linux/list.h>
 #include <linux/slab.h>
 #include <linux/version.h>
+#include <generated/utsrelease.h>
 
 #include <linux/livepatch.h>
 
 #include "kpatch-patch.h"
+
+#ifndef UTS_UBUNTU_RELEASE_ABI
+#define UTS_UBUNTU_RELEASE_ABI 0
+#endif
 
 /*
  * There are quite a few similar structures at play in this file:
@@ -238,7 +243,10 @@ static int __init patch_init(void)
 			lfunc = &lfuncs[j];
 			lfunc->old_name = func->kfunc->name;
 			lfunc->new_func = (void *)func->kfunc->new_addr;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#if (( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) ) || \
+     ( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+      UTS_UBUNTU_RELEASE_ABI >= 7 ) \
+    )
 			lfunc->old_sympos = func->kfunc->sympos;
 #else
 			lfunc->old_addr = func->kfunc->old_addr;
@@ -255,7 +263,10 @@ static int __init patch_init(void)
 		list_for_each_entry(reloc, &object->relocs, list) {
 			lreloc = &lrelocs[j];
 			lreloc->loc = reloc->kdynrela->dest;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0)
+#if (( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) ) || \
+     ( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
+      UTS_UBUNTU_RELEASE_ABI >= 7 ) \
+    )
 			lreloc->sympos = reloc->kdynrela->sympos;
 #else
 			lreloc->val = reloc->kdynrela->src;

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -602,6 +602,14 @@ echo "Building patch module: kpatch-$PATCHNAME.ko"
 cp "$OBJDIR/.config" "$SRCDIR"
 cd "$SRCDIR"
 make prepare >> "$LOGFILE" 2>&1 || die
+
+if [[ $DISTRO == ubuntu ]]; then
+	# UBUNTU: add UTS_UBUNTU_RELEASE_ABI to utsrelease.h after regenerating it
+	UBUNTU_ABI=${ARCHVERSION#*-}
+	UBUNTU_ABI=${UBUNTU_ABI%-*}
+	echo "#define UTS_UBUNTU_RELEASE_ABI "$UBUNTU_ABI"" >> "$SRCDIR"/include/generated/utsrelease.h
+fi
+
 cd "$TEMPDIR/output"
 ld -r -o ../patch/output.o $(find . -name "*.o") >> "$LOGFILE" 2>&1 || die
 md5sum ../patch/output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die


### PR DESCRIPTION
These patches address Ubuntu specific patches that change livepatch structures in a way that breaks checking for kernel versions strictly on 4.X

FIxes #636 