### PR TITLE
create-diff-object: fix ppc64le static local variable correlation

### DIFF
--- a/test/integration/centos-7/gcc-static-local-var-6.patch
+++ b/test/integration/centos-7/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index a9d587a..23336ed 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -106,6 +106,8 @@ static int nf_ip6_reroute(struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -119,6 +121,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/fedora-27/gcc-static-local-var-6.patch
+++ b/test/integration/fedora-27/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index 9bf2604..026ac6c 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -109,6 +109,8 @@ static int nf_ip6_reroute(struct net *net, struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -122,6 +124,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/ubuntu-16.04/gcc-static-local-var-6.patch
+++ b/test/integration/ubuntu-16.04/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index 39970e2..85e750d 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -108,6 +108,8 @@ static int nf_ip6_reroute(struct net *net, struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -121,6 +123,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)


### PR DESCRIPTION
On ppc64le, the static local variable correlation doesn't take into
account the .toc rela indirection for data references, meaning that it's
basically broken in many cases.

Fix it by making the code .toc-aware.

Fixes #793.

Reported-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>
Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>