### PR TITLE
lookup: skip discarded symbols in local symbol comparison

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -84,6 +84,9 @@ static void find_local_syms(struct lookup_table *table, char *hint,
 	int i, in_file = 0;
 	struct sym_compare_type *child_sym;
 
+	if (!child_locals)
+		return;
+
 	for_each_obj_symbol(i, sym, table) {
 		if (sym->type == STT_FILE) {
 			if (in_file && !child_sym->name) {
@@ -287,10 +290,7 @@ struct lookup_table *lookup_open(char *obj_path, char *symvers_path,
 
 	obj_read(table, obj_path);
 	symvers_read(table, symvers_path);
-
-	table->local_syms = NULL;
-	if (locals)
-		find_local_syms(table, hint, locals);
+	find_local_syms(table, hint, locals);
 
 	return table;
 }

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -65,15 +65,15 @@ struct lookup_table {
 	for (ndx = 0, iter = table->exp_syms; ndx < table->exp_nr; ndx++, iter++)
 
 static void find_local_syms(struct lookup_table *table, char *hint,
-			    struct sym_compare_type *locals)
+			    struct sym_compare_type *child_locals)
 {
 	struct object_symbol *sym, *file_sym;
 	int i, in_file = 0;
-	struct sym_compare_type *local_index;
+	struct sym_compare_type *child_sym;
 
 	for_each_obj_symbol(i, sym, table) {
 		if (sym->type == STT_FILE) {
-			if (in_file && !local_index->name) {
+			if (in_file && !child_sym->name) {
 				if (table->local_syms)
 					ERROR("find_local_syms for %s: found_dup", hint);
 				table->local_syms = file_sym;
@@ -82,7 +82,7 @@ static void find_local_syms(struct lookup_table *table, char *hint,
 			if (!strcmp(hint, sym->name)) {
 				in_file = 1;
 				file_sym = sym;
-				local_index = locals;
+				child_sym = child_locals;
 			}
 			else
 				in_file = 0;
@@ -95,15 +95,14 @@ static void find_local_syms(struct lookup_table *table, char *hint,
 		if (sym->bind != STB_LOCAL || (sym->type != STT_FUNC && sym->type != STT_OBJECT))
 			continue;
 
-		if (local_index->name &&
-		    local_index->type == sym->type &&
-		    !strcmp(local_index->name, sym->name))
-			local_index++;
+		if (child_sym->name && child_sym->type == sym->type &&
+		    !strcmp(child_sym->name, sym->name))
+			child_sym++;
 		else
 			in_file = 0;
 	}
 
-	if (in_file && !local_index->name) {
+	if (in_file && !child_sym->name) {
 		if (table->local_syms)
 			ERROR("find_local_syms for %s: found_dup", hint);
 		table->local_syms = file_sym;


### PR DESCRIPTION
A few symbols are discarded in the kernel linking phase, which means
they won't be in the lookup table.  Skip their comparison.
    
This fixes a bunch of warnings seen when building a patch which triggers
a tree-wide rebuild:
    
    create-diff-object: ERROR: aes_glue.o: find_local_syms: 112: find_local_syms for aes_glue.c: found_none
    create-diff-object: ERROR: aesni-intel_glue.o: find_local_syms: 112: find_local_syms for aesni-intel_glue.c: found_none
    create-diff-object: ERROR: init.o: find_local_syms: 112: find_local_syms for init.c: found_none
    create-diff-object: ERROR: iosf_mbi.o: find_local_syms: 112: find_local_syms for iosf_mbi.c: found_none
    create-diff-object: ERROR: setup.o: find_local_syms: 112: find_local_syms for setup.c: found_none
    ...
    
After this patch, there's still one warning remaining:
   
    create-diff-object: ERROR: dynamic_debug.o: find_local_syms: 133: find_local_syms for dynamic_debug.c: found_none
    
That one has a completely different cause, which I'll fix in another
pull request (coming soon).

Fixes: #676