### PR TITLE
kpatch: add ABI backwards compatibility

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -27,14 +27,6 @@ INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 VERSION="0.4.0"
 
-# Livepatch is built into the kernel, if it's not present
-# we must use kpatch core module.
-if [[ -e /sys/kernel/livepatch ]] ; then
-	SYSFS="/sys/kernel/livepatch"
-else
-	SYSFS="/sys/kernel/kpatch"
-fi
-
 usage_cmd() {
 	printf '   %-20s\n      %s\n' "$1" "$2" >&2
 }
@@ -132,6 +124,23 @@ get_module_name () {
 	echo $(readelf -p .gnu.linkonce.this_module $1 | grep '\[.*\]' | awk '{print $3}')
 }
 
+init_sysfs_var() {
+	# If the kernel is configured with CONFIG_LIVEPATCH, use that.
+	# Otherwise, use the kpatch core module (kpatch.ko).
+	if [[ -e /sys/kernel/livepatch ]] ; then
+		# livepatch ABI
+		SYSFS="/sys/kernel/livepatch"
+
+	elif [[ -e /sys/kernel/kpatch/patches ]] ; then
+		# kpatch pre-0.4 ABI
+		SYSFS="/sys/kernel/kpatch/patches"
+
+	else
+		# kpatch 0.4 ABI
+		SYSFS="/sys/kernel/kpatch"
+	fi
+}
+
 verify_module_checksum () {
 	modname=$(get_module_name $1)
 	[[ -z $modname ]] && return 1
@@ -158,6 +167,10 @@ load_module () {
 			echo "loading core module: $COREMOD"
 			insmod "$COREMOD" || die "failed to load core module"
 		fi
+
+		# Now that the core module has been loaded, set $SYSFS to the
+		# correct value based on the loaded core module's ABI.
+		init_sysfs_var
 	fi
 
 	local modname=$(get_module_name $module)
@@ -222,6 +235,12 @@ get_module_version() {
 }
 
 unset MODULE
+
+# Initialize the $SYSFS var.  This only works if the core module has been
+# loaded.  Otherwise, the value of $SYSFS doesn't matter at this point anyway,
+# and we'll have to call this function again after loading it.
+init_sysfs_var
+
 [[ "$#" -lt 1 ]] && usage
 case "$1" in
 "load")


### PR DESCRIPTION
When running a kernel for a long period of time without rebooting, it's
possible that newer versions of the kpatch script may get installed.  So
new versions of the kpatch script need to support old versions of
kpatch.ko.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>