### PR TITLE
Fix NULL pointer deref in main due to base_locals

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3332,7 +3332,7 @@ int main(int argc, char *argv[])
 
 	/* create symbol lookup table */
 	lookup = lookup_open(parent_symtab, mod_symvers, hint, base_locals);
-	for (sym_comp = base_locals; sym_comp->name; sym_comp++) {
+	for (sym_comp = base_locals; sym_comp && sym_comp->name; sym_comp++) {
 		free(sym_comp->name);
 	}
 	free(base_locals);


### PR DESCRIPTION
For fun I tried to create a livepatch of upstream patch
ad211f3e94b314a910d4af03178a0b52a7d1ee0a for my kernel. This
caused kpatch-build to fail with a NULL pointer derefence because
base_locals was NULL (returned via kpatch_elf_locals(), which
can return a NULL pointer). This patch fixes the SIGSEGV
via a NULL check. The end result is a live patch is created
and loaded.

Signed-off-by: Balbir singh <bsingharora@gmail.com>