### PR TITLE
compile original module for create-diff-object

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -532,6 +532,7 @@ do
 	cp -f "$OBJDIR/$i" "$TEMPDIR/patched/$i" || die
 done
 
+unset KCFLAGS
 echo "Extracting new and modified ELF sections"
 FILES="$(cat "$TEMPDIR/changed_objs")"
 cd "$TEMPDIR"
@@ -552,6 +553,13 @@ for i in $FILES; do
 	if [[ $KOBJFILE = vmlinux ]]; then
 		KOBJFILE=$VMLINUX
 	else
+		cd "$SRCDIR"
+		patch -p1 -R -d "$SRCDIR" < "$SRCDIR/$APPLIEDPATCHFILE" &> /dev/null
+		make "-j$CPUS" $KOBJFILE "O=$OBJDIR" >> "$LOGFILE" 2>&1 || die
+		cd "$OBJDIR"
+
+		# pass original module to create-diff-object
+		cp -f "$KOBJFILE" "$TEMPDIR/module/$KOBJFILE" || die
 		KOBJFILE="$TEMPDIR/module/$KOBJFILE"
 	fi
 	cd $TEMPDIR


### PR DESCRIPTION
Normally, the symbols in the freshly built object file that
create-diff-object used are the same with our original module.

But the name of the symbols may change if use --skip-gcc-check
or the influence of KCFLAGS. This patch compile original module
for create-diff-object, like original vmlinux, to detect this
problem earlier, before we need to insmod klp.ko.

Fixes #612.

Signed-off-by: Zhou Chengming <zhouchengming1@huawei.com>