### PR TITLE
kmod: fix kpatch patch module load if CONFIG_LIVEPATCH=n

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -1011,18 +1011,19 @@ int kpatch_register(struct kpatch_module *kpmod, bool replace)
 /* HAS_MODULE_TAINT - upstream 2992ef29ae01 "livepatch/module: make TAINT_LIVEPATCH module-specific" */
 #ifdef RHEL_RELEASE_CODE
 # if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 4)
-#  define HAS_MODULE_TAINT
+#  define HAS_RHEL7_MODULE_TAINT
 # endif
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 # define HAS_MODULE_TAINT
 #endif
 
 #ifdef TAINT_LIVEPATCH
-# ifdef HAS_MODULE_TAINT
-	/* kernel will add TAINT_LIVEPATCH on module load. */
-# else
 	pr_notice_once("tainting kernel with TAINT_LIVEPATCH\n");
 	add_taint(TAINT_LIVEPATCH, LOCKDEP_STILL_OK);
+# ifdef HAS_MODULE_TAINT
+	set_bit(TAINT_LIVEPATCH, &kpmod->mod->taints);
+# elif defined(HAS_RHEL7_MODULE_TAINT)
+	kpmod->mod->taints |= (1 << TAINT_LIVEPATCH);
 # endif
 #else
 	pr_notice_once("tainting kernel with TAINT_USER\n");

--- a/kmod/patch/kpatch-patch-hook.c
+++ b/kmod/patch/kpatch-patch-hook.c
@@ -420,4 +420,3 @@ static void __exit patch_exit(void)
 module_init(patch_init);
 module_exit(patch_exit);
 MODULE_LICENSE("GPL");
-MODULE_INFO(livepatch, "Y");


### PR DESCRIPTION
Previous commit "kmod: let kernel apply TAINT_LIVEPATCH" modified the
kpatch patch module to set the "livepatch" module info.  This breaks
module loading for kernel config CONFIG_LIVEPATCH=n

  kpatch_kmalloc: module is marked as livepatch module, but livepatch support is disabled

kpatch modules can still use TAINT_LIVEPATCH as a per-module taint flag,
but only if it is set after the module loads.

Fixes: 660.