### PR TITLE
kpatch-build: Fix clean rule (remove insn/*.o)

### DIFF
--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -35,4 +35,4 @@ uninstall:
 	$(RM) $(BINDIR)/kpatch-build
 
 clean:
-	$(RM) $(TARGETS) *.o *.d insn/*.d
+	$(RM) $(TARGETS) *.o *.d insn/*.o insn/*.d


### PR DESCRIPTION
Might result in build failures or unexpected behaviour otherwise.