### PR TITLE
kpatch: a couple small enhancements in retry logic

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -29,6 +29,11 @@ VERSION="0.5.0"
 POST_ENABLE_WAIT=5	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 
+# How many times to try loading the patch if activeness safety check fails.
+MAX_LOAD_ATTEMPTS=5
+# How long to wait before retry, in seconds.
+RETRY_INTERVAL=2
+
 usage_cmd() {
 	printf '   %-20s\n      %s\n' "$1" "$2" >&2
 }
@@ -325,12 +330,12 @@ load_module () {
 		# "Device or resource busy" means the activeness safety check
 		# failed.  Retry in a few seconds.
 		i=$((i+1))
-		if [[ $i = 5 ]]; then
+		if [[ $i = $MAX_LOAD_ATTEMPTS ]]; then
 			die "failed to load module $module"
 			break
 		else
 			warn "retrying..."
-			sleep 2
+			sleep $RETRY_INTERVAL
 		fi
 	done
 

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -316,7 +316,7 @@ load_module () {
 	echo "loading patch module: $module"
 	local i=0
 	while true; do
-		out="$(insmod "$module" 2>&1)"
+		out="$(LC_ALL=C insmod "$module" 2>&1)"
 		[[ -z "$out" ]] && break
 		echo "$out" 1>&2
 		[[ ! "$out" =~ "Device or resource busy" ]] &&


### PR DESCRIPTION
The first of the changes is to makes sure we get "Device or resource busy" message in English when it is output by insmod. kpatch does not expect it in any other language, so let us force "C" locale here.

The other change is rather small too, it just makes it easier to adjust the number of attempts to load the patches, as well as the interval between retries by putting them into easy to find variables. This is especially helpful for the "old-style" (not livepatch-based) patches when doing stress testing, etc. In such conditions, I often had to increase both the number of attempts and the interval.