### PR TITLE
lookup: use the "UND" instead of "UNDEF"

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -218,7 +218,7 @@ static void symtab_read(struct lookup_table *table, char *path)
 		}
 
 		if (matched != 6 ||
-		    !strcmp(ndx, "UNDEF") ||
+		    !strcmp(ndx, "UND") ||
 		    !strcmp(type, "SECTION"))
 			continue;
 
@@ -242,7 +242,7 @@ static void symtab_read(struct lookup_table *table, char *path)
 		}
 
 		if (matched != 6 ||
-		    !strcmp(ndx, "UNDEF") ||
+		    !strcmp(ndx, "UND") ||
 		    !strcmp(type, "SECTION"))
 			continue;
 


### PR DESCRIPTION
Using "readelf -s xxx.ko" to get the symtab, when the symbol type
is SHN_UNDEF, it will display "UND", not "UNDEF", such as follow:

Symbol table '.symtab' contains 64 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND
    61: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND printk

and the command readelf's in binutils-2.27/binutils/readelf.c :

static const char *
get_symbol_index_type (unsigned int type)
{
	......
  switch (type)
    {
    case SHN_UNDEF:     return "UND";
    case SHN_ABS:       return "ABS";
    case SHN_COMMON:    return "COM";
	......
    }
	......
}

Therefore, we should strcmp with "UND" instead of "UNDEF".

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>