### PR TITLE
kmod: restructure kpatch sysfs tree

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -71,9 +71,8 @@ static LIST_HEAD(kpmod_list);
 
 static int kpatch_num_patched;
 
-static struct kobject *kpatch_root_kobj;
-struct kobject *kpatch_patches_kobj;
-EXPORT_SYMBOL_GPL(kpatch_patches_kobj);
+struct kobject *kpatch_root_kobj;
+EXPORT_SYMBOL_GPL(kpatch_root_kobj);
 
 struct kpatch_kallsyms_args {
 	const char *objname;
@@ -1127,21 +1126,12 @@ static int kpatch_init(void)
 	if (!kpatch_root_kobj)
 		return -ENOMEM;
 
-	kpatch_patches_kobj = kobject_create_and_add("patches",
-						     kpatch_root_kobj);
-	if (!kpatch_patches_kobj) {
-		ret = -ENOMEM;
-		goto err_root_kobj;
-	}
-
 	ret = register_module_notifier(&kpatch_module_nb);
 	if (ret)
-		goto err_patches_kobj;
+		goto err_root_kobj;
 
 	return 0;
 
-err_patches_kobj:
-	kobject_put(kpatch_patches_kobj);
 err_root_kobj:
 	kobject_put(kpatch_root_kobj);
 	return ret;
@@ -1153,7 +1143,6 @@ static void kpatch_exit(void)
 
 	WARN_ON(kpatch_num_patched != 0);
 	WARN_ON(unregister_module_notifier(&kpatch_module_nb));
-	kobject_put(kpatch_patches_kobj);
 	kobject_put(kpatch_root_kobj);
 }
 

--- a/kmod/core/kpatch.h
+++ b/kmod/core/kpatch.h
@@ -46,6 +46,7 @@ struct kpatch_func {
 	/* private */
 	struct hlist_node node;
 	enum kpatch_op op;
+	struct kobject kobj;
 };
 
 struct kpatch_dynrela {
@@ -74,6 +75,7 @@ struct kpatch_object {
 
 	/* private */
 	struct module *mod;
+	struct kobject kobj;
 };
 
 struct kpatch_module {
@@ -86,9 +88,10 @@ struct kpatch_module {
 
 	/* private */
 	struct list_head list;
+	struct kobject kobj;
 };
 
-extern struct kobject *kpatch_patches_kobj;
+extern struct kobject *kpatch_root_kobj;
 
 extern int kpatch_register(struct kpatch_module *kpmod, bool replace);
 extern int kpatch_unregister(struct kpatch_module *kpmod);

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -32,7 +32,7 @@ VERSION="0.3.4"
 if [[ -e /sys/kernel/livepatch ]] ; then
 	SYSFS="/sys/kernel/livepatch"
 else
-	SYSFS="/sys/kernel/kpatch/patches"
+	SYSFS="/sys/kernel/kpatch"
 fi
 
 usage_cmd() {

--- a/test/testmod/doit-client.sh
+++ b/test/testmod/doit-client.sh
@@ -16,7 +16,7 @@ if [[ "$(cat /sys/kernel/testmod/value)" != "3" ]]
 then
 	exit 1
 fi
-echo 0 > /sys/kernel/kpatch/patches/kpatch_patch/enabled
+echo 0 > /sys/kernel/kpatch/kpatch_patch/enabled
 rmmod kpatch-patch
 if [[ "$(cat /sys/kernel/testmod/value)" != "2" ]]
 then


### PR DESCRIPTION
Restructure kpatch's sysfs interface and mirror the sysfs tree after
livepatch's sysfs layout. With the current sysfs layout, we cannot
distinguish which object a function belongs to, and we cannot tell which
modules/objects are patched. Therefore, restructure the kpatch sysfs tree
such that module/object information is available. With the new layout, each
patched object has its own directory, with each function being a
subdirectory of its object.

Implement this by embedding a kobject struct within the kpatch_module,
kpatch_func, and kpatch_object structs and supplying their ktypes and
kobject release methods.

Before:
```
/sys/kernel/kpatch
└── patches
    └── <patch_module>
        ├── checksum
        ├── enabled
        └── functions
            ├── <function>    # from <object1>
            │    ├── new_addr
            │    └── old_addr
            ├── <function>    # from <object2>
            │    ├── new_addr
            │    └── old_addr
            └─── <function>   # from <object3>
                 ├── new_addr
                 └── old_addr
```
After:
```
/sys/kernel/kpatch
└── <patch_module>
    ├── <object1>
    │   └── <function,sympos>
    │       ├── new_addr
    │       └── old_addr
    ├── <object2>
    │   └── <function,sympos>
    │       ├── new_addr
    │       └── old_addr
    ├── checksum
    ├── enabled
    └── <object3>
        └── <function,sympos>
            ├── new_addr
            └── old_addr
```

Fixes #678.