### PR TITLE
unittests: skip clean if objdir is not present

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -8,4 +8,4 @@ all: Makefile.include
 	$(MAKE) -C $(OBJDIR)
 
 clean: Makefile.include
-	$(MAKE) -C $(OBJDIR) clean
+	if [ -d $(OBJDIR) ]; then $(MAKE) -C $(OBJDIR) clean; fi


### PR DESCRIPTION
Don't try to call unittest clean if objfile dir is non-existant (e.g.
when objfile submodule wasn't cloned). Another solution would be to make
clean target dependant on objdir but that would mean downloading a lot
of unneeded data for users who don't run unit-tests.

Fixes: #872

Signed-off-by: Artem Savkov <asavkov@redhat.com>