### PR TITLE
kpatch-elf: fix Segmentation fault when d_type not set properly

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -647,6 +647,7 @@ struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
 	relasec->data = malloc(sizeof(*relasec->data));
 	if (!relasec->data)
 		ERROR("malloc");
+	relasec->data->d_type = ELF_T_RELA;
 
 	/* set section header */
 	relasec->sh.sh_type = SHT_RELA;


### PR DESCRIPTION
kpatch-elf::create_section_pair would create new rela section, and the
relasec->data->d_type is not set, which is a random value, and it will
use in kpatch-elf::kpatch_write_output_elf
	data->d_type = sec->data->d_type;
which would cause Segmentation fault in kpatch_write_output_elf::elf_update.

Program received signal SIGSEGV, Segmentation fault.
(gdb) bt
0  0x00007ffff7bcd8d2 in __elf64_updatefile at elf64_updatefile.c
1  0x00007ffff7bc9bed in write_file at elf_update.c
2  0x00007ffff7bc9f16 in elf_update at elf_update.c
3  0x000000000040ca3d in kpatch_write_output_elf at kpatch-elf.c
4  0x0000000000409a92 in main at create-diff-object.c

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>