### PR TITLE
contrib/service: don't unload modules on stop

### DIFF
--- a/contrib/kpatch.service
+++ b/contrib/kpatch.service
@@ -6,7 +6,6 @@ ConditionKernelCommandLine=!kpatch.enable=0
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=PREFIX/sbin/kpatch load --all
-ExecStop=PREFIX/sbin/kpatch unload --all
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The kpatch.service file shouldn't unload patch modules on service stop
(this is also executed by systemd on reboot).  Patch modules may not be
designed to be safely unloaded and/or may patch kernel routines that
need to continue to run throughout system bring down.

Suggested-by: disaster123
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>