### PR TITLE
8D Use the correct version suffix when moving the extracted kernel

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -620,7 +620,7 @@ else
 		echo "Downloading and unpacking the kernel source for $ARCHVERSION"
 		# Download source deb pkg
 		(dget -u "$url/${pkgname}/${dscname}" 2>&1) | logger || die "dget: Could not fetch/unpack $url/${pkgname}/${dscname}"
-		mv "${pkgname}-$KVER" "$SRCDIR" || die
+		mv "${pkgname}-${pkgver%%-*}" "$SRCDIR" || die
 		cp "/boot/config-${ARCHVERSION}" "$SRCDIR/.config" || die
 		if [[ "$ARCHVERSION" == *-* ]]; then
 			echo "-${ARCHVERSION#*-}" > "$SRCDIR/localversion" || die


### PR DESCRIPTION
On a fresh debian stretch install, `kpatch-build` uses the wrong version due to a discretion between the apt version for `linux-image` and the actual source version number:

    # uname -r
    4.9.0-6-amd64
    # dpkg-query -W "linux-image-4.9.0-6-amd64"
    linux-image-4.9.0-6-amd64	4.9.82-1+deb9u3

so `kpatch-build` incorrectly guesses the path for the extracted kernel by using `KVER`. I haven't tested this change on Ubuntu, but under Debian patches successfully compile now.