### PR TITLE
kpatch-gcc: update ignorelist to avoid foo/.lib_exports.o files

### DIFF
--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -32,7 +32,7 @@ if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
 				arch/x86/vdso/*|\
 				arch/x86/entry/vdso/*|\
 				drivers/firmware/efi/libstub/*|\
-				.*.o)
+				*.*.o)
 					break
 					;;
 				*.o)


### PR DESCRIPTION
Upstream kernel commit 7f2084fa55e6 ("[kbuild] handle exports in lib-y
objects reliably") (v4.9+) added temporary dummy .lib_exports.o objects
to the kernel build.  As these ephemeral files don't contain any code,
update the kpatch-gcc glob pattern to ignore them.

(glob pattern suggested by flaming-toast)

Fixes #686.