### PR TITLE
kpatch-build: fix clean_cache

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -125,7 +125,7 @@ cleanup() {
 }
 
 clean_cache() {
-	rm -rf "${CACHEDIR:?}/*"
+	rm -rf "${CACHEDIR:?}"/*
 	mkdir -p "$TEMPDIR" || die "Couldn't create $TEMPDIR"
 }
 


### PR DESCRIPTION
Commit d86c1113cc25 ("kpatch-build: less aggressive clean_cache()")
broke clean_cache().  Instead of expanding the wildcard, it tries to
delete a file named '*'.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>