### PR TITLE
lookup: silence maybe-uninitialized warnings for -O2

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -80,9 +80,9 @@ static int discarded_sym(struct lookup_table *table,
 static void find_local_syms(struct lookup_table *table, char *hint,
 			    struct sym_compare_type *child_locals)
 {
-	struct object_symbol *sym, *file_sym;
+	struct object_symbol *sym, *file_sym = NULL;
 	int i, in_file = 0;
-	struct sym_compare_type *child_sym;
+	struct sym_compare_type *child_sym = NULL;
 
 	if (!child_locals)
 		return;


### PR DESCRIPTION
When compiling with -O2, it fails with:
```
  gcc -MMD -MP -O2 -I../kmod/patch -Iinsn -Wall -g -Werror -c -o lookup.o lookup.c
  lookup.c: In function ‘lookup_open’:
  lookup.c:132:21: error: ‘file_sym’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     table->local_syms = file_sym;
     ~~~~~~~~~~~~~~~~~~^~~~~~~~~~
  lookup.c:83:30: note: ‘file_sym’ was declared here
    struct object_symbol *sym, *file_sym;
                                ^~~~~~~~
  lookup.c:129:27: error: ‘child_sym’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
    if (in_file && !child_sym->name) {
                    ~~~~~~~~~^~~~~~
  lookup.c:85:27: note: ‘child_sym’ was declared here
    struct sym_compare_type *child_sym;
                             ^~~~~~~~~
  cc1: all warnings being treated as errors
  Makefile:17: recipe for target 'lookup.o' failed
  make[1]: *** [lookup.o] Error 1
  make[1]: Leaving directory '/home/jpoimboe/git/kpatch/kpatch-build'
  Makefile:14: recipe for target 'build-kpatch-build' failed
  make: *** [build-kpatch-build] Error 2
```
As far as I can tell, these are false positive warnings.  When
in_file is 1, file_sym and child_sym are properly initialized.  But
silence the warnings anyway so Gentoo users can build with -O2.

Fixes: #675