### PR TITLE
kmod/core: fix dynrela writes for kernel 4.11+

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -676,7 +676,7 @@ static int kpatch_write_relocations(struct kpatch_module *kpmod,
 			continue;
 		}
 
-#ifdef CONFIG_DEBUG_SET_MODULE_RONX
+#if defined(CONFIG_DEBUG_SET_MODULE_RONX) || defined(CONFIG_ARCH_HAS_SET_MEMORY)
 #if (( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 5, 0) ) || \
      ( LINUX_VERSION_CODE >= KERNEL_VERSION(4, 4, 0) && \
       UTS_UBUNTU_RELEASE_ABI >= 7 ) \


### PR DESCRIPTION
Starting with kernel 4.11, CONFIG_DEBUG_SET_MODULE_RONX has been
replaced with CONFIG_ARCH_HAS_SET_MEMORY.  This fixes the following
error:

  kpatch: write to 0xffffffffc0d7650e failed for symbol copy_mnt_ns

Fixes #721.