### PR TITLE
kpatch: fix kpatch-build matching changed object bug

### DIFF
--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -38,7 +38,8 @@ if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
 				arch/x86/entry/vdso/*|\
 				drivers/firmware/efi/libstub/*|\
 				arch/powerpc/kernel/prom_init.o|\
-				*.*.o)
+				.*.o|\
+				*/.lib_exports.o)
 					break
 					;;
 				*.o)


### PR DESCRIPTION
When there is a ".." in the source object path, kpatch-gcc can't handle
it correctly.  kpatch-gcc is called for objects which were recompiled
and writes the changed objects to "changed_objs". But if the path of the
input obj is something like:

  arch/x86/kvm/../../../virt/kvm/.tmp_kvm_main.o

then it will fall into the "*.*.o" branch of the kpatch-gcc case
statement and kpatch-build will report "ERROR: no changed objects
found."

Use Joe's suggestion to revert d526805619de ("kpatch-gcc: update
ignorelist to avoid foo/.lib_exports.o files") and instead add a
"*/.lib_exports.o" pattern.

Fixes #735.

[ cleaned up changelog - jpoimboe@redhat.com ]

Cc: Joe Lawrence <joe.lawrence@redhat.com>
Signed-off-by: chen xiaoguang <xiaoggchen@tencent.com>