### PR TITLE
Testing systemctl existence before executing it

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -469,7 +469,7 @@ case "$1" in
 	echo "installing $PATCH ($KVER)"
 	mkdir -p "$INSTALLDIR/$KVER" || die "failed to create install directory"
 	cp -f "$PATCH" "$INSTALLDIR/$KVER" || die "failed to install module $PATCH"
-	systemctl enable kpatch.service
+	command -v systemctl > /dev/null 2>&1 && systemctl enable kpatch.service
 	;;
 
 "uninstall")


### PR DESCRIPTION
Since commit c9614c429822b kpatch has support for upstart systems,
which means we should test the existence of `systemctl` before executing
it.

The command `command` is POSIX compliant, and should be widely
available.

Signed-of-by: Bruno Loreto <loretob@amazon.com>