### PR TITLE
kpatch: retry kpatch load on failure

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -165,7 +165,27 @@ load_module () {
 	fi
 
 	echo "loading patch module: $module"
-	insmod "$module"
+	local i=0
+	while true; do
+		out=$(insmod "$module" 2>&1)
+		[[ -z $out ]] && break
+		echo $out 1>&2
+		[[ ! $out =~ "Device or resource busy" ]] &&
+			die "failed to load module $module"
+
+		# "Device or resource busy" means the activeness safety check
+		# failed.  Retry in a few seconds.
+		i=$((i+1))
+		if [[ $i = 5 ]]; then
+			die "failed to load module $module"
+			break
+		else
+			warn "retrying..."
+			sleep 2
+		fi
+	done
+
+	return 0
 }
 
 unload_module () {

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -136,6 +136,8 @@ verify_module_checksum () {
 }
 
 load_module () {
+	local module="$1"
+
 	if ! core_module_loaded; then
 		if modprobe -q kpatch; then
 			echo "loaded core module"
@@ -146,11 +148,11 @@ load_module () {
 		fi
 	fi
 
-	modname=$(get_module_name $1)
-	moddir=/sys/kernel/kpatch/patches/$modname
+	local modname=$(get_module_name $module)
+	local moddir=/sys/kernel/kpatch/patches/$modname
 	if [[ -d $moddir ]] ; then
 		if [[ $(cat "${moddir}/enabled") -eq 0 ]]; then
-			if verify_module_checksum $1; then # same checksum
+			if verify_module_checksum $module; then # same checksum
 				echo "module already loaded, re-enabling"
 				echo 1 > ${moddir}/enabled || die "failed to re-enable module $modname"
 				return
@@ -162,8 +164,8 @@ load_module () {
 		fi
 	fi
 
-	echo "loading patch module: $1"
-	insmod "$1" "$2"
+	echo "loading patch module: $module"
+	insmod "$module"
 }
 
 unload_module () {


### PR DESCRIPTION
If a kpatch load fails, try again, up to 5 times.

It will usually only fail if the activeness safety check failed, in
which case trying again might work.  Unfortunately, insmod doesn't
return the error reported by the module, so we can't distinguish
activeness safety errors from other types of errors.