### PR TITLE
create-diff-object: better error message for dup file+symbol

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1915,7 +1915,7 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 	struct symbol *strsym;
 	struct lookup_result result;
 	struct kpatch_patch_dynrela *dynrelas;
-	int vmlinux, external;
+	int vmlinux, external, ret;
 
 	vmlinux = !strcmp(objname, "vmlinux");
 
@@ -1967,10 +1967,15 @@ void kpatch_create_dynamic_rela_sections(struct kpatch_elf *kelf,
 
 			if (rela->sym->bind == STB_LOCAL) {
 				/* An unchanged local symbol */
-				if (lookup_local_symbol(table, rela->sym->name,
-				                        hint, &result))
-					ERROR("lookup_local_symbol %s (%s) needed for %s",
-			               rela->sym->name, hint, sec->base->name);
+				ret = lookup_local_symbol(table,
+					rela->sym->name, hint, &result);
+				if (ret == 2)
+					ERROR("lookup_local_symbol: ambiguous %s:%s relocation, needed for %s",
+			               hint, rela->sym->name, sec->base->name);
+				else if (ret)
+					ERROR("lookup_local_symbol %s:%s needed for %s",
+			               hint, rela->sym->name, sec->base->name);
+
 			}
 			else if (vmlinux) {
 				/*

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -174,7 +174,7 @@ int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
 
 				if (match)
 					/* dup file+symbol, unresolvable ambiguity */
-					return 1;
+					return 2;
 				match = sym;
 			}
 		}


### PR DESCRIPTION
Give a slightly better error message for the dup file+symbol issue.
It's still cryptic but it's good enough to at least give us kpatch
developers a better idea about what went wrong.  This would have helped
diagnose issue #633 much more quickly.