### PR TITLE
kpatch-build: update for RHEL / CentOS 8

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -580,7 +580,7 @@ else
 			if [[ "$DISTRO" = fedora ]]; then
 				wget -P "$TEMPDIR" "http://kojipkgs.fedoraproject.org/packages/kernel/$KVER/$KREL/src/kernel-$KVER-$KREL.src.rpm" 2>&1 | logger || die
 			else
-				rpm -q --quiet yum-utils || die "yum-utils not installed"
+				which yumdownloader &>/dev/null || die "yumdownloader (yum-utils or dnf-utils) not installed"
 				yumdownloader --source --destdir "$TEMPDIR" "kernel$ALT-$KVER-$KREL" 2>&1 | logger || die
 			fi
 			SRCRPM="$TEMPDIR/kernel$ALT-$KVER-$KREL.src.rpm"
@@ -592,7 +592,7 @@ else
 		rpmbuild -D "_topdir $RPMTOPDIR" -bp "--target=$(uname -m)" "$RPMTOPDIR"/SPECS/kernel$ALT.spec 2>&1 | logger ||
 			die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
 
-		mv "$RPMTOPDIR"/BUILD/kernel-*/linux-"${ARCHVERSION%.*}"*"${ARCHVERSION##*.}" "$SRCDIR" 2>&1 | logger || die
+		mv "$RPMTOPDIR"/BUILD/kernel-*/linux-* "$SRCDIR" 2>&1 | logger || die
 		rm -rf "$RPMTOPDIR"
 		rm -rf "$SRCDIR/.git"
 


### PR DESCRIPTION
- Future releases of RHEL / CentOS will provide the yumdownloader
  program with the 'dnf-utils' package (not 'yum-utils').  Instead of
  looking to see that the package is installed, just look for the
  program itself.

- RHEL / CentOS 8 kernel release names (as returned by 'uname -r') may
  not match the SRPM buildroot release subdirectory name.  Relax the
  wildcard when moving this directory to $SRCDIR.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>