### PR TITLE
gcc-plugin: run the plugin at an earlier pass

### DIFF
--- a/kpatch-build/gcc-plugins/ppc64le-plugin.c
+++ b/kpatch-build/gcc-plugins/ppc64le-plugin.c
@@ -72,7 +72,7 @@ int plugin_init(struct plugin_name_args *plugin_info,
 {
 	const char * const plugin_name = plugin_info->base_name;
 
-	PASS_INFO(ppc64le_plugin, "dwarf2", 1, PASS_POS_INSERT_BEFORE);
+	PASS_INFO(ppc64le_plugin, "vregs", 1, PASS_POS_INSERT_AFTER);
 
 	if (!plugin_default_version_check(version, &gcc_version))
                 error(1, 0, PLUGIN_NAME ": incompatible gcc/plugin versions");


### PR DESCRIPTION
On ppc64le, building drivers/media/i2c/cx25840/cx25840.ko with GCC 4.85,
the plugin triggers the following errors:

  {standard input}: Assembler messages:
  {standard input}:1078: Error: operand out of range (0x0000000000008fd4 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:1288: Error: operand out of range (0x000000000000874c is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:3844: Error: operand out of range (0x00000000000080e8 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:4028: Error: operand out of range (0x00000000000082b4 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:4031: Error: operand out of range (0x00000000000080b4 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:6661: Error: operand out of range (0x000000000000841c is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:6664: Error: operand out of range (0x0000000000008214 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:6845: Error: operand out of range (0x00000000000089dc is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:6848: Error: operand out of range (0x00000000000087d4 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:7587: Error: operand out of range (0x0000000000008930 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:7590: Error: operand out of range (0x0000000000008728 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  {standard input}:14592: Error: operand out of range (0xffffffffffff79b8 is not between 0xffffffffffff8000 and 0x0000000000007ffc)
  make[1]: *** [drivers/media/i2c/cx25840/cx25840-core.o] Error 1

The problem is that the plugin nops were inserted too late.  GCC laid
out the code with knowledge about the distance between branches, but
then the plugin came along after that and increased the branch distances
by inserting the nops.

Fix it by inserting the nops as early as possible.  The 'vregs' pass is
where the insn codes get initialized, so run the plugin immediately
afterwards.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>

/cc @kamalesh-babulal 