### PR TITLE
Adding support to upstart systems.

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -15,6 +15,7 @@ LIBEXECDIR = $(DESTDIR)$(PREFIX)/$(LIBEXEC)/kpatch
 DATADIR    = $(DESTDIR)$(PREFIX)/share/kpatch
 MANDIR     = $(DESTDIR)$(PREFIX)/share/man/man1
 SYSTEMDDIR = $(DESTDIR)$(PREFIX)/lib/systemd/system
+UPSTARTDIR = $(DESTDIR)/etc/init
 
 # The core module is only supported on x86_64
 ifeq ($(ARCH),x86_64)

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -6,8 +6,12 @@ install: all
 	$(INSTALL) -d $(SYSTEMDDIR)
 	$(INSTALL) -m 0644 kpatch.service $(SYSTEMDDIR)
 	sed -i 's~PREFIX~$(PREFIX)~' $(SYSTEMDDIR)/kpatch.service
+	$(INSTALL) -d $(UPSTARTDIR)
+	$(INSTALL) -m 0644 kpatch.conf $(UPSTARTDIR)
+	sed -i 's~PREFIX~$(PREFIX)~' $(UPSTARTDIR)/kpatch.conf
 
 uninstall:
 	$(RM) $(SYSTEMDDIR)/kpatch.service
+	$(RM) $(UPSTARTDIR)/kpatch.conf
 
 clean:

--- a/contrib/kpatch.conf
+++ b/contrib/kpatch.conf
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# This upstart version lacks the ability of unloading modules with
+# the "stop" directive, as upstart does not support a feature like
+# systemd's RemainAfterExit option.
+
+
+description "Apply kpatch kernel patches"
+
+start on runlevel [2345] # Roughly equivalent to multi-user.target
+
+# We are not a daemon
+task
+
+# Emulating systemd's ConditionKernelCommandLine option.
+pre-start script
+    if [[ -e /proc/cmdline ]]
+    then
+        grep -q "kpatch.enable=0" /proc/cmdline && exit 1
+    else
+        dmesg | grep -q "Command line.*kpatch.enable=0" && exit 1
+    fi
+
+    exit 0
+end script
+
+# Main process (start)
+exec PREFIX/sbin/kpatch load --all
+

--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -79,6 +79,7 @@ rm -rf %{buildroot}
 %{_sbindir}/kpatch
 %{_mandir}/man1/kpatch.1*
 %{_usr}/lib/systemd/system/*
+%{_sysconfdir}/init/kpatch.conf
 
 %files %{KVER}
 %defattr(-,root,root,-)


### PR DESCRIPTION
Currently kpatch rely on systemd to load all kmods on startup.
This patch aims to enable kpatch to be used on upstart systems.

Limitations:
With systemd, it would be possible to unload all modules by issuing:
        systemctl stop kpatch
It was not possible to make a reasonable upstart's equivalent of it, so
to unload the modules it will be necessary to call kpatch explicitly:
        kpatch unload --all

I believe this it an non-issue, as it is still possible to unload
the modules by calling kpatch explicitly.

Instead of copying the upstart config file (kpatch.conf) directly
to /etc/init, it first copies it to /usr/share/kpatch/contrib,
and on post installation this file is copied to /etc/init if the
target host has upstart installed.

On my tests I have verified that all newly added files by this commit
are also deleted on uninstall.

It was also verified that applied patches are loaded again on startup.

rpmlint does not complain about anything new.

Signed-off-by: Bruno Loreto <loretob@amazon.com>