### PR TITLE
kpatch-build fixups for various kernel configs

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -516,10 +516,10 @@ echo "Reading special section data"
 SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
 	       gawk --non-decimal-data '
 	       BEGIN { a = b = p = e = 0 }
-	       a == 0 && /DW_AT_name.* alt_instr\s*$/ {a = 1; next}
-	       b == 0 && /DW_AT_name.* bug_entry\s*$/ {b = 1; next}
-	       p == 0 && /DW_AT_name.* paravirt_patch_site\s*$/ {p = 1; next}
-	       e == 0 && /DW_AT_name.* exception_table_entry\s*$/ {e = 1; next}
+	       a == 0 && /DW_AT_name.* alt_instr[[:space:]]*$/ {a = 1; next}
+	       b == 0 && /DW_AT_name.* bug_entry[[:space:]]*$/ {b = 1; next}
+	       p == 0 && /DW_AT_name.* paravirt_patch_site[[:space:]]*$/ {p = 1; next}
+	       e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
 	       a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
 	       b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
 	       p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -505,6 +505,9 @@ else
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi
 
+# unsupported kernel option checking: CONFIG_DEBUG_INFO_SPLIT
+grep -q "CONFIG_DEBUG_INFO_SPLIT=y" "$OBJDIR/.config" && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
+
 echo "Testing patch file"
 cd "$SRCDIR" || die
 patch -N -p1 --dry-run < "$PATCHFILE" || die "source patch file failed to apply"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -505,6 +505,13 @@ else
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi
 
+# optional kernel configs: CONFIG_PARAVIRT
+if grep "CONFIG_PARAVIRT=y" "$OBJDIR/.config" > /dev/null; then
+	CONFIG_PARAVIRT=1
+else
+	CONFIG_PARAVIRT=0
+fi
+
 # unsupported kernel option checking: CONFIG_DEBUG_INFO_SPLIT
 grep -q "CONFIG_DEBUG_INFO_SPLIT=y" "$OBJDIR/.config" && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
 
@@ -516,8 +523,9 @@ cp -LR "$DATADIR/patch" "$TEMPDIR" || die
 export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections"
 
 echo "Reading special section data"
+[[ $CONFIG_PARAVIRT -eq 0 ]] && AWK_OPTIONS="-vskip_p=1"
 SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
-	       gawk --non-decimal-data '
+	       gawk --non-decimal-data $AWK_OPTIONS '
 	       BEGIN { a = b = p = e = 0 }
 
 	       # Set state if name matches
@@ -539,14 +547,15 @@ SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
 	       e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
 
 	       # Bail out once we have everything
-	       a == 2 && b == 2 && p == 2 && e == 2 {exit}')
+	       a == 2 && b == 2 && (p == 2 || skip_p) && e == 2 {exit}')
 
 [[ -n $SPECIAL_VARS ]] && eval "$SPECIAL_VARS"
 
-if [[ -z $ALT_STRUCT_SIZE ]] || [[ -z $BUG_STRUCT_SIZE ]] ||
-   [[ -z $PARA_STRUCT_SIZE ]] || [[ -z $EX_STRUCT_SIZE ]]; then
-	die "can't find special struct size"
-fi
+[[ -z $ALT_STRUCT_SIZE ]] && die "can't find special struct alt_instr size"
+[[ -z $BUG_STRUCT_SIZE ]] && die "can't find special struct bug_entry size"
+[[ -z $EX_STRUCT_SIZE ]]  && die "can't find special struct paravirt_patch_site size"
+[[ -z $PARA_STRUCT_SIZE && $CONFIG_PARAVIRT -ne 0 ]] && die "can't find special struct paravirt_patch_site size"
+
 for i in $ALT_STRUCT_SIZE $BUG_STRUCT_SIZE $PARA_STRUCT_SIZE $EX_STRUCT_SIZE; do
 	if [[ ! $i -gt 0 ]] || [[ ! $i -le 16 ]]; then
 		die "invalid special struct size $i"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -516,14 +516,26 @@ echo "Reading special section data"
 SPECIAL_VARS=$(readelf -wi "$VMLINUX" |
 	       gawk --non-decimal-data '
 	       BEGIN { a = b = p = e = 0 }
+
+	       # Set state if name matches
 	       a == 0 && /DW_AT_name.* alt_instr[[:space:]]*$/ {a = 1; next}
 	       b == 0 && /DW_AT_name.* bug_entry[[:space:]]*$/ {b = 1; next}
 	       p == 0 && /DW_AT_name.* paravirt_patch_site[[:space:]]*$/ {p = 1; next}
 	       e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
+
+	       # Reset state unless this abbrev describes the struct size
+	       a == 1 && !/DW_AT_byte_size/ { a = 0; next }
+	       b == 1 && !/DW_AT_byte_size/ { b = 0; next }
+	       p == 1 && !/DW_AT_byte_size/ { p = 0; next }
+	       e == 1 && !/DW_AT_byte_size/ { e = 0; next }
+
+	       # Now that we know the size, stop parsing for it
 	       a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
 	       b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
 	       p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}
 	       e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
+
+	       # Bail out once we have everything
 	       a == 2 && b == 2 && p == 2 && e == 2 {exit}')
 
 [[ -n $SPECIAL_VARS ]] && eval "$SPECIAL_VARS"


### PR DESCRIPTION
This patchset addresses a few issues with ```kpatch-build``` and various kernel config settings:

1. Some versions of gawk do not support the whitespace ```'\s'``` operator.  Drop back to using the ```[[:space:]]``` expression as it's supported in older verisons, too.
2. @marcin-github reported issues building on Gentoo when the kernel was configured with ```CONFIG_DEBUG_INFO_REDUCED```.  This reorders ```readelf -wi``` output a bit, and requires a smarter awk script to parse special structure sizings.
3. @marcin-github also reported problems when ```CONFIG_DEBUG_INFO_SPLIT``` was set.  This configuration stores debuginfo in separate ```.dwo``` files.  Since no major distribution is doing this (yet), just detect and note that this isn't supported.
4. @marcin-github also reported problems when ```CONFIG_PARAVIRT``` was not set.  This is technically not required, so adjust ```kpatch-build``` to handle cases when it is not set.