### PR TITLE
sparse: quiet latest trivial complaints

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -139,7 +139,7 @@ static int (*kpatch_set_memory_ro)(unsigned long addr, int numpages);
 
 #define MAX_STACK_TRACE_DEPTH   64
 static unsigned long stack_entries[MAX_STACK_TRACE_DEPTH];
-struct stack_trace trace = {
+static struct stack_trace trace = {
 	.max_entries	= ARRAY_SIZE(stack_entries),
 	.entries	= &stack_entries[0],
 };

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -71,7 +71,7 @@
  *  done, the scaffold structs are no longer needed.
  */
 
-struct klp_patch *lpatch;
+static struct klp_patch *lpatch;
 
 static LIST_HEAD(patch_objects);
 static int patch_objects_nr;


### PR DESCRIPTION
Fixes sparse warnings:

  kmod/core/core.c:142:20: warning: symbol 'trace' was not declared. Should it be static?

  livepatch-patch-hook.c:73:18: warning: symbol 'lpatch' was not declared. Should it be static?

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>