### PR TITLE
create-diff-object: prevent "'toc_data1' may be used uninitialized" warning

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -255,7 +255,7 @@ static int kpatch_mangled_strcmp(char *s1, char *s2)
 static int rela_equal(struct rela *rela1, struct rela *rela2)
 {
 	struct rela *rela_toc1, *rela_toc2;
-	unsigned long toc_data1, toc_data2;
+	unsigned long toc_data1 = 0, toc_data2 = 0; /* = 0 to prevent gcc warning */
 
 	if (rela1->type != rela2->type ||
 	    rela1->offset != rela2->offset)


### PR DESCRIPTION

Building with GCC 7.3.0 on Debian sid fails with the following error:

    gcc -g -O2 -fdebug-prefix-map=/build/kpatch-0.6.0=. -fstack-protector-strong -Wformat -Werror=format-security -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare -g -Werror -Wdate-time -D_FORTIFY_SOURCE=2  -c -c
    create-diff-object.c: In function 'kpatch_compare_correlated_rela_section':
    create-diff-object.c:316:20: error: 'toc_data1' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    return toc_data1 == toc_data2;
           ~~~~~~~~~~^~~~~~~~~~~~
    create-diff-object.c:256:16: note: 'toc_data1' was declared here
    unsigned long toc_data1, toc_data2;
                  ^~~~~~~~~
    cc1: all warnings being treated as errors

This is a false positive as the code only compares those two values
after initializing them. But lets keep GCC happy.
