### PR TITLE
kmod: let kernel apply TAINT_LIVEPATCH

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -1008,9 +1008,22 @@ int kpatch_register(struct kpatch_module *kpmod, bool replace)
 		func->op = KPATCH_OP_NONE;
 	} while_for_each_linked_func();
 
+/* HAS_MODULE_TAINT - upstream 2992ef29ae01 "livepatch/module: make TAINT_LIVEPATCH module-specific" */
+#ifdef RHEL_RELEASE_CODE
+# if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 4)
+#  define HAS_MODULE_TAINT
+# endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+# define HAS_MODULE_TAINT
+#endif
+
 #ifdef TAINT_LIVEPATCH
+# ifdef HAS_MODULE_TAINT
+	/* kernel will add TAINT_LIVEPATCH on module load. */
+# else
 	pr_notice_once("tainting kernel with TAINT_LIVEPATCH\n");
 	add_taint(TAINT_LIVEPATCH, LOCKDEP_STILL_OK);
+# endif
 #else
 	pr_notice_once("tainting kernel with TAINT_USER\n");
 	add_taint(TAINT_USER, LOCKDEP_STILL_OK);

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -420,3 +420,4 @@ static void __exit patch_exit(void)
 module_init(patch_init);
 module_exit(patch_exit);
 MODULE_LICENSE("GPL");
+MODULE_INFO(livepatch, "Y");

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -315,3 +315,4 @@ static void __exit patch_exit(void)
 module_init(patch_init);
 module_exit(patch_exit);
 MODULE_LICENSE("GPL");
+MODULE_INFO(livepatch, "Y");


### PR DESCRIPTION
Upstream commit [2992ef29ae01](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=2992ef29ae01) ("livepatch/module: make TAINT_LIVEPATCH module-specific") v4.9+ modified the kernel to add the TAINT_LIVEPATCH flag on module load.  To support this feature, add the "livepatch" module info in the {k,live}patch modules and drop the add_taint() in the core module.

Testing: ran on a RHEL7 kernel with and without a [2992ef29ae01](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=2992ef29ae01) backport and observed the expected results with the backport: ```cat /sys/module/<kpatch_module>/taint``` = ```OEK```.

I did not see this kernel feature backported yet to Ubuntu 16 LTS or Fedora 24, so no kernel version checks are needed for them.