### PR TITLE
Out of tree module fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ sys_nanosleep(), etc?**
 
 Yes! There's a few requirements, and the feature is still in its infancy.
 
-1. You need to use the `--out-of-tree` flag to specify the version of the
+1. You need to use the `--oot-module` flag to specify the version of the
 module that's currently running on the machine.
 2. `--sourcedir` has to be passed with a directory containing the same
 version of code as the running module, all set up and ready to build with a
@@ -659,15 +659,15 @@ currently-running module.
 3. If the `Module.symvers` file for the out-of-tree module doesn't appear
 in the root of the provided source directory, a symlink needs to be created
 in that directory that points to its actual location.
-4. Usually you'll need to pass the `-t` flag as well, to specify the proper
-`make` target names.
+4. Usually you'll need to pass the `--target` flag as well, to specify the
+proper `make` target names.
 5. This has only been tested for a single out-of-tree module per patch, and
 not for out-of-tree modules with dependencies on other out-of-tree modules
 built separately.
 
 ***Sample invocation***
 
-`kpatch-build -s ~/test/ -t default -e /lib/modules/$(uname -r)/extra/test.ko test.patch`
+`kpatch-build --sourcedir ~/test/ --target default --oot-module /lib/modules/$(uname -r)/extra/test.ko test.patch`
 
 
 Get involved

--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -24,7 +24,7 @@ if [[ "$TOOLCHAINCMD" = "gcc" ]] ; then
 
 			[[ "$obj" = */.tmp_*.o ]] && obj="${obj/.tmp_/}"
 			relobj=${obj//$KPATCH_GCC_SRCDIR\//}
-			case "$obj" in
+			case "$relobj" in
 				*.mod.o|\
 				*built-in.o|\
 				*built-in.a|\

--- a/man/kpatch-build.1
+++ b/man/kpatch-build.1
@@ -47,6 +47,10 @@ effect.
    Keep scratch files in /tmp
    (can be specified multiple times)
 
+-e|--oot-module
+   Enable patching out-of-tree module,
+   specify current version of module
+
 --skip-cleanup
    Skip post-build cleanup
 


### PR DESCRIPTION
Two small changes to out-of-tree module support.  

@pcd1193182 : were we building out-of-tree module kpatches differently when working on #923?  I just want to make sure I'm not breaking another use case with this change