### PR TITLE
create-diff-objject: fix memleak of the struct lookup_table

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3378,6 +3378,7 @@ int main(int argc, char *argv[])
 	kpatch_dump_kelf(kelf_out);
 	kpatch_write_output_elf(kelf_out, kelf_patched->elf, output_obj);
 
+	lookup_close(lookup);
 	kpatch_elf_free(kelf_patched);
 	kpatch_elf_teardown(kelf_out);
 	kpatch_elf_free(kelf_out);


### PR DESCRIPTION
 reason: Firstly, in the function lookup_open use the malloc to
              allocate some memory, but call the function lookup_close
               to free the memory.
               Secondly, table->obj_sym->name, table->exp_sym->name and
               table->exp_sym->objname used the strdup, so them should
               free also.
               Thirdly, adjust the order of make_nodname, if not, it
               will cause an exception when free(exp_sym->objname) in
                lookup_close.