### PR TITLE
More ppc64le fixes

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -47,7 +47,8 @@
 #define HAVE_SYMPOS
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0) ||			\
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0) &&			\
+     LINUX_VERSION_CODE <= KERNEL_VERSION(4, 15, 0)) ||			\
     defined(RHEL_RELEASE_CODE)
 #define HAVE_IMMEDIATE
 #endif

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1296,12 +1296,11 @@ static void kpatch_verify_patchability(struct kpatch_elf *kelf)
 
 		/*
 		 * ensure we aren't including .data.* or .bss.*
-		 * (.data.unlikely is ok b/c it only has __warned vars)
+		 * (.data.unlikely and .data.once is ok b/c it only has __warned vars)
 		 */
 		if (sec->include && sec->status != NEW &&
-		    (!strncmp(sec->name, ".data", 5) ||
-		     !strncmp(sec->name, ".bss", 4)) &&
-		    strcmp(sec->name, ".data.unlikely")) {
+		    (!strncmp(sec->name, ".data", 5) || !strncmp(sec->name, ".bss", 4)) &&
+		    (strcmp(sec->name, ".data.unlikely") && strcmp(sec->name, ".data.once"))) {
 			log_normal("data section %s selected for inclusion\n",
 				   sec->name);
 			errs++;

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1168,17 +1168,6 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 			}
 
 #ifdef __powerpc__
-			/*
-			 * With -mcmodel=large, R_PPC64_REL24 is only used for
-			 * functions.  Assuming the function is bundled in a
-			 * section, the section symbol should have been
-			 * replaced with a text symbol already.  Otherwise,
-			 * bail out.  If we hit this situation, more core is
-			 * needed here to calculate the value of 'add_off'.
-			 */
-			if (rela->type == R_PPC64_REL24)
-				ERROR("Unexpected relocation type R_PPC64_REL24 for %s\n", rela->sym->name);
-
 			add_off = 0;
 #else
 			if (rela->type == R_X86_64_PC32) {


### PR DESCRIPTION
This patchset fixes couple of corner cases seen on POWER and one architecture independent fix for `.data.once` section, which gets created with recent upstream kernel changes. This patchset applies on top of #757.