### PR TITLE
kpatch-build: clear Elf_Data d_buf buffer on allocation

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -626,6 +626,7 @@ struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
 	sec->data->d_buf = malloc(size);
 	if (!sec->data->d_buf)
 		ERROR("malloc");
+	memset(sec->data->d_buf, 0, size);
 	sec->data->d_size = size;
 	sec->data->d_type = ELF_T_BYTE;
 


### PR DESCRIPTION
Valgrind complains about uninitialized bytes passed to pwrite64(buf)
from kpatch_write_output_elf()'s call to elf_update():

  ==32378== Syscall param pwrite64(buf) points to uninitialised byte(s)
  ==32378==    at 0x5141A03: __pwrite_nocancel (in /usr/lib64/libc-2.23.so)
  ==32378==    by 0x4E46846: ??? (in /usr/lib64/libelf-0.168.so)
  ==32378==    by 0x4E42B88: elf_update (in /usr/lib64/libelf-0.168.so)
  ==32378==    by 0x40C57A: kpatch_write_output_elf (kpatch-elf.c:895)
  ==32378==    by 0x40926F: main (create-diff-object.c:2851)
  ==32378==  Address 0x28d52300 is 0 bytes inside a block of size 56 alloc'd
  ==32378==    at 0x4C2BBAD: malloc (vg_replace_malloc.c:299)
  ==32378==    by 0x40B86A: create_section_pair (kpatch-elf.c:707)
  ==32378==    by 0x406CAE: kpatch_create_patches_sections (create-diff-object.c:2109)
  ==32378==    by 0x4090C5: main (create-diff-object.c:2815)

These are fields which we don't need to populate (like a
funcs[index].new_addr value that will be filled by relocation).  The
easiest way to appease valgrind and not clutter the code is to just
zero-out this entire buffer on allocation.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>