### PR TITLE
livepatch-patch-hook: add RHEL immediate check

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -49,7 +49,8 @@
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0) &&			\
      LINUX_VERSION_CODE <= KERNEL_VERSION(4, 15, 0)) ||			\
-    defined(RHEL_RELEASE_CODE)
+     (defined(RHEL_RELEASE_CODE) &&					\
+      RHEL_RELEASE_CODE <= RHEL_RELEASE_VERSION(7, 5))
 #define HAVE_IMMEDIATE
 #endif
 


### PR DESCRIPTION
The 'immediate' flag removal is going to be backported to RHEL 7.
Adjust the check accordingly.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>