### PR TITLE
bump version to 0.4.0

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,6 +1,6 @@
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.3.4
+Version: 0.4.0
 License: GPLv2 
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-VERSION="0.3.4"
+VERSION="0.4.0"
 
 # Livepatch is built into the kernel, if it's not present
 # we must use kpatch core module.


### PR DESCRIPTION
This release has many fixes and improvements since 0.3.4.  The '0.3' was
bumped to '0.4' because of commit 0bb5c106ef18 ("kmod: restructure
kpatch sysfs tree"), which broke the ABI between the kpatch core module
and the kpatch script, as it changed the sysfs layout.

Other notable changes since 0.3.4:

- The tools underlying kpatch-build have been made more modular, in
  preparation for making create-diff-object more generally useful to
  other use cases (kernel livepatch, Xen live patching, user space
  patching).
- Support for all new upstream kernels up to 4.10.
- KASLR support.
- Many other bug fixes and improvements.