### PR TITLE
create-diff-object: Mark correlated static local variables the SAME i…

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -767,6 +767,9 @@ static void kpatch_correlate_static_local_variables(struct kpatch_elf *base,
 			sym->twin = patched_sym;
 			patched_sym->twin = sym;
 
+			/* set initial status, might change */
+			sym->status = patched_sym->status = SAME;
+
 			if (bundled) {
 				sym->sec->twin = patched_sym->sec;
 				patched_sym->sec->twin = sym->sec;


### PR DESCRIPTION
…nitially

Normal correlated symbols are marked the SAME initially but static local
variables are correlated in a separate function. Also mark these the
SAME.

This fixes an issue where patching a function which called printk_once
(which uses a static local variable) would fail to build because the
static local variable was considered new and thus introduced a new data
member into .data..read_mostly which is not allowed to change.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>