### PR TITLE
create-diff-object: Fix PPC64_LOCAL_ENTRY_OFFSET usage

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -137,7 +137,7 @@ static int is_bundleable(struct symbol *sym)
  */
 static int is_gcc6_localentry_bundled_sym(struct symbol *sym)
 {
-	return (PPC64_LOCAL_ENTRY_OFFSET(sym->sym.st_other) &&
+	return ((PPC64_LOCAL_ENTRY_OFFSET(sym->sym.st_other) != 0) &&
 		sym->sym.st_value == 8);
 }
 #else


### PR DESCRIPTION
GCC 7.2.1 complains about the usage of the PPC64_LOCAL_ENTRY_OFFSET
macro:

  create-diff-object.c: In function ‘is_gcc6_localentry_bundled_sym’:
  create-diff-object.c:119:83: error: ‘<<’ in boolean context, did you mean ‘<’ ? [-Werror=int-in-bool-context]
            (((1 << (((other) & STO_PPC64_LOCAL_MASK) >> STO_PPC64_LOCAL_BIT)) >> 2) << 2)
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
  create-diff-object.c:140:10: note: in expansion of macro ‘PPC64_LOCAL_ENTRY_OFFSET’
    return (PPC64_LOCAL_ENTRY_OFFSET(sym->sym.st_other) &&
          ^~~~~~~~~~~~~~~~~~~~~~~~

Fix it by explicitly treating the macro as an integer instead of a bool.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>

/cc @kamalesh-babulal 