### PR TITLE
Cross compilation fixes

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -387,12 +387,13 @@ usage() {
 	echo "		                   (can be specified multiple times)" >&2
 	echo "		--cross-compile    Specify the prefix used for all executables" >&2
 	echo "		                   used during compilation" >&2
+	echo "		--distro           Override distro name" >&2
 	echo "		--skip-cleanup     Skip post-build cleanup" >&2
 	echo "		--skip-gcc-check   Skip gcc version matching check" >&2
 	echo "		                   (not recommended)" >&2
 }
 
-options="$(getopt -o ha:r:s:c:v:j:t:n:o:d -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,cross-compile:,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
+options="$(getopt -o ha:r:s:c:v:j:t:n:o:d -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,cross-compile:,distro:,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"
 
@@ -452,6 +453,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--cross-compile)
 		KPATCH_CROSS_COMPILE="$2"
+		shift
+		;;
+	--distro)
+		DISTRO="$2"
 		shift
 		;;
 	--skip-cleanup)
@@ -530,7 +535,7 @@ fi
 # Don't check external file.
 # shellcheck disable=SC1091
 source /etc/os-release
-DISTRO="$ID"
+DISTRO="${DISTRO:-${ID}}"
 if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]]; then
 	[[ -z "$VMLINUX" ]] && VMLINUX="/usr/lib/debug/lib/modules/$ARCHVERSION/vmlinux"
 	[[ -e "$VMLINUX" ]] || die "kernel-debuginfo-$ARCHVERSION not installed"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -198,7 +198,7 @@ gcc_version_check() {
 	# gcc --version varies between distributions therefore extract version
 	# by compiling a test file and compare it to vmlinux's version.
 	echo 'void main(void) {}' > "$c"
-	out="$(gcc -c -pg -ffunction-sections -o "$o" "$c" 2>&1)"
+	out="$(${KPATCH_CROSS_COMPILE}gcc -c -pg -ffunction-sections -o "$o" "$c" 2>&1)"
 	gccver="$(gcc_version_from_file "$o")"
 	kgccver="$(gcc_version_from_file "$VMLINUX")"
 	rm -f "$c" "$o"
@@ -385,12 +385,14 @@ usage() {
 	echo "		-d, --debug        Enable 'xtrace' and keep scratch files" >&2
 	echo "		                   in <CACHEDIR>/tmp" >&2
 	echo "		                   (can be specified multiple times)" >&2
+	echo "		--cross-compile    Specify the prefix used for all executables" >&2
+	echo "		                   used during compilation" >&2
 	echo "		--skip-cleanup     Skip post-build cleanup" >&2
 	echo "		--skip-gcc-check   Skip gcc version matching check" >&2
 	echo "		                   (not recommended)" >&2
 }
 
-options="$(getopt -o ha:r:s:c:v:j:t:n:o:d -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
+options="$(getopt -o ha:r:s:c:v:j:t:n:o:d -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,cross-compile:,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"
 
@@ -447,6 +449,10 @@ while [[ $# -gt 0 ]]; do
 		if [[ $DEBUG -eq 1 ]]; then
 			echo "DEBUG mode enabled"
 		fi
+		;;
+	--cross-compile)
+		KPATCH_CROSS_COMPILE="$2"
+		shift
 		;;
 	--skip-cleanup)
 		echo "Skipping cleanup"
@@ -694,6 +700,8 @@ if [[ $DEBUG -ge 4 ]]; then
 	export KPATCH_GCC_DEBUG=1
 fi
 
+export KPATCH_CROSS_COMPILE
+
 echo "Building original kernel"
 ./scripts/setlocalversion --save-scmversion || die
 make mrproper 2>&1 | logger || die
@@ -848,6 +856,7 @@ cd "$TEMPDIR/patch" || die
 KPATCH_BUILD="$SRCDIR" KPATCH_NAME="$MODNAME" \
 KBUILD_EXTRA_SYMBOLS="$KBUILD_EXTRA_SYMBOLS" \
 KPATCH_LDFLAGS="$KPATCH_LDFLAGS" \
+CROSS_COMPILE="$KPATCH_CROSS_COMPILE" \
 	make 2>&1 | logger || die
 
 if ! "$KPATCH_MODULE"; then

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -8,7 +8,7 @@ TOOLCHAINCMD="$1"
 shift
 
 if [[ -z "$KPATCH_GCC_TEMPDIR" ]]; then
-	exec "$TOOLCHAINCMD" "$@"
+	exec ${KPATCH_CROSS_COMPILE}${TOOLCHAINCMD} "$@"
 fi
 
 declare -a args=("$@")
@@ -81,4 +81,4 @@ elif [[ "$TOOLCHAINCMD" = "ld" ]] ; then
 	done
 fi
 
-exec "$TOOLCHAINCMD" "${args[@]}"
+exec ${KPATCH_CROSS_COMPILE}${TOOLCHAINCMD} "${args[@]}"


### PR DESCRIPTION
These two patches allow cross-compiled LivePatch generation.
They fix two cross-compile scenarios:
 - building LivePatch for another architecture
 - building LivePatch for another distro

This has been tested on OpenEmbedded build system.