### PR TITLE
kpatch-build: create-klp-module: set default arguments.no_klp_arch

### DIFF
--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -449,7 +449,7 @@ int main(int argc, char *argv[])
 	char *strings;
 	int ksyms_nr, krelas_nr;
 
-	arguments.debug = 0;
+	memset(&arguments, 0, sizeof(arguments));
 	argp_parse (&argp, argc, argv, 0, 0, &arguments);
 	if (arguments.debug)
 		loglevel = DEBUG;


### PR DESCRIPTION
Valgrind complains about an uninitialized variable in
create-klp-module.c:

  ==4412== Conditional jump or move depends on uninitialised value(s)
  ==4412==    at 0x402846: main (create-klp-module.c:497)

This warning refers to main()'s struct arguments stack variable,
precisely its .no_klp_arch member.  Initialize it to zero to avoid the
complaint.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>