### PR TITLE
Revert "create-diff-object: add jump label support"

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -227,40 +227,33 @@ gcc_version_check() {
 }
 
 find_special_section_data_ppc64le() {
-
-	[[ "$CONFIG_JUMP_LABEL" -eq 0 ]] && AWK_OPTIONS="-vskip_j=1"
-
 	SPECIAL_VARS="$(readelf -wi "$VMLINUX" |
 		gawk --non-decimal-data '
-		BEGIN { f = b = e = j = 0 }
+		BEGIN { f = b = e = 0 }
 
 		# Set state if name matches
 		f == 0 && /DW_AT_name.* fixup_entry[[:space:]]*$/ {f = 1; next}
 		b == 0 && /DW_AT_name.* bug_entry[[:space:]]*$/ {b = 1; next}
 		e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
-		j == 0 && /DW_AT_name.* jump_entry[[:space:]]*$/ {j = 1; next}
 
 		# Reset state unless this abbrev describes the struct size
 		f == 1 && !/DW_AT_byte_size/ { f = 0; next }
 		b == 1 && !/DW_AT_byte_size/ { b = 0; next }
 		e == 1 && !/DW_AT_byte_size/ { e = 0; next }
-		j == 1 && !/DW_AT_byte_size/ { j = 0; next }
 
 		# Now that we know the size, stop parsing for it
 		f == 1 {printf("export FIXUP_STRUCT_SIZE=%d\n", $4); f = 2}
 		b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
 		e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
-		j == 1 {printf("export JUMP_STRUCT_SIZE=%d\n", $4); j = 2}
 
 		# Bail out once we have everything
-		f == 2 && b == 2 && e == 2 && (j == 2 || skip_j) {exit}')"
+		f == 2 && b == 2 && e == 2 {exit}')"
 
 	[[ -n "$SPECIAL_VARS" ]] && eval "$SPECIAL_VARS"
 
 	[[ -z "$FIXUP_STRUCT_SIZE" ]] && die "can't find special struct fixup_entry size"
 	[[ -z "$BUG_STRUCT_SIZE" ]] && die "can't find special struct bug_entry size"
 	[[ -z "$EX_STRUCT_SIZE" ]]  && die "can't find special struct exception_table_entry size"
-	[[ -z "$JUMP_STRUCT_SIZE" && "$CONFIG_JUMP_LABEL" -ne 0 ]]  && die "can't find special struct jump_entry size"
 
 	return
 }
@@ -273,13 +266,12 @@ find_special_section_data() {
 
 	[[ "$CONFIG_PARAVIRT" -eq 0 ]] && AWK_OPTIONS="-vskip_p=1"
 	[[ "$CONFIG_UNWINDER_ORC" -eq 0 ]] && AWK_OPTIONS="$AWK_OPTIONS -vskip_o=1"
-	[[ "$CONFIG_JUMP_LABEL" -eq 0 ]] && AWK_OPTIONS="$AWK_OPTIONS -vskip_j=1"
 
 	# If $AWK_OPTIONS are blank gawk would treat "" as a blank script
 	# shellcheck disable=SC2086
 	SPECIAL_VARS="$(readelf -wi "$VMLINUX" |
 		gawk --non-decimal-data $AWK_OPTIONS '
-		BEGIN { a = b = p = e = o = j = 0 }
+		BEGIN { a = b = p = e = o = 0 }
 
 		# Set state if name matches
 		a == 0 && /DW_AT_name.* alt_instr[[:space:]]*$/ {a = 1; next}
@@ -287,7 +279,6 @@ find_special_section_data() {
 		p == 0 && /DW_AT_name.* paravirt_patch_site[[:space:]]*$/ {p = 1; next}
 		e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
 		o == 0 && /DW_AT_name.* orc_entry[[:space:]]*$/ {o = 1; next}
-		j == 0 && /DW_AT_name.* jump_entry[[:space:]]*$/ {j = 1; next}
 
 		# Reset state unless this abbrev describes the struct size
 		a == 1 && !/DW_AT_byte_size/ { a = 0; next }
@@ -295,7 +286,6 @@ find_special_section_data() {
 		p == 1 && !/DW_AT_byte_size/ { p = 0; next }
 		e == 1 && !/DW_AT_byte_size/ { e = 0; next }
 		o == 1 && !/DW_AT_byte_size/ { o = 0; next }
-		j == 1 && !/DW_AT_byte_size/ { j = 0; next }
 
 		# Now that we know the size, stop parsing for it
 		a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
@@ -303,10 +293,9 @@ find_special_section_data() {
 		p == 1 {printf("export PARA_STRUCT_SIZE=%d\n", $4); p = 2}
 		e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
 		o == 1 {printf("export ORC_STRUCT_SIZE=%d\n", $4); o = 2}
-		j == 1 {printf("export JUMP_STRUCT_SIZE=%d\n", $4); j = 2}
 
 		# Bail out once we have everything
-		a == 2 && b == 2 && (p == 2 || skip_p) && e == 2 && (o == 2 || skip_o) && (j == 2 || skip_j) {exit}')"
+		a == 2 && b == 2 && (p == 2 || skip_p) && e == 2 && (o == 2 || skip_o) {exit}')"
 
 	[[ -n "$SPECIAL_VARS" ]] && eval "$SPECIAL_VARS"
 
@@ -315,7 +304,6 @@ find_special_section_data() {
 	[[ -z "$EX_STRUCT_SIZE" ]]  && die "can't find special struct paravirt_patch_site size"
 	[[ -z "$PARA_STRUCT_SIZE" && "$CONFIG_PARAVIRT" -ne 0 ]] && die "can't find special struct paravirt_patch_site size"
 	[[ -z "$ORC_STRUCT_SIZE" && "$CONFIG_UNWINDER_ORC" -ne 0 ]] && die "can't find special struct orc_entry size"
-	[[ -z "$JUMP_STRUCT_SIZE" && "$CONFIG_JUMP_LABEL" -ne 0 ]] && die "can't find special struct jump_entry size"
 
 	return
 }
@@ -725,11 +713,6 @@ if grep -q "CONFIG_UNWINDER_ORC=y" "$CONFIGFILE"; then
 	CONFIG_UNWINDER_ORC=1
 else
 	CONFIG_UNWINDER_ORC=0
-fi
-if grep -q "CONFIG_JUMP_LABEL=y" "$CONFIGFILE"; then
-	CONFIG_JUMP_LABEL=1
-else
-	CONFIG_JUMP_LABEL=0
 fi
 
 # unsupported kernel option checking


### PR DESCRIPTION
This reverts commit 87c64519fce02424e00725ddaeff8b619d40d160.

The jump label support doesn't work with upstream livepatch.  Joe
Lawrence found the following ordering issue:

```
load_module

  apply_relocations

    /* Livepatch relocation sections are applied by livepatch */
    if (info->sechdrs[i].sh_flags & SHF_RELA_LIVEPATCH)
            continue;

  post_relocation
    module_finalize
      jump_label_apply_nops        << crash

  ...

  do_init_module
    do_one_initcall(mod->init)
      __init patch_init [kpatch-patch]
        klp_register_patch
          klp_init_patch
            klp_init_object
              klp_init_object_loaded
                klp_write_object_relocations
```

So jump_label_apply_nops() is called *before*
klp_write_object_relocations() has had a chance to write the klp
relocations (.klp.rela.kvm_intel.__jump_table, for example).

We need to resolve this upstream first.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>