### PR TITLE
create-diff-object: Relax sh_addralign check for .text sections

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -375,8 +375,9 @@ static void kpatch_compare_correlated_section(struct section *sec)
 	/* Compare section headers (must match or fatal) */
 	if (sec1->sh.sh_type != sec2->sh.sh_type ||
 	    sec1->sh.sh_flags != sec2->sh.sh_flags ||
-	    sec1->sh.sh_addralign != sec2->sh.sh_addralign ||
-	    sec1->sh.sh_entsize != sec2->sh.sh_entsize)
+	    sec1->sh.sh_entsize != sec2->sh.sh_entsize ||
+	    (sec1->sh.sh_addralign != sec2->sh.sh_addralign &&
+	     !is_text_section(sec1)))
 		DIFF_FATAL("%s section header details differ", sec1->name);
 
 	/* Short circuit for mcount sections, we rebuild regardless */


### PR DESCRIPTION
.text section addralign value might chance between original and
patched .o files, for a loop() such as:

for (i = 0; i < sections_per_block; i++) {
	remove_memory(nid, base, MIN_MEMORY_BLOCK_SIZE);
	 base += MIN_MEMORY_BLOCK_SIZE;
}

On ppc64le, which translate to:

  f0:   78 1b 7b 7c     mr      r27,r3
  f4:   6c 00 9d 40     ble     cr7,160 <pseries_remove_memblock+0x158>
  f8:   ff ff 9c 3b     addi    r28,r28,-1
  fc:   38 00 a1 fb     std     r29,56(r1)
 100:   00 01 bf 3f     addis   r29,r31,256
 104:   08 c2 9c 7b     rldic   r28,r28,24,8
 108:   14 ea 9c 7f     add     r28,r28,r29
 10c:   14 00 00 48     b       120 <pseries_remove_memblock+0x118>
 110:   00 00 00 60     nop
 114:   00 00 00 60     nop
 118:   00 00 00 60     nop
 11c:   00 00 00 60     nop
 120:   78 fb e4 7f     mr      r4,r31

.LVL174:
        rldic 28,28,24,8         #, tmp198, tmp196,
        add 28,28,29     # _45, tmp198, base
        .p2align 5,,31

Patch removing such loop, changes the section alignment boundary. Given
that alignment changes to .text section are not fatal, relax the check
for text sections.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>