### PR TITLE
create-diff-object: don't convert .TOC. references to dynrelas

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2467,8 +2467,17 @@ static int function_ptr_rela(const struct rela *rela)
 
 static int may_need_dynrela(const struct rela *rela)
 {
+	/*
+	 * References to .TOC. are treated specially by the module loader and
+	 * should never be converted to dynrelas.
+	 */
+	if (rela->type == R_PPC64_REL16_HA || rela->type == R_PPC64_REL16_LO ||
+	    rela->type == R_PPC64_REL64)
+		return 0;
+
 	if (!rela->sym->sec)
 		return 1;
+
 	/*
 	 * Nested functions used as callbacks are a special case.
 	 * They are not supposed to be visible outside of the


### PR DESCRIPTION
When I made a patch to the nfsd module on a ppc64le system with a RHEL 7
based kernel, livepatch prevented the target module from loading with:

  livepatch: symbol '.TOC.' not found in symbol table

References to this symbol are treated specially by the kernel module
loader, so references to it should never be converted to dynrelas.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>