### PR TITLE
kpatch-build: Add UTS_UBUNTU_RELEASE_ABI tag for non-stock kernel

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -419,6 +419,7 @@ else
 			extension="bz2"
 			sublevel="SUBLEVEL = 0"
 			taroptions="xvjf"
+			UBUNTU_KERNEL=1
 
 		elif [[ $DISTRO = debian ]]; then
 
@@ -601,7 +602,7 @@ cp "$OBJDIR/.config" "$SRCDIR"
 cd "$SRCDIR"
 make prepare >> "$LOGFILE" 2>&1 || die
 
-if [[ $DISTRO == ubuntu ]]; then
+if [[ ! -z $UBUNTU_KERNEL ]]; then
 	# UBUNTU: add UTS_UBUNTU_RELEASE_ABI to utsrelease.h after regenerating it
 	UBUNTU_ABI=${ARCHVERSION#*-}
 	UBUNTU_ABI=${UBUNTU_ABI%-*}


### PR DESCRIPTION
commit eb55adc52d0c ("use livepatch 4.5 features in
Ubuntu Xenial kernel") will trigger following build
failure, while building stock kernel on Ubuntu:
make[2]: Entering directory '/root/.kpatch/obj'
  CC [M]  /root/.kpatch/tmp/patch/patch-hook.o
In file included from /root/.kpatch/tmp/patch/livepatch-patch-hook.c:28:0,
                 from /root/.kpatch/tmp/patch/patch-hook.c:21:
/root/.kpatch/tmp/patch/livepatch-patch-hook.c: In functionpatch_ini:
/root/linux-4.8.15/include/generated/utsrelease.h:2:32: error: too many decimal points in number
 #define UTS_UBUNTU_RELEASE_ABI 4.8.15
                                ^
/root/.kpatch/tmp/patch/livepatch-patch-hook.c:252:7: note: in expansion of macro UTS_UBUNTU_RELEASE_ABI
       UTS_UBUNTU_RELEASE_ABI >= 7 ) \
       ^
Stock kernel version string might differ from the ubuntu
kernel versioning format. This patch sets UBUNTU_KERNEL
flag, when kpatch module is being build for ubuntu distro
kernel and check for this flag before echoing
UTS_UBUNTU_RELEASE_ABI tag.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>
Cc: Chris J Arges <christopherarges@gmail.com>