### PR TITLE
create-diff-object: Strip kpatch_ignore_func_* symbols

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1691,11 +1691,18 @@ static void kpatch_mark_ignored_sections_same(struct kpatch_elf *kelf)
 			sym->status = SAME;
 		}
 	}
+
+	/* strip temporary global __UNIQUE_ID_kpatch_ignore_section_* symbols */
+	list_for_each_entry(sym, &kelf->symbols, list)
+		if (!strncmp(sym->name, "__UNIQUE_ID_kpatch_ignore_section_",
+		            strlen("__UNIQUE_ID_kpatch_ignore_section_")))
+			sym->status = SAME;
 }
 
 static void kpatch_mark_ignored_functions_same(struct kpatch_elf *kelf)
 {
 	struct section *sec;
+	struct symbol *sym;
 	struct rela *rela;
 
 	sec = find_section_by_name(&kelf->sections, ".kpatch.ignore.functions");
@@ -1717,6 +1724,12 @@ static void kpatch_mark_ignored_functions_same(struct kpatch_elf *kelf)
 		if (rela->sym->sec->rela)
 			rela->sym->sec->rela->status = SAME;
 	}
+
+	/* strip temporary global kpatch_ignore_func_* symbols */
+	list_for_each_entry(sym, &kelf->symbols, list)
+		if (!strncmp(sym->name, "__kpatch_ignore_func_",
+		            strlen("__kpatch_ignore_func_")))
+			sym->status = SAME;
 }
 
 static void kpatch_create_kpatch_arch_section(struct kpatch_elf *kelf, char *objname)


### PR DESCRIPTION
Strip kpatch_ignore_func_* symbols to prevent the inclusion of
.kpatch.ignore.functions.  If this section is included, it creates a
dynrela to the ignored function.  When loaded, the kpatch core module
may change the page protection of this section to read only. This could
cause the patch module's data structures to become read only.

Fixes #681.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>