### PR TITLE
create-diff-object: skip dynrelas for function pointers to new functions

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2412,6 +2412,7 @@ static int may_need_dynrela(const struct rela *rela)
 	 * unlikely to be used as callbacks.
 	 */
 	return (function_ptr_rela(rela) &&
+		toc_rela(rela)->sym->status != NEW &&
 		!strchr(toc_rela(rela)->sym->name, '.'));
 }
 

--- a/test/unit/x86_64/function-ptr-new.ORIG.o
+++ b/test/unit/x86_64/function-ptr-new.ORIG.o
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:550e34f0e1ad732f6fb2adee2b8ef40c23959770f3885a99b03387df1ca8b479
+size 9696

--- a/test/unit/x86_64/function-ptr-new.PATCHED.o
+++ b/test/unit/x86_64/function-ptr-new.PATCHED.o
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f71d13f5f4f31dc025ef9a270d7afbb3eb591d09b56a604e578ae23d05d43ff
+size 10344


### PR DESCRIPTION
With #755, we started using dynrelas for function pointers.  However,
this behavior only makes sense for function pointers to existing
functions.  For function pointers to *new* functions, just use a normal
rela.

The 'function-ptr-new' unit test is from the following patch:

  https://github.com/dynup/kpatch/files/1927198/new-static-callback.patch.txt

Fixes #834.

Fixes: 495e6197508d ("kpatch-build, x86: do not use the patched functions as callbacks directly")
Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>