### PR TITLE
create-klp-module: group .kpatch.symbols with like-scope

### DIFF
--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -128,7 +128,8 @@ struct rela *find_rela_by_offset(struct section *relasec, unsigned int offset);
 		ERROR("malloc"); \
 	memset((_new), 0, sizeof(*(_new))); \
 	INIT_LIST_HEAD(&(_new)->list); \
-	list_add_tail(&(_new)->list, (_list)); \
+	if (_list) \
+		list_add_tail(&(_new)->list, (_list)); \
 }
 
 int offset_of_string(struct list_head *list, char *name);


### PR DESCRIPTION
From Oracle's Linker and Libraries Guide [1]:

"The symbols in a symbol table are written in the following order ...
The global symbols immediately follow the local symbols in the symbol
table. The first global symbol is identified by the symbol table sh_info
value. Local and global symbols are always kept separate in this manner,
and cannot be mixed together."

[1] https://docs.oracle.com/cd/E19120-01/open.solaris/819-0690/chapter6-79797/index.html

Fixes #854.
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>