### PR TITLE
create-klp-module: fixup GROUP section sh_links

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3225,7 +3225,6 @@ int main(int argc, char *argv[])
 	struct arguments arguments;
 	int num_changed, callbacks_exist, new_globals_exist;
 	struct lookup_table *lookup;
-	struct section *sec, *symtab;
 	struct symbol *sym;
 	char *hint = NULL, *orig_obj, *patched_obj, *parent_name;
 	char *parent_symtab, *mod_symvers, *patch_name, *output_obj;
@@ -3353,18 +3352,6 @@ int main(int argc, char *argv[])
 	kpatch_strip_unneeded_syms(kelf_out, lookup);
 	kpatch_reindex_elements(kelf_out);
 
-	/*
-	 * Update rela section headers and rebuild the rela section data
-	 * buffers from the relas lists.
-	 */
-	symtab = find_section_by_name(&kelf_out->sections, ".symtab");
-	list_for_each_entry(sec, &kelf_out->sections, list) {
-		if (!is_rela_section(sec))
-			continue;
-		sec->sh.sh_link = symtab->index;
-		sec->sh.sh_info = sec->base->index;
-		kpatch_rebuild_rela_section_data(sec);
-	}
 	kpatch_check_relocations(kelf_out);
 
 	kpatch_create_shstrtab(kelf_out);

--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -435,7 +435,6 @@ static struct argp argp = { options, parse_opt, args_doc, 0 };
 int main(int argc, char *argv[])
 {
 	struct kpatch_elf *kelf;
-	struct section *symtab, *sec;
 	struct section *ksymsec, *krelasec, *strsec;
 	struct arguments arguments;
 	char *strings;
@@ -493,16 +492,6 @@ int main(int argc, char *argv[])
 
 	remove_intermediate_sections(kelf);
 	kpatch_reindex_elements(kelf);
-
-	/* Rebuild rela sections, new klp rela sections will be rebuilt too. */
-	symtab = find_section_by_name(&kelf->sections, ".symtab");
-	list_for_each_entry(sec, &kelf->sections, list) {
-		if (!is_rela_section(sec))
-			continue;
-		sec->sh.sh_link = symtab->index;
-		sec->sh.sh_info = sec->base->index;
-		kpatch_rebuild_rela_section_data(sec);
-	}
 
 	kpatch_create_shstrtab(kelf);
 	kpatch_create_strtab(kelf);

--- a/kpatch-build/create-kpatch-module.c
+++ b/kpatch-build/create-kpatch-module.c
@@ -185,7 +185,6 @@ static struct argp argp = { options, parse_opt, args_doc, 0 };
 int main(int argc, char *argv[])
 {
 	struct kpatch_elf *kelf;
-	struct section *symtab, *sec;
 	struct section *ksymsec, *krelasec, *strsec;
 	struct arguments arguments;
 	int ksyms_nr, krelas_nr;
@@ -229,15 +228,6 @@ int main(int argc, char *argv[])
 	remove_intermediate_sections(kelf);
 
 	kpatch_reindex_elements(kelf);
-
-	symtab = find_section_by_name(&kelf->sections, ".symtab");
-	list_for_each_entry(sec, &kelf->sections, list) {
-		if (!is_rela_section(sec))
-			continue;
-		sec->sh.sh_link = symtab->index;
-		sec->sh.sh_info = sec->base->index;
-		kpatch_rebuild_rela_section_data(sec);
-	}
 
 	kpatch_create_shstrtab(kelf);
 	kpatch_create_strtab(kelf);

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -48,6 +48,7 @@ struct section {
 	struct list_head list;
 	struct section *twin;
 	GElf_Shdr sh;
+	struct symbol *link_sym;
 	Elf_Data *data;
 	char *name;
 	unsigned int index;
@@ -116,6 +117,7 @@ char *status_str(enum status status);
 int is_rela_section(struct section *sec);
 int is_text_section(struct section *sec);
 int is_debug_section(struct section *sec);
+int is_group_section(struct section *sec);
 
 struct section *find_section_by_index(struct list_head *list, unsigned int index);
 struct section *find_section_by_name(struct list_head *list, const char *name);


### PR DESCRIPTION
remove_intermediate_sections() deletes a few sections from the ELF file,
potentially moving the .strtab's section index.  Be sure to adjust not
only RELA sections that sh_link to the .strtab but also any GROUP
sections.

Fixes: #906
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>