### PR TITLE
Update fixup-section patches

### DIFF
--- a/test/integration/centos-7/fixup-section.patch
+++ b/test/integration/centos-7/fixup-section.patch
@@ -1,12 +1,12 @@
-diff -Nupr src.orig/fs/readdir.c src/fs/readdir.c
---- src.orig/fs/readdir.c	2017-09-22 15:27:21.658056010 -0400
-+++ src/fs/readdir.c	2017-09-22 15:27:26.378075555 -0400
-@@ -166,6 +166,8 @@ static int filldir(void * __buf, const c
+diff --git a/fs/readdir.c b/fs/readdir.c
+index febd02dfbe2d..064db7bd70d0 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -176,6 +176,7 @@ static int filldir(void * __buf, const char * name, int namlen, loff_t offset,
  			goto efault;
  	}
  	dirent = buf->current_dir;
-+	if (dirent->d_ino == 12345678)
-+		printk("kpatch-test: testing .fixup section changes\n");
++	asm("nop");
  	if (__put_user(d_ino, &dirent->d_ino))
  		goto efault;
  	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/ubuntu-16.04/fixup-section.patch
+++ b/test/integration/ubuntu-16.04/fixup-section.patch
@@ -1,12 +1,12 @@
-diff -Nupr src.orig/fs/readdir.c src/fs/readdir.c
---- src.orig/fs/readdir.c	2016-12-15 19:55:39.196000000 +0000
-+++ src/fs/readdir.c	2016-12-15 19:56:25.868000000 +0000
-@@ -173,6 +173,8 @@ static int filldir(struct dir_context *c
+diff --git a/fs/readdir.c b/fs/readdir.c
+index ced679179cac..7fb338324582 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -173,6 +173,7 @@ static int filldir(struct dir_context *ctx, const char *name, int namlen,
  			goto efault;
  	}
  	dirent = buf->current_dir;
-+	if (dirent->d_ino == 12345678)
-+		printk("kpatch-test: testing .fixup section changes\n");
++	asm("nop");
  	if (__put_user(d_ino, &dirent->d_ino))
  		goto efault;
  	if (__put_user(reclen, &dirent->d_reclen))


### PR DESCRIPTION
These patches previously would try to dereference a userspace pointer
directly which can cause issue on some systems. Since the aim of these
patches is to check fixup section changes we can don't need to do any
meaningful changes to the function, so change the patches to just add
asm("nop") instead.