### PR TITLE
Patch release v0.6.3

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,6 +1,6 @@
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.6.2
+Version: 0.6.3
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch
@@ -93,6 +93,17 @@ rm -rf %{buildroot}
 %{_mandir}/man1/kpatch-build.1*
 
 %changelog
+* Fri Apr 12 2019 Joe Lawrence <joe.lawrence@redhat.com> - 0.6.3
+- Lots of integration test work
+- Better support for building out-of-tree modules
+- Updated manpage options, drop deprecated distro specific mentions
+- README.md updates for shadow variables, out-of-tree modules
+- Fix core module compilation with CONFIG_HAVE_ARCH_PREL32_RELOCATIONS
+- kpatch-build detects and abort on unsupported options
+  GCC_PLUGIN_LATENT_ENTROPY, GCC_PLUGIN_RANDSTRUCT
+- Fix patch linking with 4.20+
+- Other minor shellcheck and kpatch-build fixups
+
 * Tue Oct 2 2018 Joe Lawrence <joe.lawrence@redhat.com> - 0.6.2
 - ppc64le: relax .text section addralign value check
 - gcc8: unit-tests

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
-VERSION="0.6.2"
+VERSION="0.6.3"
 POST_ENABLE_WAIT=15	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 


### PR DESCRIPTION
Create a minor release that includes fixes for:

- Lots of integration test work
- Better support for building out-of-tree modules
- Updated manpage options, drop deprecated distro specific mentions
- README.md updates for shadow variables, out-of-tree modules
- Fix core module compilation with CONFIG_HAVE_ARCH_PREL32_RELOCATIONS
- kpatch-build detects and abort on unsupported options
  GCC_PLUGIN_LATENT_ENTROPY, GCC_PLUGIN_RANDSTRUCT
- Fix patch linking with 4.20+
- Other minor shellcheck and kpatch-build fixups

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>