### PR TITLE
elf: add .eh_frame* sections to debug section list

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -71,7 +71,9 @@ int is_debug_section(struct section *sec)
 		name = sec->base->name;
 	else
 		name = sec->name;
-	return !strncmp(name, ".debug_", 7);
+
+	return !strncmp(name, ".debug_", 7) ||
+	       !strncmp(name, ".eh_frame", 9);
 }
 
 struct section *find_section_by_index(struct list_head *list, unsigned int index)


### PR DESCRIPTION
SUSE-based kernels have a DWARF unwinder, so they build with the gcc
'-fasynchronous-unwind-tables' flag, which adds .eh_frame and
.eh_frame_hdr sections.  Treat those sections like the other debug
sections.

Fixes: #703