### PR TITLE
kpatch-build/kpatch-build: fix error of invalid ancestor

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -323,8 +323,8 @@ find_parent_obj() {
 			num="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | grep -Fvc "$pdir/.${file}.cmd")"
 		fi
 		if [[ "$num" -eq 0 ]]; then
-			parent="$(find ./* -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fv "$pdir/.${file}.cmd" | cut -c3- | head -n1)"
-			num="$(find ./* -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fvc "$pdir/.${file}.cmd")"
+			parent="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fv "$pdir/.${file}.cmd" | cut -c3- | head -n1)"
+			num="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fvc "$pdir/.${file}.cmd")"
 			[[ "$num" -eq 1 ]] && last_deep_find="$(dirname "$parent")"
 		fi
 	else


### PR DESCRIPTION
reason:	when I make a livepatch for a out of module.Cause the error
	as follow:
	ERROR: invalid ancestor xxx/xxx.o for xxx/xxx.o.

	The testcase is as follow:
	wwheart@linux41:~/helloworld 0 > tree
	├── hello.c
	├── Makefile
	├── test.patch
	└── xxx
	    ├── xxx.c
	    └── xxx.h
	wwheart@linux41:~/helloworld 0 > cat test.patch
	diff --git a/xxx/xxx.c b/xxx/xxx.c
	index aab3c67..d81ad00 100644
	--- a/xxx/xxx.c
	+++ b/xxx/xxx.c
	@@ -1,6 +1,7 @@
	#include <linux/kernel.h>
	void czf_test(void)
	{
	+       printk("livepatch test\n");
		printk("xxx\n");
	}

        Makefile:
        obj-m += buffer_overflow1.o
        buffer_overflow1-y += hello.o xxx/xxx.o

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>