### PR TITLE
Small kpatch-test fixups

### DIFF
--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -267,6 +267,10 @@ build_combined_module() {
 }
 
 run_combined_test() {
+	if [[ ! -e COMBINED.patch ]]; then
+		return
+	fi
+
 	if [[ ! -e kpatch-COMBINED.ko ]]; then
 		log "can't find kpatch-COMBINED.ko, skipping"
 		return

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -40,6 +40,8 @@
 # built from the *.patch files.  They can be used for more custom tests above
 # and beyond the simple loading and unloading tests.
 
+shopt -s nullglob
+
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
 # TODO: option to use system-installed binaries instead
@@ -95,6 +97,10 @@ done
 if [[ ${#PATCH_LIST[@]} = 0 ]]; then
 	PATCH_LIST=($PATCHDIR/*.patch)
 	TEST_LIST=($PATCHDIR/*.test)
+	if [[ ${#PATCH_LIST[@]} = 0 ]]; then
+		echo "No patches found!"
+		exit 1
+	fi
 else
 	for file in "${PATCH_LIST[@]}"; do
 		prefix=${file%%.patch}

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -120,12 +120,12 @@ log() {
 }
 
 unload_all() {
-	for i in `lsmod |egrep '^kpatch' |awk '{print $1}'`; do
+	for i in `/sbin/lsmod |egrep '^kpatch' |awk '{print $1}'`; do
 		if [[ $i != kpatch ]]; then
 			$KPATCH unload $i >> $LOG 2>&1 || error "\"kpatch unload $i\" failed"
 		fi
 	done
-	if lsmod |egrep -q '^kpatch'; then
+	if /sbin/lsmod |egrep -q '^kpatch'; then
 		$RMMOD kpatch >> $LOG 2>&1 || error "\"rmmod kpatch\" failed"
 	fi
 }


### PR DESCRIPTION
This is a set of really small fixes for kpatch-test:

* **testing: handle empty glob cases** - found when running ```kpatch-test``` against an empty patch directory.  I could have modified the globbing behavior via ```shopt -s failglob```, but I thought that was a more esoteric fix (and changes default behavior for the rest of the script).

* **testing: skip gcc check** - installed gcc vs kernel build gcc can drift on Vagrant VM boxes.  We could alternatively add a command line switch to ```kpatch-test``` to optionally pass this option along.

* **testing: skip combined test for a single patch** - this cleans up the test output a bit.

* **testing: add full path for /sbin executables** - as seen on a Fedora Vagrant VM box when running a command via ```ssh ... <command>```.  I verified the user PATH with:
```
% ssh vagrant@192.168.121.4 echo \$PATH
/usr/lib64/ccache:/usr/local/bin:/usr/bin
```
Note that ```/etc/sudoers``` on most distributions includes a line like ```/sbin:/bin:/usr/sbin:/usr/bin```, so any commands that ```kpatch-test``` is invoking via ```sudo``` should be fine.