### PR TITLE
kpatch-build: less agressive clean_cache()

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -125,7 +125,7 @@ cleanup() {
 }
 
 clean_cache() {
-	rm -rf "$CACHEDIR"
+	rm -rf "${CACHEDIR:?}/*"
 	mkdir -p "$TEMPDIR" || die "Couldn't create $TEMPDIR"
 }
 


### PR DESCRIPTION
Some of the provisioned machines I sometimes use don't have enought
diskspace for a full kpatch-patch build in a home partitions, I usually
solve this by symlinking .kpatch(and .ccache) dirs to a different
partition, however this only works with -s option because of
clean_cache().

clean_cache() currently removes .kpatch directory completely, recreating
it from scratch, change it to only remove the contents of the directory
instead.

Signed-off-by: Artem Savkov <asavkov@redhat.com>