### PR TITLE
lookup: use log.h version of ERROR macro

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -37,9 +37,7 @@
 #include <libgen.h>
 
 #include "lookup.h"
-
-#define ERROR(format, ...) \
-	error(1, 0, "%s: %d: " format, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#include "log.h"
 
 struct object_symbol {
 	unsigned long value;


### PR DESCRIPTION
Use the log.h version of the ERROR macro so the childobj gets printed.