### PR TITLE
kpatch-build: make patches for debug kernels too

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1095,6 +1095,7 @@ void kpatch_include_standard_elements(struct kpatch_elf *kelf)
 		if (!strcmp(sec->name, ".shstrtab") ||
 		    !strcmp(sec->name, ".strtab") ||
 		    !strcmp(sec->name, ".symtab") ||
+		    !strcmp(sec->name, ".rodata") ||
 		    !strncmp(sec->name, ".rodata.str1.", 13)) {
 			sec->include = 1;
 			if (sec->secsym)


### PR DESCRIPTION
GCC with KASAN instrumentation creates section ".rodata" with some static strings (i.e. some of them go to ".rodata.str1.1" for release build).
This change makes possible to build patch and check if it fixes issue found with KASAN, such as CVE-2016-9555.