### PR TITLE
create-diff-object: add ORC section support

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -260,30 +260,35 @@ find_special_section_data() {
 	fi
 
 	[[ "$CONFIG_PARAVIRT" -eq 0 ]] && AWK_OPTIONS="-vskip_p=1"
+	[[ "$CONFIG_UNWINDER_ORC" -eq 0 ]] && AWK_OPTIONS="$AWK_OPTIONS -vskip_o=1"
+
 	SPECIAL_VARS="$(readelf -wi "$VMLINUX" |
-		gawk --non-decimal-data $AWK_OPTIONS '
-		BEGIN { a = b = p = e = 0 }
+		gawk --non-decimal-data "$AWK_OPTIONS" '
+		BEGIN { a = b = p = e = o = 0 }
 
 		# Set state if name matches
 		a == 0 && /DW_AT_name.* alt_instr[[:space:]]*$/ {a = 1; next}
 		b == 0 && /DW_AT_name.* bug_entry[[:space:]]*$/ {b = 1; next}
 		p == 0 && /DW_AT_name.* paravirt_patch_site[[:space:]]*$/ {p = 1; next}
 		e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
+		o == 0 && /DW_AT_name.* orc_entry[[:space:]]*$/ {o = 1; next}
 
 		# Reset state unless this abbrev describes the struct size
 		a == 1 && !/DW_AT_byte_size/ { a = 0; next }
 		b == 1 && !/DW_AT_byte_size/ { b = 0; next }
 		p == 1 && !/DW_AT_byte_size/ { p = 0; next }
 		e == 1 && !/DW_AT_byte_size/ { e = 0; next }
+		o == 1 && !/DW_AT_byte_size/ { o = 0; next }
 
 		# Now that we know the size, stop parsing for it
 		a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
 		b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
 		p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}
 		e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
+		o == 1 {printf("export ORC_STRUCT_SIZE=%d\n", $4); o = 2}
 
 		# Bail out once we have everything
-		a == 2 && b == 2 && (p == 2 || skip_p) && e == 2 {exit}')"
+		a == 2 && b == 2 && (p == 2 || skip_p) && e == 2 && (o == 2 || skip_o) {exit}')"
 
 	[[ -n "$SPECIAL_VARS" ]] && eval "$SPECIAL_VARS"
 
@@ -291,6 +296,7 @@ find_special_section_data() {
 	[[ -z "$BUG_STRUCT_SIZE" ]] && die "can't find special struct bug_entry size"
 	[[ -z "$EX_STRUCT_SIZE" ]]  && die "can't find special struct paravirt_patch_site size"
 	[[ -z "$PARA_STRUCT_SIZE" && "$CONFIG_PARAVIRT" -ne 0 ]] && die "can't find special struct paravirt_patch_site size"
+	[[ -z "$ORC_STRUCT_SIZE" && "$CONFIG_UNWINDER_ORC" -ne 0 ]] && die "can't find special struct orc_entry size"
 
 	return
 }
@@ -667,11 +673,16 @@ else
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi
 
-# optional kernel configs: CONFIG_PARAVIRT
+# optional kernel configs:
 if grep -q "CONFIG_PARAVIRT=y" "$CONFIGFILE"; then
 	CONFIG_PARAVIRT=1
 else
 	CONFIG_PARAVIRT=0
+fi
+if grep -q "CONFIG_UNWINDER_ORC=y" "$CONFIGFILE"; then
+	CONFIG_UNWINDER_ORC=1
+else
+	CONFIG_UNWINDER_ORC=0
 fi
 
 # unsupported kernel option checking: CONFIG_DEBUG_INFO_SPLIT


### PR DESCRIPTION
Finally add support for processing the ORC unwinder sections.

The ORC unwinder sections are more special than the other special
sections, so they need their own dedicated function to process them,
though the code is similar to kpatch_regenerate_special_sections().

BTW, upstream livepatch still doesn't support the ORC unwinder.  That
change will be coming soon (probably Linux 4.19).

Fixes #785.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>