### PR TITLE
kpatch-build: fix Ubuntu kernel detection on successive retries

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -602,7 +602,6 @@ else
 			# url may be changed for a different mirror
 			url="http://archive.ubuntu.com/ubuntu/pool/main/l"
 			sublevel="SUBLEVEL = 0"
-			UBUNTU_KERNEL=1
 
 		elif [[ "$DISTRO" = debian ]]; then
 
@@ -820,7 +819,7 @@ fi
 
 echo "Building patch module: $MODNAME.ko"
 
-if [[ ! -z "$UBUNTU_KERNEL" ]]; then
+if [[ -z "$USERSRCDIR" ]] && [[ "$DISTRO" = ubuntu ]]; then
 	# UBUNTU: add UTS_UBUNTU_RELEASE_ABI to utsrelease.h after regenerating it
 	UBUNTU_ABI="${ARCHVERSION#*-}"
 	UBUNTU_ABI="${UBUNTU_ABI%-*}"


### PR DESCRIPTION
If a patch failed a first time, kpatch-build is using the previous
cache directory on subsequent builds. The UBUNTU_KERNEL=1 variable is
not set in this case. Therefore, utsrelease.h is not updated correctly
and the appropriate structures are not used. Just check if distro is
Ubuntu and we didn't request our own specific directory.

Signed-off-by: Vincent Bernat <vincent@bernat.im>