### PR TITLE
gitignore: ignore cache.mk from newer kernel builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.so
 .tmp_versions
 Module.symvers
+kmod/core/.cache.mk
 kpatch-build/lookup
 kpatch-build/create-diff-object
 kpatch-build/create-klp-module


### PR DESCRIPTION
Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>