### PR TITLE
Do not mention initrd in the help messages and in the man page

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -44,8 +44,8 @@ usage () {
 	echo "usage: kpatch <command> [<args>]" >&2
 	echo >&2
 	echo "Valid commands:" >&2
-	usage_cmd "install [-k|--kernel-version=<kernel version>] <module>" "install patch module to the initrd to be loaded at boot"
-	usage_cmd "uninstall [-k|--kernel-version=<kernel version>] <module>" "uninstall patch module from the initrd"
+	usage_cmd "install [-k|--kernel-version=<kernel version>] <module>" "install patch module to be loaded at boot"
+	usage_cmd "uninstall [-k|--kernel-version=<kernel version>] <module>" "uninstall patch module"
 	echo >&2
 	usage_cmd "load --all" "load all installed patch modules into the running kernel"
 	usage_cmd "load <module>" "load patch module into the running kernel"

--- a/man/kpatch.1
+++ b/man/kpatch.1
@@ -12,10 +12,10 @@ the system.
 .SH COMMANDS
 
 install [-k|--kernel-version=<kernel version>] <module>
-       install patch module to the initrd to be loaded at boot
+       install patch module to be loaded at boot
 
 uninstall [-k|--kernel-version=<kernel version>] <module>
-       uninstall patch module from the initrd
+       uninstall patch module
 
 load --all
        load all installed patch modules into the running kernel


### PR DESCRIPTION
Kpatch no longer uses initrd to make sure the patch modules are loaded
at boot. The users could either install the provided systemd service
for that or come up with some other solution.

The messages mentioning initrd could confuse the users.

Signed-off-by: Evgenii Shatokhin <eshatokhin@virtuozzo.com>