### PR TITLE
lookup: Fix memleak in symtab_read()

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -248,7 +248,6 @@ static void symtab_read(struct lookup_table *table, char *path)
 
 		table->obj_syms[i].value = value;
 		table->obj_syms[i].size = size;
-		table->obj_syms[i].name = strdup(name);
 
 		if (!strcmp(bind, "LOCAL")) {
 			table->obj_syms[i].bind = STB_LOCAL;


### PR DESCRIPTION
Fix memory leak in symtab_read(), by removing the duplicate strdup()
of obj_syms.name.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>