### PR TITLE
Fix livepatch-enabled kernel detection in kpatch script

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -126,7 +126,7 @@ find_core_module() {
 }
 
 core_loaded () {
-	grep -q -e "T klp_register_patch" -e "T kpatch_register" /proc/kallsyms
+	grep -q -e "T klp_enable_patch" -e "T kpatch_register" /proc/kallsyms
 }
 
 get_module_name () {


### PR DESCRIPTION
We can no longer use klp_register_patch symbol to determine if the
kernel is livepatch-enabled. Use klp_enable_patch instead.