### PR TITLE
Fix false-positives in kpatch_check_relocations

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1935,7 +1935,7 @@ static void kpatch_check_relocations(struct kpatch_elf *kelf)
 		list_for_each_entry(rela, &sec->relas, list) {
 			if (rela->sym->sec) {
 				sdata = rela->sym->sec->data;
-				if (rela->addend > sdata->d_size) {
+				if (rela->addend > (int)sdata->d_size) {
 					ERROR("out-of-range relocation %s+%x in %s", rela->sym->sec->name,
 							rela->addend, sec->name);
 				}


### PR DESCRIPTION
Because of signdness difference kpatch_check_relocations() would trigger
an error on any negative addend.
Fix by casting Elf_Data->d_size from size_t to long.

Signed-off-by: Artem Savkov <asavkov@redhat.com>