### PR TITLE
Prepare for built-in.o -> built-in.a rename

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -343,6 +343,7 @@ find_kobj() {
 			[[ "$KOBJFILE" = *.ko ]] && return
 			case "$KOBJFILE" in
 				*/built-in.o|\
+				*/built-in.a|\
 				arch/x86/lib/lib.a|\
 				arch/x86/kernel/head*.o|\
 				arch/x86/kernel/ebda.o|\

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -26,6 +26,7 @@ if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
 			case "$obj" in
 				*.mod.o|\
 				*built-in.o|\
+				*built-in.a|\
 				vmlinux.o|\
 				.tmp_kallsyms1.o|\
 				.tmp_kallsyms2.o|\

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -30,6 +30,7 @@ do
 	case $i in
 		*.mod.o|\
 		*built-in.o|\
+		*built-in.a|\
 		vmlinux.o|\
 		.tmp_kallsyms1.o|\
 		.tmp_kallsyms2.o|\


### PR DESCRIPTION
for-next branch of kbuild repo contains a "kbuild: rename built-in.o to
built-in.a" which renames all built-in.o instances. Filter on both .o
and .a in kpatch-gcc/kpatch-build to be prepared for this change.

Fixes #800.

Signed-off-by: Artem Savkov <asavkov@redhat.com>