### PR TITLE
kpatch-build: detect truncated Module.symvers

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -724,6 +724,8 @@ if [[ ! -e "$TEMPDIR/changed_objs" ]]; then
 	die "no changed objects found"
 fi
 
+grep -q vmlinux "$SRCDIR/Module.symvers" || die "truncated $SRCDIR/Module.symvers file"
+
 # Read as words, no quotes.
 # shellcheck disable=SC2013
 for i in $(cat "$TEMPDIR/changed_objs")


### PR DESCRIPTION
"make mrproper" combined with the '-t' flag is dangerous, as it results
in the Module.symvers file getting truncated, which causes
create-diff-object to create some funky dynrelas.  Detect this condition
in kpatch-build and error out.

We will hopefully also be removing "make mrproper" soon, which will make
'-t' even more useful.

Fixes #589.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>