### PR TITLE
kmod: fix memleak in the function patch_exit

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -460,6 +460,7 @@ out:
 static void __exit patch_exit(void)
 {
 	WARN_ON(klp_unregister_patch(lpatch));
+	patch_free_livepatch(lpatch);
 }
 
 module_init(patch_init);


### PR DESCRIPTION
reason: after calling the function klp_unregister_patch in patch_exit,
             the lpatch must be freed, otherwise, it would cause memory leak.

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>