### PR TITLE
test: use readelf instead of eu-readelf

### DIFF
--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -46,7 +46,7 @@ do
 		;;
 	esac
 	# skip objects that are the linked product of more than one object file
-	[[ $(eu-readelf -s $i | grep FILE | wc -l) -ne 1 ]] && continue
+	[[ $(readelf -s $i | awk '$4=="FILE" {n++} END {print n}') -ne 1 ]] && continue
 	$SCRIPTDIR/../kpatch-build/create-diff-object $i $i /usr/lib/debug/lib/modules/$(uname -r)/vmlinux "$TEMPDIR/output.o" > "$TEMPDIR/log.txt" 2>&1
 	RETCODE=$?
 	# expect RETCODE to be 3 indicating no change

--- a/test/unit/Makefile.include
+++ b/test/unit/Makefile.include
@@ -43,7 +43,7 @@ clean:
 	rm -f *.$(EXT_TEST_OUTPUT) *.$(EXT_OUTPUT)
 
 %.$(EXT_SYMTAB):
-	eu-readelf -s $(patsubst %.$(EXT_SYMTAB),%.$(EXT_ORIG),$(@)) >$@
+	readelf -s --wide $(patsubst %.$(EXT_SYMTAB),%.$(EXT_ORIG),$(@)) >$@
 
 %.$(EXT_TEST_OUTPUT): %.$(EXT_OUTPUT) %.$(EXT_TEST) $(TEST_LIBRARY)
 	@echo "TEST $(@:.$(EXT_TEST_OUTPUT)=)"


### PR DESCRIPTION
readelf is more standard, using readelf insteaded

test/difftree.sh: the symbol name may be with "FILE", which may be
	get a incorrect count, here add "awk".

test/unit/Makefile.include: use "readelf -s --wide" instead of
	"eu-readelf -s".

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>