### PR TITLE
kmod/core: fix definition of KERNELRELEASE

### DIFF
--- a/kmod/core/Makefile
+++ b/kmod/core/Makefile
@@ -1,6 +1,6 @@
 # make rules
 KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
-KERNELRELEASE := $(lastword $(subst /, , $(dir $(KPATCH_BUILD))))
+KERNELRELEASE := $(lastword $(subst /, , $(dir $(patsubst %/,%,$(KPATCH_BUILD)))))
 THISDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 ifeq ($(wildcard $(KPATCH_BUILD)),)


### PR DESCRIPTION
A cosmetic fix.

If KPATCH_BUILD ending with 'build/' is passed to 'make', KERNELRELEASE
will become 'build' and the error message will look like:

"<...> doesn't exist. Try installing the kernel-devel-build RPM or
linux-headers-build DEB."

Let us fix that.

Signed-off-by: Evgenii Shatokhin <eshatokhin@virtuozzo.com>