### PR TITLE
kpatch-build: fix errors messages for missing files/dirs

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -259,36 +259,36 @@ while [[ $# -gt 0 ]]; do
 		exit 0
 		;;
 	-r|--sourcerpm)
+		[[ ! -f "$2" ]] && die "source rpm '$2' not found"
 		SRCRPM=$(readlink -f "$2")
 		shift
-		[[ ! -f "$SRCRPM" ]] && die "source rpm $SRCRPM not found"
 		rpmname=$(basename "$SRCRPM")
 		ARCHVERSION=${rpmname%.src.rpm}.$(uname -m)
 		ARCHVERSION=${ARCHVERSION#kernel-}
 		;;
 	-s|--sourcedir)
+		[[ ! -d "$2" ]] && die "source dir '$2' not found"
 		USERSRCDIR=$(readlink -f "$2")
 		shift
-		[[ ! -d "$USERSRCDIR" ]] && die "source dir $USERSRCDIR not found"
 		;;
 	-c|--config)
+		[[ ! -f "$2" ]] && die "config file '$2' not found"
 		CONFIGFILE=$(readlink -f "$2")
 		shift
-		[[ ! -f "$CONFIGFILE" ]] && die "config file $CONFIGFILE not found"
 		;;
 	-v|--vmlinux)
+		[[ ! -f "$2" ]] && die "vmlinux file '$2' not found"
 		VMLINUX=$(readlink -f "$2")
 		shift
-		[[ ! -f "$VMLINUX" ]] && die "vmlinux file $VMLINUX not found"
 		;;
 	-t|--target)
 		TARGETS="$TARGETS $2"
 		shift
 		;;
 	-o|--output)
+		[[ ! -d "$2" ]] && die "output dir '$2' not found"
 		BASE=$(readlink -f "$2")
 		shift
-		[[ ! -d "$BASE" ]] && die "output dir $BASE not found"
 		;;
 	-d|--debug)
 		echo "DEBUG mode enabled"
@@ -304,13 +304,9 @@ while [[ $# -gt 0 ]]; do
 		SKIPGCCCHECK=1
 		;;
 	--)
-		if [[ -z "$2" ]]; then
-			warn "no patch file specified"
-			usage
-			exit 1
-		fi
+		[[ -z "$2" ]] && die "no patch file specified"
+		[[ ! -f "$2" ]] && die "patch file '$2' not found"
 		PATCHFILE=$(readlink -f "$2")
-		[[ ! -f "$PATCHFILE" ]] && die "patch file $PATCHFILE not found"
 		break
 		;;
 	esac


### PR DESCRIPTION
If you give kpatch-build a bad argument for the '-s' option, it shows
the following error:

  $ kpatch-build/kpatch-build -s foo
  ERROR: source dir  not found.

The supplied 'foo' argument isn't printed as intended.

Also fix some other options which have a similar issue.