### PR TITLE
kpatch-build: remove localentry data from ppc64le symtab

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -846,6 +846,9 @@ for i in $FILES; do
 		fi
 
 		readelf -s --wide "$KOBJFILE_PATH" > "$SYMTAB"
+		if [[ "$ARCH" = "ppc64le" ]]; then
+			sed -ri 's/\s+\[<localentry>: 8\]//' "$SYMTAB"
+		fi
 
 		# create-diff-object orig.o patched.o parent-name parent-symtab
 		#		     Module.symvers patch-mod-name output.o

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -209,18 +209,8 @@ static void symtab_read(struct lookup_table *table, char *path)
 		ERROR("fopen");
 
 	while (fgets(line, 256, file)) {
-		if (strstr(line, "[<localentry>: 8]")) {
-			/*
-			 * 23: 0000000000000008    96 FUNC    LOCAL  DEFAULT [<localentry>: 8]     4 cmdline_proc_show
-			 * On Power, local func syms Ndx is preceded with "[<localentry>: 8]"
-			 * denoting local entry point offset of the function.
-			 */
-			matched = sscanf(line, "%*s %lx %s %s %s %*s [<localentry>: 8] %s %s\n",
-					 &value, size, type, bind, ndx, name);
-		} else {
-			matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
-					 &value, size, type, bind, ndx, name);
-		}
+		matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
+				 &value, size, type, bind, ndx, name);
 
 		if (matched == 5) {
 			name[0] = '\0';
@@ -243,13 +233,8 @@ static void symtab_read(struct lookup_table *table, char *path)
 	rewind(file);
 
 	while (fgets(line, 256, file)) {
-		if (strstr(line, "[<localentry>: 8]")) {
-			matched = sscanf(line, "%*s %lx %s %s %s %*s [<localentry>: 8] %s %s\n",
-					 &value, size, type, bind, ndx, name);
-		} else {
-			matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
-					 &value, size, type, bind, ndx, name);
-		}
+		matched = sscanf(line, "%*s %lx %s %s %s %*s %s %s\n",
+				 &value, size, type, bind, ndx, name);
 
 		if (matched == 5) {
 			name[0] = '\0';


### PR DESCRIPTION
```
commit f8213c87f64a ("lookup: Fix format string for symtab_read() on
PPC64LE") fixed the symbol table lookup when readelf adds ppc64le
"[<localentry>: 8]" info for functions like so:

  23: 0000000000000008    96 FUNC    LOCAL  DEFAULT [<localentry>: 8]    4 cmdline_proc_show

however, it seems that readelf 2.30-57.el8 displays this in a slightly
different format:

  24493: c000000000587970    96 FUNC    LOCAL  DEFAULT    2 cmdline_proc_show    [<localentry>: 8]

Instead of adding more cases to kpatch-build's lookup.c scanf format,
let's just delete this information from the symtab file with a quick and
dirty sed regex.  This allows us to handle both observed cases (and
perhaps others) while removing the arch-specific scanf formatting in
lookup.c

Fixes: f8213c87f64a ("lookup: Fix format string for symtab_read() on PPC64LE")
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>
```