### PR TITLE
Added distros to man page

### DIFF
--- a/man/kpatch-build.1
+++ b/man/kpatch-build.1
@@ -11,9 +11,6 @@ currently running and creates a kernel module that will replace
 modified functions in the kernel such that the patched code takes 
 effect.
 
-This script currently only works on Fedora and will need to be adapted 
-to work on other distros.  
-
 .SH OPTIONS
 
 -h|--help


### PR DESCRIPTION
The man page earlier said that kpatch-build only works for Fedora, so I
added all the other distros it works for based on the README.

Signed-off-by: Sanskriti Sharma <sansharm@redhat.com>