### PR TITLE
drop unused rpmdevtools dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ sudo dnf install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 Install the dependencies for the "kpatch-build" command:
 
 ```bash
-sudo dnf install rpmdevtools pesign yum-utils openssl wget numactl-devel
+sudo dnf install pesign yum-utils openssl wget numactl-devel
 sudo dnf builddep kernel-${UNAME%.*}
 sudo dnf debuginfo-install kernel-${UNAME%.*}
 
@@ -68,7 +68,7 @@ Install the dependencies for the "kpatch-build" command:
 
 ```bash
 sudo yum-config-manager --enable rhel-7-server-optional-rpms
-sudo yum install rpmdevtools pesign yum-utils zlib-devel \
+sudo yum install pesign yum-utils zlib-devel \
   binutils-devel newt-devel python-devel perl-ExtUtils-Embed \
   audit-libs-devel numactl-devel pciutils-devel bison ncurses-devel
 
@@ -98,7 +98,7 @@ sudo yum install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 Install the dependencies for the "kpatch-build" command:
 
 ```bash
-sudo yum install rpmdevtools pesign yum-utils zlib-devel \
+sudo yum install pesign yum-utils zlib-devel \
   binutils-devel newt-devel python-devel perl-ExtUtils-Embed \
   audit-libs audit-libs-devel numactl-devel pciutils-devel bison
 
@@ -131,7 +131,7 @@ sudo yum install gcc kernel-devel-${UNAME%.*} elfutils elfutils-devel
 Install the dependencies for the "kpatch-build" command:
 
 ```bash
-sudo yum install rpmdevtools pesign yum-utils zlib-devel \
+sudo yum install pesign yum-utils zlib-devel \
   binutils-devel newt-devel python-devel perl-ExtUtils-Embed \
   audit-libs numactl-devel pciutils-devel bison
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -563,7 +563,6 @@ else
 	if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]]; then
 
 		echo "Fedora/Red Hat distribution detected"
-		rpm -q --quiet rpmdevtools || die "rpmdevtools not installed"
 
 		clean_cache
 

--- a/test/integration/centos-7/remote-setup
+++ b/test/integration/centos-7/remote-setup
@@ -20,7 +20,7 @@ install_rpms() {
 	$sudo dnf install -y $* || $sudo dnf install -y $*
 }
 
-install_rpms gcc elfutils elfutils-devel rpmdevtools pesign openssl numactl-devel wget patchutils
+install_rpms gcc elfutils elfutils-devel pesign openssl numactl-devel wget patchutils
 
 $sudo dnf builddep -y kernel || $sudo dnf builddep -y kernel
 

--- a/test/integration/fedora-25/remote-setup
+++ b/test/integration/fedora-25/remote-setup
@@ -20,7 +20,7 @@ install_rpms() {
 	$sudo dnf install -y $* || $sudo dnf install -y $*
 }
 
-install_rpms gcc elfutils elfutils-devel rpmdevtools pesign openssl numactl-devel wget patchutils
+install_rpms gcc elfutils elfutils-devel pesign openssl numactl-devel wget patchutils
 
 $sudo dnf builddep -y kernel || $sudo dnf builddep -y kernel
 


### PR DESCRIPTION
It appears that since 0dec5136eef945aa086a0290b3a8de65393fdf5f nothing
has been used from the rpmdevtools package by kpatch-build.

Signed-off-by: Doug Goldstein <cardoe@cardoe.com>