### PR TITLE
create-diff-object: support gcc 6 per-function string tables

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1096,7 +1096,8 @@ void kpatch_include_standard_elements(struct kpatch_elf *kelf)
 		    !strcmp(sec->name, ".strtab") ||
 		    !strcmp(sec->name, ".symtab") ||
 		    !strcmp(sec->name, ".rodata") ||
-		    !strncmp(sec->name, ".rodata.str1.", 13)) {
+		    (!strncmp(sec->name, ".rodata.", 8) &&
+		     strstr(sec->name, ".str1."))) {
 			sec->include = 1;
 			if (sec->secsym)
 				sec->secsym->include = 1;


### PR DESCRIPTION
With older versions of gcc, string tables were stored in a few
.rodata.str1.* sections:

  # eu-readelf -S patched/fs/proc/meminfo.o |grep rodata
  [ 6] .rodata.str1.1       PROGBITS     0000000000000000 0000005c 00000008  1 AMS    0   0  1
  [11] .rodata.str1.8       PROGBITS     0000000000000000 000000a0 00000364  1 AMS    0   0  8
  [16] .rodata.meminfo_proc_fops PROGBITS     0000000000000000 000009c0 000000d8  0 A      0   0 32
  [17] .rela.rodata.meminfo_proc_fops RELA         0000000000000000 00017a58 00000060 24 I     35  16  8

With gcc 6, there can now be per-function string tables:

  # eu-readelf -S patched/kernel/fork.o |grep rodata
  [10] .rodata.trace_raw_output_task_newtask.str1.8 PROGBITS     0000000000000000 00000208 00000032  1 AMS    0   0  8
  [13] .rodata.trace_raw_output_task_rename.str1.8 PROGBITS     0000000000000000 000002b0 00000030  1 AMS    0   0  8
  [24] .rodata.mm_init.str1.1 PROGBITS     0000000000000000 0000094b 0000000e  1 AMS    0   0  1
  [29] .rodata.sighand_ctor.str1.1 PROGBITS     0000000000000000 00000ba1 00000017  1 AMS    0   0  1
  [32] .rodata.str1.1       PROGBITS     0000000000000000 00000bec 000001d9  1 AMS    0   0  1
  [33] .rodata.__mmdrop.str1.8 PROGBITS     0000000000000000 00000dc8 000000c4  1 AMS    0   0  8
  [82] .rodata.copy_process.part.30.str1.8 PROGBITS     0000000000000000 000019e0 00000098  1 AMS    0   0  8
  [83] .rodata.copy_process.part.30.str1.1 PROGBITS     0000000000000000 00001a78 0000003f  1 AMS    0   0  1
  [92] .rodata._do_fork.str1.1 PROGBITS     0000000000000000 0000372e 00000009  1 AMS    0   0  1
  [173] .init.rodata         PROGBITS     0000000000000000 00004a18 00000011  0 A      0   0  1
  [202] .rodata.str__task__trace_system_name PROGBITS     0000000000000000 00004df0 00000005  0 A      0   0  1

Fixes: #628