### PR TITLE
create-diff-object: Use .rela.toc as list head in kpatch_correlate_st…

### DIFF
--- a/test/integration/centos-7/gcc-static-local-var-6.patch
+++ b/test/integration/centos-7/gcc-static-local-var-6.patch
@@ -1,0 +1,14 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index a9d587a..23336ed 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -119,6 +121,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/fedora-27/gcc-static-local-var-6.patch
+++ b/test/integration/fedora-27/gcc-static-local-var-6.patch
@@ -1,0 +1,14 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index 9bf2604..026ac6c 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -122,6 +124,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/ubuntu-16.04/gcc-static-local-var-6.patch
+++ b/test/integration/ubuntu-16.04/gcc-static-local-var-6.patch
@@ -1,0 +1,14 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index 39970e2..85e750d 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -121,6 +123,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)


### PR DESCRIPTION
…atic_local_variables

kpatch_correlate_static_local_variables() assumes that the .text
sections are parsed ahead of .rodata sections and the references to
static local variable are correlated by the .text section rela
referring them. This assumption is not true on PowerPC, as all data
loads for -mcmodel=large are loaded from .toc section + offset and
fails with the error:

ERROR: netfilter.o: reference to static local variable fake_pinfo.63552 in fake_sk.63553 was removed

As per PPC64le ABIv2:
"TOC may straddle the boundary between initialized and uninitialized
data in the data segment."

$ readelf -s ./net/ipv6/netfilter.o
...
  [16] .rodata.__func__.63533
  [17] .rodata.fake_sk.63553
  [18] .rela.rodata.fake_sk.63553
...
  [28] .toc              PROGBITS
  [29] .rela.toc         RELA
  [30] .data             PROGBITS
  [31] .data.rel.ro.ipv6ops PROGBITS

fix this issue by looping .toc as section head if available, creating
the correlation by referring to section twin of .rela.toc.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>