### PR TITLE
kpatch: increase patch transition stall timeout

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -26,7 +26,7 @@
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
 VERSION="0.5.0"
-POST_ENABLE_WAIT=5	# seconds
+POST_ENABLE_WAIT=15	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 
 # How many times to try loading the patch if activeness safety check fails.


### PR DESCRIPTION
I loaded a livepatch on an idle 112 CPU system, and it took over three
seconds for the patch transition to complete:

  [1561551.584871] livepatch: 'livepatch_foo': starting patching transition
  [1561554.867486] livepatch: 'livepatch_foo: patching complete

Presumably this is because more CPUS == more kthreads and idle tasks,
which are more likely to be running at any given time.

Currently the kpatch script will start signaling tasks if the transition
takes more than five seconds.  Increase that timeout a bit to 15
seconds, to give big/busy systems more time before we start signaling.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>