### PR TITLE
README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,8 +443,7 @@ kpatch-build already works with both livepatch and kpatch.  If your kernel has
 CONFIG\_LIVEPATCH enabled, it detects that and builds a patch module in the
 livepatch format.  Otherwise it builds a kpatch patch module.
 
-Soon the kpatch script will also support both patch module formats (TODO issue
-[#479](https://github.com/dynup/kpatch/issues/479)).
+The kpatch script also supports both patch module formats.
 
 **Q. Isn't this just a virus/rootkit injection framework?**
 
@@ -454,11 +453,10 @@ ability to arbitrarily modify the kernel, with or without kpatch.
 
 **Q. How can I detect if somebody has patched the kernel?**
 
-When a patch module is loaded, the `TAINT_USER` flag is set.  To test for it,
-`cat /proc/sys/kernel/tainted` and check to see if the value of 64 has been
-OR'ed in.
-
-Eventually we hope to have a dedicated `TAINT_KPATCH` flag instead.
+When a patch module is loaded, the `TAINT_USER` or `TAINT_LIVEPATCH` flag is
+set.  (The latter flag was introduced in Linux version 4.0.)  To test for
+these flags, `cat /proc/sys/kernel/tainted` and check to see if the value of
+`TAINT_USER` (64) or `TAINT_LIVEPATCH` (32768) has been OR'ed in.
 
 Note that the `TAINT_OOT_MODULE` flag (4096) will also be set, since the patch
 module is built outside the Linux kernel source tree.
@@ -466,6 +464,11 @@ module is built outside the Linux kernel source tree.
 If your patch module is unsigned, the `TAINT_FORCED_MODULE` flag (2) will also
 be set.  Starting with Linux 3.15, this will be changed to the more specific
 `TAINT_UNSIGNED_MODULE` (8192).
+
+Linux versions starting with 4.9 also support a per-module `TAINT_LIVEPATCH`
+taint flag. This can be checked by verifying the output of
+`cat /sys/module/<kpatch module>/taint` -- a 'K' character indicates the
+presence of `TAINT_LIVEPATCH`.
 
 **Q. Will it destabilize my system?**
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ Limitations
 - Patches which modify functions in vdso are not supported.  These run in
   user-space and ftrace can't hook them.
 
+- Patches which modify functions that are missing a `fentry` call are not
+  supported.  This includes any `lib-y` targets that are archived into a
+  `lib.a` library for later linking (for example, `lib/string.o`).
+
 - Some incompatibilities currently exist between kpatch and usage of ftrace and
   kprobes.  See the Frequently Asked Questions section for more details.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Installation
 
 ###Prerequisites
 
-####Fedora 23
+####Fedora
 
 *NOTE: You'll need about 15GB of free disk space for the kpatch-build cache in
 `~/.kpatch` and for ccache.*
@@ -33,19 +33,23 @@ Installation
 Install the dependencies for compiling kpatch:
 
 ```bash
-sudo dnf install gcc kernel-devel elfutils elfutils-devel
+UNAME=$(uname -r)
+sudo dnf install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 ```
 
 Install the dependencies for the "kpatch-build" command:
 
 ```bash
 sudo dnf install rpmdevtools pesign yum-utils openssl wget numactl-devel
-sudo dnf builddep kernel
-sudo dnf debuginfo-install kernel
+sudo dnf builddep kernel-${UNAME%.*}
+sudo dnf debuginfo-install kernel-${UNAME%.*}
 
 # optional, but highly recommended
 sudo dnf install ccache
 ccache --max-size=5G
+
+# optional, for kpatch-test
+sudo dnf install patchutils
 ```
 
 ####RHEL 7
@@ -56,7 +60,8 @@ ccache --max-size=5G
 Install the dependencies for compiling kpatch:
 
 ```bash
-sudo yum install gcc kernel-devel elfutils elfutils-devel
+UNAME=$(uname -r)
+sudo yum install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 ```
 
 Install the dependencies for the "kpatch-build" command:
@@ -67,12 +72,15 @@ sudo yum install rpmdevtools pesign yum-utils zlib-devel \
   binutils-devel newt-devel python-devel perl-ExtUtils-Embed \
   audit-libs-devel numactl-devel pciutils-devel bison ncurses-devel
 
-sudo yum-builddep kernel
-sudo debuginfo-install kernel
+sudo yum-builddep kernel-${UNAME%.*}
+sudo debuginfo-install kernel-${UNAME%.*}
 
 # optional, but highly recommended
-sudo yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/c/ccache-3.1.9-3.el7.x86_64.rpm
+sudo yum install https://dl.fedoraproject.org/pub/epel/7/x86_64/c/ccache-3.2.7-3.el7.x86_64.rpm
 ccache --max-size=5G
+
+# optional, for kpatch-test
+sudo dnf install patchutils
 ```
 
 ####CentOS 7
@@ -83,7 +91,8 @@ ccache --max-size=5G
 Install the dependencies for compiling kpatch:
 
 ```bash
-sudo yum install gcc kernel-devel elfutils elfutils-devel
+UNAME=$(uname -r)
+sudo yum install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 ```
 
 Install the dependencies for the "kpatch-build" command:
@@ -96,12 +105,15 @@ sudo yum install rpmdevtools pesign yum-utils zlib-devel \
 # enable CentOS 7 debug repo
 sudo yum-config-manager --enable debug
 
-sudo yum-builddep kernel
-sudo debuginfo-install kernel
+sudo yum-builddep kernel-${UNAME%.*}
+sudo debuginfo-install kernel-${UNAME%.*}
 
 # optional, but highly recommended - enable EPEL 7
 sudo yum install ccache
 ccache --max-size=5G
+
+# optional, for kpatch-test
+sudo dnf install patchutils
 ```
 
 ####Oracle Linux 7
@@ -112,7 +124,8 @@ ccache --max-size=5G
 Install the dependencies for compiling kpatch:
 
 ```bash
-sudo yum install gcc kernel-devel elfutils elfutils-devel
+UNAME=$(uname -r)
+sudo yum install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 ```
 
 Install the dependencies for the "kpatch-build" command:
@@ -125,7 +138,7 @@ sudo yum install rpmdevtools pesign yum-utils zlib-devel \
 # enable ol7_optional_latest repo
 sudo yum-config-manager --enable ol7_optional_latest
 
-sudo yum-builddep kernel
+sudo yum-builddep kernel-${UNAME%.*}
 
 # manually install kernel debuginfo packages
 rpm -ivh https://oss.oracle.com/ol7/debuginfo/kernel-debuginfo-$(uname -r).rpm
@@ -134,6 +147,9 @@ rpm -ivh https://oss.oracle.com/ol7/debuginfo/kernel-debuginfo-common-x86_64-$(u
 # optional, but highly recommended - enable EPEL 7
 sudo yum install ccache
 ccache --max-size=5G
+
+# optional, for kpatch-test
+sudo dnf install patchutils
 ```
 
 ####Ubuntu 14.04


### PR DESCRIPTION
A small collection of documentation updates.

Tacking on part of the running kernel release is a little ugly, but I kept running into the situation where dnf/yum wants to install the lastest kernel-xyz package in Vagrant boxes if I omit a version spec.  The debuginfo lines for Oracle already do something this, so using the current kver throughout would be more consistent.