### PR TITLE
integration/centos-7: fix shadow-newpid.patch warnings

### DIFF
--- a/test/integration/centos-7/shadow-newpid.patch
+++ b/test/integration/centos-7/shadow-newpid.patch
@@ -63,7 +63,7 @@ Index: src/kernel/fork.c
 +		int *newpid;
 +		static int ctr = 0;
 +
-+		newpid = klp_shadow_alloc(p, 0, sizeof(*newpid),
++		newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid),
 +					     GFP_KERNEL, NULL, NULL);
 +		if (newpid)
 +			*newpid = ctr++;


### PR DESCRIPTION
When quickly loading/unloading this patch multiple times it is possible
to hit "Duplicate shadow variable" warnings since the patch doesn't have
any cleanup hooks on unload.
Switch to klp_shadow_get_or_alloc to ignore these.
