### PR TITLE
Makefile.inc: replace uname -p with uname -m

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -3,7 +3,7 @@ CC    = gcc
 
 INSTALL = /usr/bin/install
 
-ARCH       = $(shell uname -p)
+ARCH       = $(shell uname -m)
 
 PREFIX    ?= /usr/local
 LIBDIR    ?= lib

--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -6,7 +6,7 @@ LDFLAGS += $(KPATCH_LDFLAGS)
 # ppc64le kernel modules are expected to compile with the
 # -mcmodel=large flag.  This enables 64-bit relocations
 # instead of a 32-bit offset from the TOC pointer.
-PROCESSOR = $(shell uname -p)
+PROCESSOR = $(shell uname -m)
 ifeq ($(PROCESSOR), ppc64le)
 KBUILD_CFLAGS_MODULE += -mcmodel=large
 endif


### PR DESCRIPTION
uname -p returns "unknown" on many systems effectively breaking the
build. Replace it with uname -m which yields the correct architecture.

I didn't touch kmod/patch/Makefile because I don't know what values uname -m will return on non-x86 architectures.