### PR TITLE
kpatch-build: check if DEBUG_INFO is enabled

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -559,8 +559,8 @@ KBUILD_EXTRA_SYMBOLS=""
 KPATCH_LDFLAGS=""
 KPATCH_MODULE=true
 
-# kernel option checking: CONFIG_DEBUG_KERNEL and CONFIG_LIVEPATCH
-grep -q "CONFIG_DEBUG_KERNEL=y" "$CONFIGFILE" || die "kernel doesn't have 'CONFIG_DEBUG_KERNEL' enabled"
+# kernel option checking
+grep -q "CONFIG_DEBUG_INFO=y" "$CONFIGFILE" || die "kernel doesn't have 'CONFIG_DEBUG_INFO' enabled"
 if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE"; then
 	# The kernel supports livepatch.
 	if version_gte ${ARCHVERSION//-*/} 4.7.0; then


### PR DESCRIPTION
Without this option kpatch-build dies with "ERROR: can't find special
struct alt_instr size.".

I just noticed this when trying to build a patch for a custom kernel which didn't have this option enabled. This error message would've helped.