### PR TITLE
test/unit: run submodule command from base git directory

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -4,7 +4,7 @@ OBJDIR ?= objs/$(ARCH)
 .PHONY: all clean
 
 all: Makefile.include
-	git submodule update --init --rebase
+	cd $(shell git rev-parse --show-toplevel) && git submodule update --init --rebase
 	$(MAKE) -C $(OBJDIR)
 
 clean: Makefile.include


### PR DESCRIPTION
This fixes the following error with an older version of git
(1.8.3.1):

  make -C test/unit
  make[1]: Entering directory `/root/kpatch/test/unit'
  git submodule update --init --rebase
  You need to run this command from the toplevel of the working tree.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>