### PR TITLE
create-diff-object.c: Extend is_bundleable()

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -113,6 +113,16 @@ static int is_bundleable(struct symbol *sym)
 		return 1;
 
 	if (sym->type == STT_OBJECT &&
+	    !strncmp(sym->sec->name, ".data.rel.", 10) &&
+	    !strcmp(sym->sec->name + 10, sym->name))
+		return 1;
+
+	if (sym->type == STT_OBJECT &&
+	    !strncmp(sym->sec->name, ".data.rel.ro.", 13) &&
+	    !strcmp(sym->sec->name + 13, sym->name))
+		return 1;
+
+	if (sym->type == STT_OBJECT &&
 	   !strncmp(sym->sec->name, ".rodata.",8) &&
 	   !strcmp(sym->sec->name + 8, sym->name))
 		return 1;


### PR DESCRIPTION
GCC puts the constant variable requiring relocation into .data.rel. or
.data.rel.ro depending upon the bind type of the symbol. Extend
is_bundledable() to check these .data sections too.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>