### PR TITLE
Testcase: Clean up gcc-static-local-var-2

### DIFF
--- a/test/integration/centos-7/gcc-static-local-var-2.patch
+++ b/test/integration/centos-7/gcc-static-local-var-2.patch
@@ -1,14 +1,6 @@
 diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
 --- src.orig/mm/mmap.c	2017-09-22 15:27:21.618055844 -0400
 +++ src/mm/mmap.c	2017-09-22 15:27:31.024094794 -0400
-@@ -1677,6 +1677,7 @@ static inline int accountable_mapping(st
- 	return (vm_flags & (VM_NORESERVE | VM_SHARED | VM_WRITE)) == VM_WRITE;
- }
- 
-+#include "kpatch-macros.h"
- unsigned long mmap_region(struct file *file, unsigned long addr,
- 		unsigned long len, vm_flags_t vm_flags, unsigned long pgoff,
- 		struct list_head *uf)
 @@ -1687,6 +1688,9 @@ unsigned long mmap_region(struct file *f
  	struct rb_node **rb_link, *rb_parent;
  	unsigned long charged = 0;

--- a/test/integration/fedora-27/gcc-static-local-var-2.patch
+++ b/test/integration/fedora-27/gcc-static-local-var-2.patch
@@ -1,14 +1,6 @@
 diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
 --- src.orig/mm/mmap.c	2017-11-17 15:58:51.131211972 -0500
 +++ src/mm/mmap.c	2017-11-17 15:59:09.094211972 -0500
-@@ -1599,6 +1599,7 @@ static inline int accountable_mapping(st
- 	return (vm_flags & (VM_NORESERVE | VM_SHARED | VM_WRITE)) == VM_WRITE;
- }
- 
-+#include "kpatch-macros.h"
- unsigned long mmap_region(struct file *file, unsigned long addr,
- 		unsigned long len, vm_flags_t vm_flags, unsigned long pgoff,
- 		struct list_head *uf)
 @@ -1609,6 +1610,9 @@ unsigned long mmap_region(struct file *f
  	struct rb_node **rb_link, *rb_parent;
  	unsigned long charged = 0;

--- a/test/integration/ubuntu-16.04/gcc-static-local-var-2.patch
+++ b/test/integration/ubuntu-16.04/gcc-static-local-var-2.patch
@@ -1,14 +1,6 @@
 diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
 --- src.orig/mm/mmap.c	2016-12-15 19:55:38.992000000 +0000
 +++ src/mm/mmap.c	2016-12-15 19:56:43.684000000 +0000
-@@ -1538,6 +1538,7 @@ static inline int accountable_mapping(st
- 	return (vm_flags & (VM_NORESERVE | VM_SHARED | VM_WRITE)) == VM_WRITE;
- }
- 
-+#include "kpatch-macros.h"
- unsigned long mmap_region(struct file *file, unsigned long addr,
- 		unsigned long len, vm_flags_t vm_flags, unsigned long pgoff)
- {
 @@ -1547,6 +1548,9 @@ unsigned long mmap_region(struct file *f
  	struct rb_node **rb_link, *rb_parent;
  	unsigned long charged = 0;


### PR DESCRIPTION
The test case gcc-static-local-var-2 doesn't uses any macros
from kpatch-macros.h, so remove the hunk including it.

Cc: Joe Lawrence <jdl1291@gmail.com>
Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>