### PR TITLE
Kpatch build misc fixes, round 2

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -581,7 +581,7 @@ else
 				wget -P "$TEMPDIR" "http://kojipkgs.fedoraproject.org/packages/kernel/$KVER/$KREL/src/kernel-$KVER-$KREL.src.rpm" 2>&1 | logger || die
 			else
 				rpm -q --quiet yum-utils || die "yum-utils not installed"
-				yumdownloader --source --destdir "$TEMPDIR" "kernel$ALT-$ARCHVERSION" 2>&1 | logger || die
+				yumdownloader --source --destdir "$TEMPDIR" "kernel$ALT-$KVER-$KREL" 2>&1 | logger || die
 			fi
 			SRCRPM="$TEMPDIR/kernel$ALT-$KVER-$KREL.src.rpm"
 		fi

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -525,8 +525,8 @@ KVER="${ARCHVERSION%%-*}"
 if [[ "$ARCHVERSION" =~ - ]]; then
 	KREL="${ARCHVERSION##*-}"
 	KREL="${KREL%.*}"
-	[[ "$KREL" =~ .el7a. ]] && ALT="-alt"
 fi
+[[ "$ARCHVERSION" =~ .el7a. ]] && ALT="-alt"
 
 [[ -z "$TARGETS" ]] && TARGETS="vmlinux modules"
 


### PR DESCRIPTION
This PR started with a fixup for yumdownloader and CentOS and I noticed that `kpatch-build` was failing on my RHEL-ALT ppc64le setup.  Looking for ".el7a." in `$KVER` was failing as `$KVER` looked like `83.el7a`, so adjust the script to look for it in the unadulterated `$ARCHVERSION` string.