### PR TITLE
kpatch-elf: fix the unexpected elf class

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -765,7 +765,7 @@ void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile)
 	if (!elfout)
 		ERROR("elf_begin");
 
-	if (!gelf_newehdr(elfout, gelf_getclass(kelf->elf)))
+	if (!gelf_newehdr(elfout, gelf_getclass(elf)))
 		ERROR("gelf_newehdr");
 
 	if (!gelf_getehdr(elfout, &ehout))


### PR DESCRIPTION
kpatch-elf::kpatch_write_output_elf will call the gelf_getclass()
to acquire the output elf's class. But the input parameter kelf->elf
is NULL, the gelf_getclass(kelf->elf) will return ELFCLASSNONE, not
the value we expect ELFCLASS32 or ELFCLASS64.

the gelf_getclass function code:
int
gelf_getclass (Elf *elf)
{
  return elf == NULL || elf->kind != ELF_K_ELF ? ELFCLASSNONE : elf->class;
}

the gelf_newehdr fuction code:
void *
gelf_newehdr (Elf *elf, int class)
{
  return (class == ELFCLASS32
          ? (void *) INTUSE(elf32_newehdr) (elf)
          : (void *) INTUSE(elf64_newehdr) (elf));
}

Luckily, when we create a patch for x86_64, if we pass the ELFCLASSNONE
for the function gelf_newehdr, it will return elf64_newehdr, so don't
cause the fault. But it's better to use the gelf_getclass(elf) instead of
gelf_getclass(kelf->elf).

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>