### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,6 +1,6 @@
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.5.0
+Version: 0.6.0
 License: GPLv2 
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
-VERSION="0.5.0"
+VERSION="0.6.0"
 POST_ENABLE_WAIT=5	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 


### PR DESCRIPTION
Increment version to 0.6.0 due to 926e4e0c7d14 ("kmod: add support for
in-kernel livepatch hooks"), which removed the kpatch (un)load hook API
support and converted to livepatch-style hooks.

Additional changes include:

* Lots of misc bugfixes and cleanups
* Manpage, README.md fixups
* More PPC64 work
* "Undefined reference" build failure rework
* Livepatch disable retries

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>