### PR TITLE
support dup file+symbol

### DIFF
--- a/kpatch-build/lookup.h
+++ b/kpatch-build/lookup.h
@@ -9,6 +9,11 @@ struct lookup_result {
 	unsigned long pos;
 };
 
+struct sym_compare_type {
+	char *name;
+	int type;
+};
+
 struct lookup_table *lookup_open(char *path);
 void lookup_close(struct lookup_table *table);
 int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
@@ -16,5 +21,7 @@ int lookup_local_symbol(struct lookup_table *table, char *name, char *hint,
 int lookup_global_symbol(struct lookup_table *table, char *name,
                          struct lookup_result *result);
 int lookup_is_exported_symbol(struct lookup_table *table, char *name);
+int resolve_dup_file_symbol(struct lookup_table *table, char *hint,
+			    struct sym_compare_type *name, int num);
 
 #endif /* _LOOKUP_H_ */


### PR DESCRIPTION
This patch needs some explanation. When we want to resolve a dup
file+symbol symbol, we first find out our base object in lookup table,
then we can use this information to resolve ambiguous local symbols.

We use resolve_dup_file_symbol to find out the correct base object in
lookup table. If all local symbols of a file can be found in the
kelf_base, we think it's a matched file.

Fixes #604.

Signed-off-by: Zhou Chengming <zhouchengming1@huawei.com>