### PR TITLE
RFC - 4.9 unwinder

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -580,6 +580,8 @@ for i in $FILES; do
 	[[ $DISTRO = rhel ]] || [[ $DISTRO = centos ]] || [[ $DISTRO = ol ]] && \
 		[[ $i = arch/x86/lib/copy_user_64.o ]] && continue
 
+	[[ $i = usr/initramfs_data.o ]] && continue
+
 	mkdir -p "output/$(dirname $i)"
 	cd "$OBJDIR"
 	find_kobj $i


### PR DESCRIPTION
This is based on @flaming-toast 's [4.7-changes](https://github.com/flaming-toast/kpatch/tree/4.7-changes) branch, so I don't know how well the github review interface will work, but here goes.

* patch 1 - I don't know if this is a kernel config or v4.9 thing, but kpatch-build was complaining about ```initramfs_data.o``` so just skipped the file so I could continue on.

* patch 2 -  adds in v4.9+ support for the shiny new ```unwind_{start,done,next_frame}``` interface.  Much simpler than the deprecated ```dump_trace``` and callback mechanism!  (Good work, @jpoimboe )  My modifications are pretty straightforward, I tested with a patch that changed ```n_tty_read```, which an agetty process will always be sitting on... and verified the safety check detected and returned ```-EBUSY```.

Hope this is on the right track.  If this is easier to review as a branch off master rather than [4.7-changes](https://github.com/flaming-toast/kpatch/tree/4.7-changes), let me know and I can respin.