### PR TITLE
create-diff-object: add __FUNCTION__ variables to the special static …

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -250,6 +250,7 @@ static int is_special_static(struct symbol *sym)
 		"__warned.",
 		"descriptor.",
 		"__func__.",
+		"__FUNCTION__.",
 		"_rs.",
 		"CSWTCH.",
 		NULL,


### PR DESCRIPTION
…list

As discovered in #918, the `__FUNCTION__` static local variable is
similar to the `__func__` variable, in that it refers to the current
function name.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>