### PR TITLE
gcc-plugin: Include additional header for GCC 8

### DIFF
--- a/kpatch-build/gcc-plugins/gcc-common.h
+++ b/kpatch-build/gcc-plugins/gcc-common.h
@@ -96,6 +96,10 @@
 #include "predict.h"
 #include "ipa-utils.h"
 
+#if BUILDING_GCC_VERSION >= 8000
+#include "stringpool.h"
+#endif
+
 #if BUILDING_GCC_VERSION >= 4009
 #include "attribs.h"
 #include "varasm.h"


### PR DESCRIPTION
plugin compilation fails on GCC 8:

In file included from gcc-plugins/gcc-common.h:100,
                 from gcc-plugins/ppc64le-plugin.c:1:
/usr/lib/gcc/powerpc64le-linux-gnu/8/plugin/include/attribs.h: In function ‘tree_node* canonicalize_attr_name(tree)’:
/usr/lib/gcc/powerpc64le-linux-gnu/8/plugin/include/attribs.h:118:11: error: ‘get_identifier_with_length’ was not declared in this scope
    return get_identifier_with_length (s + 2, l - 4);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/powerpc64le-linux-gnu/8/plugin/include/attribs.h:118:11: note: suggested alternative: ‘get_attr_min_length’
    return get_identifier_with_length (s + 2, l - 4);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~
           get_attr_min_length
Makefile:34: recipe for target 'gcc-plugins/ppc64le-plugin.so' failed

get_identifier_with_length() is defined under stringpool.h, include this
header file for GCC 8, before including attribs.h

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>