### PR TITLE
create-diff-object: rename mangled string sections

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -546,6 +546,24 @@ static void kpatch_correlate_symbols(struct list_head *symlist1, struct list_hea
 			if (is_special_static(sym1))
 				continue;
 
+			/*
+			 * The .LCx symbols point to strings, usually used for
+			 * the bug table.  Don't correlate and compare the
+			 * symbols themselves, because the suffix number might
+			 * change.
+			 *
+			 * If the symbol is used by the bug table (usual case),
+			 * it may get pulled in by
+			 * kpatch_regenerate_special_section().
+			 *
+			 * If the symbol is used outside of the bug table (not
+			 * sure if this actually happens anywhere), any string
+			 * changes will be detected elsewhere in rela_equal().
+			 */
+			if (sym1->type == STT_NOTYPE &&
+			    !strncmp(sym1->name, ".LC", 3))
+				continue;
+
 			/* group section symbols must have correlated sections */
 			if (sym1->sec &&
 			    sym1->sec->sh.sh_type == SHT_GROUP &&


### PR DESCRIPTION
When building the patch from PR #727, kpatch-build thought a .LC0 string
symbol moved to a different section.  In fact, its section got renamed
due to the GCC IPA SRA optimization.

Original object:
```
  [12] .rodata.__ip_append_data.isra.46.str1.1 PROGBITS     0000000000000000 000002e7 0000002e  1 AMS    0   0  1
  [13] .rodata.__ip_append_data.isra.46.str1.8 PROGBITS     0000000000000000 00000318 0000002a  1 AMS    0   0  8
  [14] .text.__ip_append_data.isra.46 PROGBITS     0000000000000000 00000350 00000a6d  0 AX     0   0 16
  [15] .rela.text.__ip_append_data.isra.46 RELA         0000000000000000 00053598 000001b0 24 I     110  14  8
```
Patched object:
```
  [12] .rodata.__ip_append_data.isra.47.str1.1 PROGBITS     0000000000000000 000002e7 0000002e  1 AMS    0   0  1
  [13] .rodata.__ip_append_data.isra.47.str1.8 PROGBITS     0000000000000000 00000318 0000002a  1 AMS    0   0  8
  [14] .text.__ip_append_data.isra.47 PROGBITS     0000000000000000 00000350 00000a5b  0 AX     0   0 16
  [15] .rela.text.__ip_append_data.isra.47 RELA         0000000000000000 00053820 000001b0 24 I     110  14  8
```
So we need to rename the .rodata.foo.isra.x.str1.* sections just like we
already do with the corresponding .text.foo.isra.x and
.rodata.foo.isra.x sections.

There's some ugly copy/paste code here that might be slightly improved
with a macro, but I don't feel inclined to do so :-)

Fixes #714.
Fixes #727.