### PR TITLE
kpatch-build: fix memleak in function kpatch_write_output_elf

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -814,6 +814,9 @@ void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile)
 		printf("%s\n",elf_errmsg(-1));
 		ERROR("elf_update");
 	}
+
+	elf_end(elfout);
+	close(fd);
 }
 
 /*


### PR DESCRIPTION
Signed-off-by: chenzefeng <chenzefeng2@huawei.com>