### PR TITLE
[RFC] PC64le - do not use the patched functions as callbacks directly

### DIFF
--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -20,6 +20,7 @@
 #ifndef _KPATCH_ELF_H_
 #define _KPATCH_ELF_H_
 
+#include <stdbool.h>
 #include <gelf.h>
 #include "list.h"
 #include "log.h"
@@ -90,6 +91,7 @@ struct rela {
 	int addend;
 	int offset;
 	char *string;
+	bool need_dynrela;
 };
 
 struct string {


### PR DESCRIPTION
It was observed by Evgenii Shatokhin in #755, that when the RCU callback was called on the patched function, from unloaded livepatch module triggered a kernel crash.

This patch implements the approach on Powerpc outlined in #755. With -mcmodel=large, like any other data, function pointers are also loaded relative to the current TOC base and are populated as relocation entries in .toc section. Every function call/passing such function as pointers needs to access them through .toc section + offset.

The simplest approach would be to convert the .toc + offset relocation into a dynamic rela referring to the original function address but the same function is also a patched function. Thus, on PowerPC we need to append a new relocation entry into .rela.toc, duplicating the entry used as a function pointer and converting the newly added rela as dynamic rela.

Also, modify the function to load the new entry by modifying the addend value to newly created dynamic rela.