### PR TITLE
create-diff-object: treat "CSWTCH.*" as a special static local

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -96,6 +96,7 @@ static int is_special_static(struct symbol *sym)
 		"descriptor.",
 		"__func__.",
 		"_rs.",
+		"CSWTCH.",
 		NULL,
 	};
 	char **prefix;


### PR DESCRIPTION
Normally, kpatch doesn't complain if you remove or rename a function.
This is a feature, because sometimes you have to rename a function in
order to patch it, if for example it doesn't have an fentry call.  In
the object code, it's treated as a new function.  You could get the same
result by copying/pasting the original function and giving the copy a
new name.  But renaming it makes it much easier to review the patch.

In RHEL 7.4, I tried to rename l2cap_config_rsp() to
l2cap_config_rsp_kpatch(), but it failed with:

  ERROR: l2cap_core.o: reference to static local variable CSWTCH.347 in l2cap_config_rsp was removed

This particular error is an easy fix, because the CSWTCH.* symbols are
read-only and are created by GCC.  So they shouldn't be correlated
anyway.

In the future, we will need a more general fix to allow the removal of
functions which use *any* static local variables.  Either automatically,
or by adding a manual annotation.  This can be handled when we rewrite
the static local variable handling in #545.