### PR TITLE
testing: remove extra '}' from run_custom_test's prefix variable

### DIFF
--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -207,7 +207,7 @@ run_load_test() {
 
 run_custom_test() {
 	testprog=$1
-	prefix=$(basename ${file%%.test}})
+	prefix=$(basename ${file%%.test})
 
 	[[ $testprog = *-LOADED.test ]] && return
 


### PR DESCRIPTION
Fixes: #664.