### PR TITLE
kpatch-build: allow the number of make jobs to be specified using CPUS

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -326,6 +326,7 @@ usage() {
 	echo "		-s, --sourcedir	   Specify kernel source directory" >&2
 	echo "		-c, --config	   Specify kernel config file" >&2
 	echo "		-v, --vmlinux	   Specify original vmlinux" >&2
+	echo "		-j, --jobs	   Specify the number of make jobs" >&2
 	echo "		-t, --target	   Specify custom kernel build targets" >&2
 	echo "		-o, --output	   Specify output folder" >&2
 	echo "		-d, --debug	   Keep scratch files in /tmp" >&2
@@ -334,7 +335,7 @@ usage() {
 	echo "		                   (not recommended)" >&2
 }
 
-options=$(getopt -o hr:s:c:v:t:o:d -l "help,sourcerpm:,sourcedir:,config:,vmlinux:,target:,output:,debug,skip-gcc-check,skip-cleanup" -- "$@") || die "getopt failed"
+options=$(getopt -o hr:s:c:v:j:t:o:d -l "help,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,output:,debug,skip-gcc-check,skip-cleanup" -- "$@") || die "getopt failed"
 
 eval set -- "$options"
 
@@ -365,6 +366,11 @@ while [[ $# -gt 0 ]]; do
 	-v|--vmlinux)
 		[[ ! -f "$2" ]] && die "vmlinux file '$2' not found"
 		VMLINUX=$(readlink -f "$2")
+		shift
+		;;
+	-j|--jobs)
+		[[ ! "$2" -gt 0 ]] && die "Invalid number of make jobs '$2'"
+		CPUS="$2"
 		shift
 		;;
 	-t|--target)


### PR DESCRIPTION
Instead of always using the maximum number of CPUs available, allow
user to tune the number of make jobs using the environment variable
CPUS.