### PR TITLE
test/unit: relax stripped object requirement

### DIFF
--- a/test/unit/Makefile.include
+++ b/test/unit/Makefile.include
@@ -33,7 +33,7 @@ define check_stripped =
 endef
 
 define check_all =
-	$(call check_stripped,$(1))
+	$(if $(findstring NOSTRIP,$(1)), , $(call check_stripped,$(1)))
 endef
 
 


### PR DESCRIPTION
Some unit tests may need debug symbols to reproduce problems (see
issue #928 for example), so skip the unit-test Makefile.include
check_stripped call for objects that include "NOSTRIP" in their
filename.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>