### PR TITLE
Fix resulting module vermagic when source dir is a git tree

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -104,15 +104,16 @@ remove_patches() {
 		patch="${PATCH_LIST[$idx]}"
 		patch -p1 -R -d "$SRCDIR" < "$patch" &> /dev/null
 	done
+
+	# If $SRCDIR was a git repo, make sure git actually sees that
+	# we've reverted our patch(es).
+	[[ -d "$SRCDIR/.git" ]] && (cd "$SRCDIR" && git update-index -q --refresh)
 }
 
 cleanup() {
 	rm -f "$SRCDIR/.scmversion"
 
 	remove_patches
-	# If $SRCDIR was a git repo, make sure git actually sees that
-	# we've reverted our patch(es).
-	[[ -d "$SRCDIR/.git" ]] && (cd "$SRCDIR" && git update-index -q --refresh)
 
 	# restore original .config and vmlinux if they were removed with mrproper
 	[[ -e "$TEMPDIR/.config" ]] && mv -f "$TEMPDIR/.config" "$SRCDIR/"


### PR DESCRIPTION
Sometimes git doesn't see that the patches have been reverted, if that
happens during ./scripts/setlocalversion call the resulting patch module
is built with a wrong vermagic because the tree is still considered
dirty.

Fix by moving git update-index call into remove_patches function so that
it is called every time the patches are reverted, not only on cleanup.

Signed-off-by: Artem Savkov <asavkov@redhat.com>