### PR TITLE
added function for archiving builded kernels or using it to kpatch-bu…

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -722,7 +722,7 @@ if [ -n "${BUILDEDKERNELDIR}" ]; then
 		CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
 
 		echo "Archive builded kernel"
-		XZ_OPT="-1v -T8" tar -C /tmp/$KVER-$KREL.x86_64 -cJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz .
+		XZ_OPT="-1v -T8" tar -C /tmp/${KVER}-${KREL}.x86_64 -cJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz .
 	fi
 else
 	echo "Building original kernel"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -564,7 +564,7 @@ if [ -n "${BUILDEDKERNELDIR}" ]; then
 		echo "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz will be created"
 	fi
 fi
-if [ -n "${BUILDEDKERNELDIR}" && ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" || ! -n "${BUILDEDKERNELDIR}" ]; then
+if [ -n "${BUILDEDKERNELDIR}" ] && [ ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" ] || [ ! -n "${BUILDEDKERNELDIR}" ]; then
 	if [[ -n "$USERSRCDIR" ]]; then
 		echo "Using source directory at $USERSRCDIR"
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -371,26 +371,27 @@ module_name_string() {
 
 usage() {
 	echo "usage: $(basename "$0") [options] <patch1 ... patchN>" >&2
-	echo "		patchN             Input patchfile(s)" >&2
-	echo "		-h, --help         Show this help message" >&2
-	echo "		-a, --archversion  Specify the kernel arch version" >&2
-	echo "		-r, --sourcerpm    Specify kernel source RPM" >&2
-	echo "		-s, --sourcedir    Specify kernel source directory" >&2
-	echo "		-c, --config       Specify kernel config file" >&2
-	echo "		-v, --vmlinux      Specify original vmlinux" >&2
-	echo "		-j, --jobs         Specify the number of make jobs" >&2
-	echo "		-t, --target       Specify custom kernel build targets" >&2
-	echo "		-n, --name         Specify the name of the kpatch module" >&2
-	echo "		-o, --output       Specify output folder" >&2
-	echo "		-d, --debug        Enable 'xtrace' and keep scratch files" >&2
-	echo "		                   in <CACHEDIR>/tmp" >&2
-	echo "		                   (can be specified multiple times)" >&2
-	echo "		--skip-cleanup     Skip post-build cleanup" >&2
-	echo "		--skip-gcc-check   Skip gcc version matching check" >&2
-	echo "		                   (not recommended)" >&2
+	echo "		patchN               Input patchfile(s)" >&2
+	echo "		-h, --help           Show this help message" >&2
+	echo "		-a, --archversion    Specify the kernel arch version" >&2
+	echo "		-b, --builded-kernel Specify builded kernel directory" >&2
+	echo "		-r, --sourcerpm      Specify kernel source RPM" >&2
+	echo "		-s, --sourcedir      Specify kernel source directory" >&2
+	echo "		-c, --config         Specify kernel config file" >&2
+	echo "		-v, --vmlinux        Specify original vmlinux" >&2
+	echo "		-j, --jobs           Specify the number of make jobs" >&2
+	echo "		-t, --target         Specify custom kernel build targets" >&2
+	echo "		-n, --name           Specify the name of the kpatch module" >&2
+	echo "		-o, --output         Specify output folder" >&2
+	echo "		-d, --debug          Enable 'xtrace' and keep scratch files" >&2
+	echo "		                     in <CACHEDIR>/tmp" >&2
+	echo "		                     (can be specified multiple times)" >&2
+	echo "		--skip-cleanup       Skip post-build cleanup" >&2
+	echo "		--skip-gcc-check     Skip gcc version matching check" >&2
+	echo "		                     (not recommended)" >&2
 }
 
-options="$(getopt -o ha:r:s:c:v:j:t:n:o:d -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
+options="$(getopt -o ha:b:r:s:c:v:j:t:n:o:d -l "help,archversion:,builded-kernel:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,debug,skip-gcc-check,skip-cleanup" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"
 
@@ -402,6 +403,11 @@ while [[ $# -gt 0 ]]; do
 		;;
 	-a|--archversion)
 		ARCHVERSION="$2"
+		shift
+		;;
+	-b|--builded-kernel)
+		BUILDEDKERNELDIR="$2"
+		[[ ! -d "$2" ]] && die "dir with builded kernel '$2' not found"
 		shift
 		;;
 	-r|--sourcerpm)
@@ -550,88 +556,98 @@ if [[ "$SKIPGCCCHECK" -eq 0 ]]; then
 	gcc_version_check || die
 fi
 
-if [[ -n "$USERSRCDIR" ]]; then
-	echo "Using source directory at $USERSRCDIR"
+if [ -n "${BUILDEDKERNELDIR}" ]; then
+	if [ -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz ]; then
+		echo "Unpack original builded kernel from ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz"
+		XZ_OPT="-v" tar -C /tmp/${KVER}-${KREL}.x86_64 -xJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz
+	else
+		echo "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz will be created"
+	fi
+fi
+if [ -n "${BUILDEDKERNELDIR}" -a  ! -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz -o ! -n "${BUILDEDKERNELDIR}" ]; then
+	if [[ -n "$USERSRCDIR" ]]; then
+		echo "Using source directory at $USERSRCDIR"
 
-	# save vmlinux before it gets removed with mrproper
-	[[ "$VMLINUX" -ef "$SRCDIR"/vmlinux ]] && cp -f "$VMLINUX" "$TEMPDIR/vmlinux" && VMLINUX="$TEMPDIR/vmlinux"
+		# save vmlinux before it gets removed with mrproper
+		[[ "$VMLINUX" -ef "$SRCDIR"/vmlinux ]] && cp -f "$VMLINUX" "$TEMPDIR/vmlinux" && VMLINUX="$TEMPDIR/vmlinux"
 
-elif [[ -e "$SRCDIR"/.config ]] && [[ -e "$VERSIONFILE" ]] && [[ "$(cat "$VERSIONFILE")" = "$ARCHVERSION" ]]; then
-	echo "Using cache at $SRCDIR"
-
-else
-	if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]]; then
-
-		echo "Fedora/Red Hat distribution detected"
-
-		clean_cache
-
-		echo "Downloading kernel source for $ARCHVERSION"
-		if [[ -z "$SRCRPM" ]]; then
-			if [[ "$DISTRO" = fedora ]]; then
-				wget -P "$TEMPDIR" "http://kojipkgs.fedoraproject.org/packages/kernel/$KVER/$KREL/src/kernel-$KVER-$KREL.src.rpm" 2>&1 | logger || die
-			else
-				rpm -q --quiet yum-utils || die "yum-utils not installed"
-				yumdownloader --source --destdir "$TEMPDIR" "kernel-$ARCHVERSION" 2>&1 | logger || die
-			fi
-			SRCRPM="$TEMPDIR/kernel-$KVER-$KREL.src.rpm"
-		fi
-
-		echo "Unpacking kernel source"
-
-		rpm -D "_topdir $RPMTOPDIR" -ivh "$SRCRPM" 2>&1 | logger || die
-		rpmbuild -D "_topdir $RPMTOPDIR" -bp "--target=$(uname -m)" "$RPMTOPDIR"/SPECS/kernel.spec 2>&1 | logger ||
-			die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
-
-		mv "$RPMTOPDIR"/BUILD/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" 2>&1 | logger || die
-		rm -rf "$RPMTOPDIR"
-		rm -rf "$SRCDIR/.git"
-
-		if [[ "$ARCHVERSION" == *-* ]]; then
-			echo "-${ARCHVERSION##*-}" > "$SRCDIR/localversion" || die
-		fi
-
-		echo "$ARCHVERSION" > "$VERSIONFILE" || die
-
-	elif [[ "$DISTRO" = ubuntu ]] || [[ "$DISTRO" = debian ]]; then
-
-		echo "Debian/Ubuntu distribution detected"
-
-		if [[ "$DISTRO" = ubuntu ]]; then
-
-			# url may be changed for a different mirror
-			url="http://archive.ubuntu.com/ubuntu/pool/main/l"
-			sublevel="SUBLEVEL = 0"
-
-		elif [[ "$DISTRO" = debian ]]; then
-
-			# url may be changed for a different mirror
-			url="http://ftp.debian.org/debian/pool/main/l"
-			sublevel="SUBLEVEL ="
-		fi
-
-		pkgname="$(dpkg-query -W -f='${Source}' "linux-image-$ARCHVERSION")"
-		pkgver="$(dpkg-query -W -f='${Version}' "linux-image-$ARCHVERSION")"
-		dscname="${pkgname}_${pkgver}.dsc"
-
-		clean_cache
-
-		cd "$TEMPDIR" || die
-		echo "Downloading and unpacking the kernel source for $ARCHVERSION"
-		# Download source deb pkg
-		(dget -u "$url/${pkgname}/${dscname}" 2>&1) | logger || die "dget: Could not fetch/unpack $url/${pkgname}/${dscname}"
-		mv "${pkgname}-$KVER" "$SRCDIR" || die
-		cp "/boot/config-${ARCHVERSION}" "$SRCDIR/.config" || die
-		if [[ "$ARCHVERSION" == *-* ]]; then
-			echo "-${ARCHVERSION#*-}" > "$SRCDIR/localversion" || die
-		fi
-		# for some reason the Ubuntu kernel versions don't follow the
-		# upstream SUBLEVEL; they are always at SUBLEVEL 0
-		sed -i "s/^SUBLEVEL.*/${sublevel}/" "$SRCDIR/Makefile" || die
-		echo "$ARCHVERSION" > "$VERSIONFILE" || die
+	elif [[ -e "$SRCDIR"/.config ]] && [[ -e "$VERSIONFILE" ]] && [[ "$(cat "$VERSIONFILE")" = "$ARCHVERSION" ]]; then
+		echo "Using cache at $SRCDIR"
 
 	else
-		die "Unsupported distribution"
+		if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]]; then
+
+			echo "Fedora/Red Hat distribution detected"
+
+			clean_cache
+
+			echo "Downloading kernel source for $ARCHVERSION"
+			if [[ -z "$SRCRPM" ]]; then
+				if [[ "$DISTRO" = fedora ]]; then
+					wget -P "$TEMPDIR" "http://kojipkgs.fedoraproject.org/packages/kernel/$KVER/$KREL/src/kernel-$KVER-$KREL.src.rpm" 2>&1 | logger || die
+				else
+					rpm -q --quiet yum-utils || die "yum-utils not installed"
+					yumdownloader --source --destdir "$TEMPDIR" "kernel-$ARCHVERSION" 2>&1 | logger || die
+				fi
+				SRCRPM="$TEMPDIR/kernel-$KVER-$KREL.src.rpm"
+			fi
+
+			echo "Unpacking kernel source"
+
+			rpm -D "_topdir $RPMTOPDIR" -ivh "$SRCRPM" 2>&1 | logger || die
+			rpmbuild -D "_topdir $RPMTOPDIR" -bp "--target=$(uname -m)" "$RPMTOPDIR"/SPECS/kernel.spec 2>&1 | logger ||
+				die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
+
+			mv "$RPMTOPDIR"/BUILD/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" 2>&1 | logger || die
+			rm -rf "$RPMTOPDIR"
+			rm -rf "$SRCDIR/.git"
+
+			if [[ "$ARCHVERSION" == *-* ]]; then
+				echo "-${ARCHVERSION##*-}" > "$SRCDIR/localversion" || die
+			fi
+
+			echo "$ARCHVERSION" > "$VERSIONFILE" || die
+
+		elif [[ "$DISTRO" = ubuntu ]] || [[ "$DISTRO" = debian ]]; then
+
+			echo "Debian/Ubuntu distribution detected"
+
+			if [[ "$DISTRO" = ubuntu ]]; then
+
+				# url may be changed for a different mirror
+				url="http://archive.ubuntu.com/ubuntu/pool/main/l"
+				sublevel="SUBLEVEL = 0"
+
+			elif [[ "$DISTRO" = debian ]]; then
+
+				# url may be changed for a different mirror
+				url="http://ftp.debian.org/debian/pool/main/l"
+				sublevel="SUBLEVEL ="
+			fi
+
+			pkgname="$(dpkg-query -W -f='${Source}' "linux-image-$ARCHVERSION")"
+			pkgver="$(dpkg-query -W -f='${Version}' "linux-image-$ARCHVERSION")"
+			dscname="${pkgname}_${pkgver}.dsc"
+
+			clean_cache
+
+			cd "$TEMPDIR" || die
+			echo "Downloading and unpacking the kernel source for $ARCHVERSION"
+			# Download source deb pkg
+			(dget -u "$url/${pkgname}/${dscname}" 2>&1) | logger || die "dget: Could not fetch/unpack $url/${pkgname}/${dscname}"
+			mv "${pkgname}-$KVER" "$SRCDIR" || die
+			cp "/boot/config-${ARCHVERSION}" "$SRCDIR/.config" || die
+			if [[ "$ARCHVERSION" == *-* ]]; then
+				echo "-${ARCHVERSION#*-}" > "$SRCDIR/localversion" || die
+			fi
+			# for some reason the Ubuntu kernel versions don't follow the
+			# upstream SUBLEVEL; they are always at SUBLEVEL 0
+			sed -i "s/^SUBLEVEL.*/${sublevel}/" "$SRCDIR/Makefile" || die
+			echo "$ARCHVERSION" > "$VERSIONFILE" || die
+
+		else
+			die "Unsupported distribution"
+		fi
 	fi
 fi
 
@@ -693,14 +709,31 @@ if [[ $DEBUG -ge 4 ]]; then
 	export KPATCH_GCC_DEBUG=1
 fi
 
-echo "Building original kernel"
-./scripts/setlocalversion --save-scmversion || die
-make mrproper 2>&1 | logger || die
-cp -f "$CONFIGFILE" "$SRCDIR/.config"
-unset KPATCH_GCC_TEMPDIR
-# $TARGETS used as list, no quotes.
-# shellcheck disable=SC2086
-CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
+
+if [ -n "${BUILDEDKERNELDIR}" ]; then
+	if [ ! -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz ]; then
+		echo "Building original kernel"
+		./scripts/setlocalversion --save-scmversion || die
+		make mrproper 2>&1 | logger || die
+		cp -f "$CONFIGFILE" "$SRCDIR/.config"
+		unset KPATCH_GCC_TEMPDIR
+		# $TARGETS used as list, no quotes.
+		# shellcheck disable=SC2086
+		CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
+
+		echo "Archive builded kernel"
+		XZ_OPT="-1v -T8" tar -C /tmp/$KVER-$KREL.x86_64 -cJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz .
+	fi
+else
+	echo "Building original kernel"
+	./scripts/setlocalversion --save-scmversion || die
+	make mrproper 2>&1 | logger || die
+	cp -f "$CONFIGFILE" "$SRCDIR/.config"
+	unset KPATCH_GCC_TEMPDIR
+	# $TARGETS used as list, no quotes.
+	# shellcheck disable=SC2086
+	CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
+fi
 
 echo "Building patched kernel"
 apply_patches

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -557,14 +557,14 @@ if [[ "$SKIPGCCCHECK" -eq 0 ]]; then
 fi
 
 if [ -n "${BUILDEDKERNELDIR}" ]; then
-	if [ -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz ]; then
+	if [ -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" ]; then
 		echo "Unpack original builded kernel from ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz"
-		XZ_OPT="-v" tar -C /tmp/${KVER}-${KREL}.x86_64 -xJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz
+		XZ_OPT="-v" tar -C "/tmp/${KVER}-${KREL}.x86_64" -xJf "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz"
 	else
 		echo "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz will be created"
 	fi
 fi
-if [ -n "${BUILDEDKERNELDIR}" -a  ! -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz -o ! -n "${BUILDEDKERNELDIR}" ]; then
+if [ -n "${BUILDEDKERNELDIR}" -a  ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" -o ! -n "${BUILDEDKERNELDIR}" ]; then
 	if [[ -n "$USERSRCDIR" ]]; then
 		echo "Using source directory at $USERSRCDIR"
 
@@ -711,7 +711,7 @@ fi
 
 
 if [ -n "${BUILDEDKERNELDIR}" ]; then
-	if [ ! -f ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz ]; then
+	if [ ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" ]; then
 		echo "Building original kernel"
 		./scripts/setlocalversion --save-scmversion || die
 		make mrproper 2>&1 | logger || die
@@ -722,7 +722,7 @@ if [ -n "${BUILDEDKERNELDIR}" ]; then
 		CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
 
 		echo "Archive builded kernel"
-		XZ_OPT="-1v -T8" tar -C /tmp/${KVER}-${KREL}.x86_64 -cJf ${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz .
+		XZ_OPT="-1v -T8" tar -C "/tmp/${KVER}-${KREL}.x86_64" -cJf "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" .
 	fi
 else
 	echo "Building original kernel"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -564,7 +564,7 @@ if [ -n "${BUILDEDKERNELDIR}" ]; then
 		echo "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz will be created"
 	fi
 fi
-if [ -n "${BUILDEDKERNELDIR}" -a  ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" -o ! -n "${BUILDEDKERNELDIR}" ]; then
+if [ -n "${BUILDEDKERNELDIR}" && ! -f "${BUILDEDKERNELDIR}/builded-${KVER}-${KREL}.x86_64.tar.xz" || ! -n "${BUILDEDKERNELDIR}" ]; then
 	if [[ -n "$USERSRCDIR" ]]; then
 		echo "Using source directory at $USERSRCDIR"
 


### PR DESCRIPTION
Added function for archiving builded kernels or using it to kpatch-build as kpatch-build -b option.
You can set -b options to directory when you want to have builded kernel with ccache cache, if you already have builded kernel it will be used instead full building, in my case xz pack workin 2.30 min, unpack 5min (one thread for unpack, can't be multithreaded), building full kernel takes around 20 minutes.

Actually need add some options for set archive threads, archiver