### PR TITLE
create-diff-object: only check if kernel object starts with "vmlinux"

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -286,7 +286,7 @@ struct lookup_table *lookup_open(char *obj_path, char *symvers_path,
 		ERROR("malloc table");
 	memset(table, 0, sizeof(*table));
 
-	table->vmlinux = !strcmp(basename(obj_path), "vmlinux");
+	table->vmlinux = !strncmp(basename(obj_path), "vmlinux", 7);
 
 	obj_read(table, obj_path);
 	symvers_read(table, symvers_path);


### PR DESCRIPTION
On Debian/Ubuntu, the `vmlinux` from `-dbg` package has a version number
appended to it. For example:
`/usr/lib/debug/boot/vmlinux-3.13.0-117-generic`. Make it work
nonetheless.