### PR TITLE
kpatch-build: reduce the debug firehose

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -555,10 +555,8 @@ for i in $FILES; do
 		KOBJFILE="$TEMPDIR/module/$KOBJFILE"
 	fi
 	cd $TEMPDIR
-	debugopt=
-	[[ $DEBUG -eq 1 ]] && debugopt=-d
 	if [[ -e "orig/$i" ]]; then
-		"$TOOLSDIR"/create-diff-object $debugopt "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
+		"$TOOLSDIR"/create-diff-object "orig/$i" "patched/$i" "$KOBJFILE" "output/$i" 2>&1 |tee -a "$LOGFILE"
 		rc="${PIPESTATUS[0]}"
 		if [[ $rc = 139 ]]; then
 			warn "create-diff-object SIGSEGV"


### PR DESCRIPTION
When passing '-d' to kpatch-build, it prints out some useful information
and keeps the related files around in ~/.kpatch/tmp.  However, it also
passes '-d' to create-diff-object, which spits out way too much
information, drowning out all the other useful messages printed by
kpatch-build.

In my experience, the create-diff-object debug info is overkill for
debugging most issues, so disable it.  The flag can still be used when
running create-diff-object manually.