### PR TITLE
lookup: Fix format string for symtab_read() on PPC64LE

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -209,8 +209,18 @@ static void symtab_read(struct lookup_table *table, char *path)
 		ERROR("fopen");
 
 	while (fgets(line, 256, file)) {
-		matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
-				 &value, size, type, bind, ndx, name);
+		if (strstr(line, "[<localentry>: 8]")) {
+			/*
+			 * 23: 0000000000000008    96 FUNC    LOCAL  DEFAULT [<localentry>: 8]     4 cmdline_proc_show
+			 * On Power, local func syms Ndx is preceded with "[<localentry>: 8]"
+			 * denoting local entry point offset of the function.
+			 */
+			matched = sscanf(line, "%*s %lx %s %s %s %*s [<localentry>: 8] %s %s\n",
+					 &value, size, type, bind, ndx, name);
+		} else {
+			matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
+					 &value, size, type, bind, ndx, name);
+		}
 
 		if (matched == 5) {
 			name[0] = '\0';
@@ -233,8 +243,13 @@ static void symtab_read(struct lookup_table *table, char *path)
 	rewind(file);
 
 	while (fgets(line, 256, file)) {
-		matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
-				 &value, size, type, bind, ndx, name);
+		if (strstr(line, "[<localentry>: 8]")) {
+			matched = sscanf(line, "%*s %lx %s %s %s %*s [<localentry>: 8] %s %s\n",
+					 &value, size, type, bind, ndx, name);
+		} else {
+			matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
+					 &value, size, type, bind, ndx, name);
+		}
 
 		if (matched == 5) {
 			name[0] = '\0';


### PR DESCRIPTION
commit 767d9669bd13 ("kpatch-build: use readelf instead of eu-readelf")
replaced eu-readelf with readelf for constructing symbol table.  The
format of symbol table entries differs a little on Power when the symbol
is a function with binding type LOCAL.  For example, consider:

23: 0000000000000008    96 FUNC    LOCAL  DEFAULT [<localentry>: 8]    4 cmdline_proc_show

An extra column preceding index of the symbol denoting symbol value to
be local entry point offset of the function is printed, with the
current sscanf format string in lookup::symtab_read the values will
mismatch ending with in-accurate lookup table getting constructed. This
patch fixes it by introducing a Power specific format string for
function symbols with bind type LOCAL.

Fixes: 767d9669 ("kpatch-build: use readelf instead of eu-readelf")
Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>