### PR TITLE
kpatch, kpatch-build: Use -n instead of ! -z

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -950,7 +950,7 @@ fi
 # column containing lines unique to first file.
 UNDEFINED=$(comm -23 <(sort -u "${TEMPDIR}"/undefined_references) \
 	<(sort -u "${TEMPDIR}"/new_symbols) | tr '\n' ' ')
-[[ ! -z "$UNDEFINED" ]] && die "Undefined symbols: $UNDEFINED"
+[[ -n "$UNDEFINED" ]] && die "Undefined symbols: $UNDEFINED"
 
 cp -f "$TEMPDIR/patch/$MODNAME.ko" "$BASE" || die
 

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -157,7 +157,7 @@ verify_module_checksum () {
 	checksum="$(readelf -p .kpatch.checksum "$1" 2>&1 | grep '\[.*\]' | awk '{print $3}')"
 
 	# Fail checksum match only if both exist and diverge
-	if [[ ! -z "$checksum" ]] && [[ -e "$SYSFS/${modname}/checksum" ]] ; then
+	if [[ -n "$checksum" ]] && [[ -e "$SYSFS/${modname}/checksum" ]] ; then
 		sysfs_checksum="$(cat "$SYSFS/${modname}/checksum")"
 		[[ "$checksum" == "$sysfs_checksum" ]] || return 1
 	fi


### PR DESCRIPTION
make check using shellcheck version 0.6.0 suggests following
improvements:
In kpatch/kpatch line 160:
        if [[ ! -z "$checksum" ]] && [[ -e "$SYSFS/${modname}/checksum"]] ; then
              ^-- SC2236: Use -n instead of ! -z.

In kpatch-build/kpatch-build line 953:
[[ ! -z "$UNDEFINED" ]] && die "Undefined symbols: $UNDEFINED"
   ^-- SC2236: Use -n instead of ! -z.

'-n' and '! -z' are used interchangeably across the scripts, let's use
'-n' consistently to check a non-empty string instead of using negation.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>