### PR TITLE
kmod/patch: more linking fixes

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -12,13 +12,14 @@ endif
 
 obj-m += $(KPATCH_NAME).o
 ldflags-y += -T $(src)/kpatch.lds
+extra-y := kpatch.lds
 
-$(KPATCH_NAME)-objs += patch-hook.o kpatch.lds output.o
+$(KPATCH_NAME)-objs += patch-hook.o output.o
 
 all: $(KPATCH_NAME).ko
 
 $(KPATCH_NAME).ko:
-	$(KPATCH_MAKE) $(KPATCH_NAME).ko
+	$(KPATCH_MAKE)
 
 patch-hook.o: patch-hook.c kpatch-patch-hook.c livepatch-patch-hook.c
 	$(KPATCH_MAKE) patch-hook.o


### PR DESCRIPTION
While adding proper linker script option my previous patch left the
linker script in the list of source files (on pre-4.20 kernels) for
ld somehow breaking kpatch callback sections. For this to work
properly kpatch.lds needs to be added to 'extra-y' instead of objs. And
for kbuild to process this option properly we need to call make without
the .ko target, i.e. let kbuild decide what to build.

Fixes: 17a97b4 ("kmod/patch: fix patch linking with 4.20")

P.S. I also don't think patch-hook.o target in this makefile does anything unless manually called as `make patch-hook.o` but that is a separate issue.