### PR TITLE
test/integration: add patches rebased for recent rhel minor releases

### DIFF
--- a/test/integration/rhel-7.4/bug-table-section.patch
+++ b/test/integration/rhel-7.4/bug-table-section.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.769056469 -0400
+@@ -266,6 +266,8 @@ void sysctl_head_put(struct ctl_table_he
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-7.4/cmdline-string-LOADED.test
+++ b/test/integration/rhel-7.4/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-7.4/cmdline-string.patch
+++ b/test/integration/rhel-7.4/cmdline-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:22.955061380 -0400
+@@ -5,7 +5,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_printf(m, "%s\n", saved_command_line);
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-7.4/data-new-LOADED.test
+++ b/test/integration/rhel-7.4/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch: 5" /proc/meminfo

--- a/test/integration/rhel-7.4/data-new.patch
+++ b/test/integration/rhel-7.4/data-new.patch
@@ -1,0 +1,28 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:24.102066130 -0400
+@@ -20,6 +20,8 @@ void __attribute__((weak)) arch_report_m
+ {
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -106,6 +108,7 @@ static int meminfo_proc_show(struct seq_
+ #ifdef CONFIG_TRANSPARENT_HUGEPAGE
+ 		"AnonHugePages:  %8lu kB\n"
+ #endif
++		"kpatch: %d"
+ 		,
+ 		K(i.totalram),
+ 		K(i.freeram),
+@@ -167,6 +170,7 @@ static int meminfo_proc_show(struct seq_
+ 		,K(global_page_state(NR_ANON_TRANSPARENT_HUGEPAGES) *
+ 		   HPAGE_PMD_NR)
+ #endif
++		,foo
+ 		);
+ 
+ 	hugetlb_report_meminfo(m);

--- a/test/integration/rhel-7.4/data-read-mostly.patch
+++ b/test/integration/rhel-7.4/data-read-mostly.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/net/core/dev.c src/net/core/dev.c
+--- src.orig/net/core/dev.c	2017-09-22 15:27:21.759056428 -0400
++++ src/net/core/dev.c	2017-09-22 15:27:25.244070859 -0400
+@@ -4012,6 +4012,7 @@ ncls:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-7.4/fixup-section.patch
+++ b/test/integration/rhel-7.4/fixup-section.patch
@@ -1,0 +1,12 @@
+diff --git a/fs/readdir.c b/fs/readdir.c
+index fee38e04fae4..bce1e5ce74e5 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -166,6 +166,7 @@ static int filldir(void * __buf, const char * name, int namlen, loff_t offset,
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-7.4/gcc-constprop.patch
+++ b/test/integration/rhel-7.4/gcc-constprop.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/time/timekeeping.c	2017-09-22 15:27:27.522080292 -0400
+@@ -877,6 +877,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-7.4/gcc-isra.patch
+++ b/test/integration/rhel-7.4/gcc-isra.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/proc_sysctl.c	2017-09-22 15:27:28.670085046 -0400
+@@ -24,6 +24,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-7.4/gcc-mangled-3.patch
+++ b/test/integration/rhel-7.4/gcc-mangled-3.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/slub.c src/mm/slub.c
+--- src.orig/mm/slub.c	2017-09-22 15:27:21.618055844 -0400
++++ src/mm/slub.c	2017-09-22 15:27:29.830089850 -0400
+@@ -5528,6 +5528,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	unsigned long nr_free = 0;
+ 	int node;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_online_node(node) {
+ 		struct kmem_cache_node *n = get_node(s, node);
+ 

--- a/test/integration/rhel-7.4/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var-2.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
+--- src.orig/mm/mmap.c	2017-09-22 15:27:21.618055844 -0400
++++ src/mm/mmap.c	2017-09-22 15:27:31.024094794 -0400
+@@ -1687,6 +1688,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-7.4/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var-3.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/kernel/sys.c src/kernel/sys.c
+--- src.orig/kernel/sys.c	2017-09-22 15:27:21.601055773 -0400
++++ src/kernel/sys.c	2017-09-22 15:27:32.170099540 -0400
+@@ -554,8 +554,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-7.4/gcc-static-local-var-4.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var-4.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2017-09-22 15:27:21.702056192 -0400
++++ src/fs/aio.c	2017-09-22 15:27:33.299104215 -0400
+@@ -219,9 +219,16 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
+ static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(aio_ring_file->f_inode, 0);
+ 

--- a/test/integration/rhel-7.4/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.4/gcc-static-local-var-4.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-7.4/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/audit.c	2017-09-22 15:27:34.429108894 -0400
+@@ -205,6 +205,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -215,6 +221,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -234,6 +241,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -282,6 +294,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(NULL, GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-7.4/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index a9d587a..23336ed 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -106,6 +106,8 @@ static int nf_ip6_reroute(struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -119,6 +121,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/rhel-7.4/gcc-static-local-var.patch
+++ b/test/integration/rhel-7.4/gcc-static-local-var.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/arch/x86/kernel/ldt.c src/arch/x86/kernel/ldt.c
+--- src.orig/arch/x86/kernel/ldt.c	2017-09-22 15:27:20.847052651 -0400
++++ src/arch/x86/kernel/ldt.c	2017-09-22 15:27:35.573113632 -0400
+@@ -98,6 +98,12 @@ static inline int copy_ldt(mm_context_t
+ 	return 0;
+ }
+ 
++void hi_there(void)
++{
++	if (!jiffies)
++		printk("hi there\n");
++}
++
+ /*
+  * we do not have to muck with descriptors here, that is
+  * done in switch_mm() as needed.
+@@ -107,6 +113,8 @@ int init_new_context(struct task_struct
+ 	struct mm_struct *old_mm;
+ 	int retval = 0;
+ 
++	hi_there();
++
+ 	mutex_init(&mm->context.lock);
+ 	mm->context.size = 0;
+ 	old_mm = current->mm;

--- a/test/integration/rhel-7.4/macro-callbacks.patch
+++ b/test/integration/rhel-7.4/macro-callbacks.patch
@@ -1,0 +1,160 @@
+kpatch/livepatch callback test patch:
+
+  vmlinux
+  pcspkr (mod)
+  joydev (mod)
+
+Note: update joydev's pre-patch callback to return -ENODEV to test failure path
+
+--- src.old/fs/aio.c	2018-02-26 11:07:51.522610407 -0500
++++ src/fs/aio.c	2018-03-05 11:17:21.560015449 -0500
+@@ -42,6 +42,50 @@
+ #include <asm/kmap_types.h>
+ #include <asm/uaccess.h>
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0
+--- src.old/drivers/input/joydev.c	2018-02-26 11:07:49.470610407 -0500
++++ src/drivers/input/joydev.c	2018-03-05 11:18:13.998015449 -0500
+@@ -954,3 +954,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+--- src.old/drivers/input/misc/pcspkr.c	2018-02-26 11:07:49.477610407 -0500
++++ src/drivers/input/misc/pcspkr.c	2018-03-05 11:18:23.411015449 -0500
+@@ -136,3 +136,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);

--- a/test/integration/rhel-7.4/macro-printk.patch
+++ b/test/integration/rhel-7.4/macro-printk.patch
@@ -1,0 +1,147 @@
+diff -Nupr src.orig/net/ipv4/fib_frontend.c src/net/ipv4/fib_frontend.c
+--- src.orig/net/ipv4/fib_frontend.c	2017-09-22 16:52:10.646110299 -0400
++++ src/net/ipv4/fib_frontend.c	2017-09-22 16:55:14.395870305 -0400
+@@ -633,6 +633,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+ {
+ 	struct net *net = sock_net(skb->sk);
+@@ -651,6 +652,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	}
+ 
+ 	err = fib_table_insert(net, tb, &cfg);
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+diff -Nupr src.orig/net/ipv4/fib_semantics.c src/net/ipv4/fib_semantics.c
+--- src.orig/net/ipv4/fib_semantics.c	2017-09-22 16:52:10.645110295 -0400
++++ src/net/ipv4/fib_semantics.c	2017-09-22 16:54:05.175584004 -0400
+@@ -925,6 +925,7 @@ fib_convert_metrics(struct fib_info *fi,
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg)
+ {
+ 	int err;
+@@ -949,6 +950,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -969,6 +971,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (fi == NULL)
+@@ -980,6 +983,7 @@ struct fib_info *fib_create_info(struct
+ 	} else
+ 		fi->fib_metrics = (u32 *) dst_default_metrics;
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
+ 
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+@@ -996,8 +1000,10 @@ struct fib_info *fib_create_info(struct
+ 		if (!nexthop_nh->nh_pcpu_rth_output)
+ 			goto failure;
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 
+ 	err = fib_convert_metrics(fi, cfg);
++	KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 	if (err)
+ 		goto failure;
+ 
+@@ -1048,6 +1054,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp)
+@@ -1065,6 +1072,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST)
+ 		goto err_inval;
+@@ -1087,6 +1095,7 @@ struct fib_info *fib_create_info(struct
+ 				goto failure;
+ 		} endfor_nexthops(fi)
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc) {
+ 		if (cfg->fc_type != RTN_LOCAL || !cfg->fc_dst ||
+@@ -1099,6 +1108,7 @@ struct fib_info *fib_create_info(struct
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 		fib_add_weight(fi, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1110,6 +1120,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	atomic_inc(&fi->fib_clntref);
+@@ -1133,6 +1144,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1143,6 +1155,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+diff -Nupr src.orig/net/ipv4/fib_trie.c src/net/ipv4/fib_trie.c
+--- src.orig/net/ipv4/fib_trie.c	2017-09-22 16:52:10.645110295 -0400
++++ src/net/ipv4/fib_trie.c	2017-09-22 16:55:39.940975963 -0400
+@@ -1191,6 +1191,7 @@ static int fib_insert_alias(struct trie
+ }
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg)
+ {
+@@ -1216,11 +1217,14 @@ int fib_table_insert(struct net *net, st
+ 	if ((plen < KEYLENGTH) && (key << plen))
+ 		return -EINVAL;
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority) : NULL;

--- a/test/integration/rhel-7.4/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-7.4/meminfo-init-FAIL.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:40.130132502 -0400
+@@ -191,6 +191,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.4/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-7.4/meminfo-init2-FAIL.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:38.972127707 -0400
+@@ -30,6 +30,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long pages[NR_LRU_LISTS];
+ 	int lru;
+ 
++	printk("a\n");
+ /*
+  * display in kilobytes.
+  */
+@@ -191,6 +192,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.4/meminfo-string-LOADED.test
+++ b/test/integration/rhel-7.4/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-7.4/meminfo-string.patch
+++ b/test/integration/rhel-7.4/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:41.274137239 -0400
+@@ -99,7 +99,7 @@ static int meminfo_proc_show(struct seq_
+ 		"Committed_AS:   %8lu kB\n"
+ 		"VmallocTotal:   %8lu kB\n"
+ 		"VmallocUsed:    %8lu kB\n"
+-		"VmallocChunk:   %8lu kB\n"
++		"VMALLOCCHUNK:   %8lu kB\n"
+ #ifdef CONFIG_MEMORY_FAILURE
+ 		"HardwareCorrupted: %5lu kB\n"
+ #endif

--- a/test/integration/rhel-7.4/module-call-external.patch
+++ b/test/integration/rhel-7.4/module-call-external.patch
@@ -1,0 +1,33 @@
+diff -Nupr src.orig/fs/nfsd/export.c src/fs/nfsd/export.c
+--- src.orig/fs/nfsd/export.c	2017-09-22 15:27:21.705056204 -0400
++++ src/fs/nfsd/export.c	2017-09-22 15:27:42.411141948 -0400
+@@ -1184,6 +1184,8 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+@@ -1193,6 +1195,7 @@ static int e_show(struct seq_file *m, vo
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2017-09-22 15:27:21.754056407 -0400
++++ src/net/netlink/af_netlink.c	2017-09-22 15:27:42.412141952 -0400
+@@ -3260,4 +3260,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-7.4/module-kvm-fixup.patch
+++ b/test/integration/rhel-7.4/module-kvm-fixup.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/arch/x86/kvm/vmx.c src/arch/x86/kvm/vmx.c
+--- src.orig/arch/x86/kvm/vmx.c	2017-09-22 15:27:20.853052676 -0400
++++ src/arch/x86/kvm/vmx.c	2017-09-22 15:27:43.583146801 -0400
+@@ -10597,6 +10597,8 @@ static int vmx_check_intercept(struct kv
+ 			       struct x86_instruction_info *info,
+ 			       enum x86_intercept_stage stage)
+ {
++	if (!jiffies)
++		printk("kpatch vmx_check_intercept\n");
+ 	return X86EMUL_CONTINUE;
+ }
+ 

--- a/test/integration/rhel-7.4/module-shadow.patch
+++ b/test/integration/rhel-7.4/module-shadow.patch
@@ -1,0 +1,24 @@
+diff -Nupr src.orig/arch/x86/kvm/vmx.c src/arch/x86/kvm/vmx.c
+--- src.orig/arch/x86/kvm/vmx.c	2017-09-22 15:27:20.853052676 -0400
++++ src/arch/x86/kvm/vmx.c	2017-09-22 15:27:44.742151601 -0400
+@@ -10581,10 +10581,20 @@ static void vmx_leave_nested(struct kvm_
+  * It should only be called before L2 actually succeeded to run, and when
+  * vmcs01 is current (it doesn't leave_guest_mode() or switch vmcss).
+  */
++#include "kpatch.h"
+ static void nested_vmx_entry_failure(struct kvm_vcpu *vcpu,
+ 			struct vmcs12 *vmcs12,
+ 			u32 reason, unsigned long qualification)
+ {
++	int *kpatch;
++
++	kpatch = kpatch_shadow_alloc(vcpu, "kpatch", sizeof(*kpatch),
++				     GFP_KERNEL);
++	if (kpatch) {
++		kpatch_shadow_get(vcpu, "kpatch");
++		kpatch_shadow_free(vcpu, "kpatch");
++	}
++
+ 	load_vmcs12_host_state(vcpu, vmcs12);
+ 	vmcs12->vm_exit_reason = reason | VMX_EXIT_REASONS_FAILED_VMENTRY;
+ 	vmcs12->exit_qualification = qualification;

--- a/test/integration/rhel-7.4/multiple.test
+++ b/test/integration/rhel-7.4/multiple.test
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+KPATCH="sudo $ROOTDIR/kpatch/kpatch"
+
+MODULE_PREFIX="test-"
+MODULE_POSTFIX=".ko"
+TEST_POSTFIX="-LOADED.test"
+
+set -o errexit
+
+die() {
+	echo "ERROR: $@" >&2
+	exit 1
+}
+
+ko_to_test() {
+	tmp=${1%${MODULE_POSTFIX}}${TEST_POSTFIX}
+	echo ${tmp#${MODULE_PREFIX}}
+}
+
+# make sure any modules added here are disjoint
+declare -a modules
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+for file in "${SCRIPTDIR}"/*"${TEST_POSTFIX}"; do
+	name=$(basename ${file})
+	skip=0
+	for bname in "${blacklist[@]}"; do
+		if [ "${bname}" == "${name}" ]; then
+			skip=1
+			break
+		fi
+	done
+	if [ ${skip} -eq 0 ]; then
+		modules+=(${MODULE_PREFIX}${name%${TEST_POSTFIX}}${MODULE_POSTFIX})
+	fi
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded before loading any modules"
+done
+
+for mod in "${modules[@]}"; do
+	$KPATCH load $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog || die "$SCRIPTDIR/$testprog failed after loading modules"
+done
+
+for mod in "${modules[@]}"; do
+	$KPATCH unload $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded after unloading modules"
+done
+
+exit 0

--- a/test/integration/rhel-7.4/new-function.patch
+++ b/test/integration/rhel-7.4/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2017-09-22 15:27:21.084053633 -0400
++++ src/drivers/tty/n_tty.c	2017-09-22 15:27:45.888156346 -0400
+@@ -2016,7 +2016,7 @@ do_it_again:
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2098,6 +2098,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++			   const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-7.4/new-globals.patch
+++ b/test/integration/rhel-7.4/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:47.028161067 -0400
+@@ -27,3 +27,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ module_init(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:47.029161071 -0400
+@@ -16,6 +16,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -53,6 +55,7 @@ static int meminfo_proc_show(struct seq_
+ 	/*
+ 	 * Tagged format, for easy grepping and expansion.
+ 	 */
++	kpatch_print_message();
+ 	seq_printf(m,
+ 		"MemTotal:       %8lu kB\n"
+ 		"MemFree:        %8lu kB\n"

--- a/test/integration/rhel-7.4/parainstructions-section.patch
+++ b/test/integration/rhel-7.4/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/generic.c	2017-09-22 15:27:48.190165879 -0400
+@@ -194,6 +194,7 @@ int proc_alloc_inum(unsigned int *inum)
+ 	unsigned int i;
+ 	int error;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ retry:
+ 	if (!ida_pre_get(&proc_inum_ida, GFP_KERNEL))
+ 		return -ENOMEM;

--- a/test/integration/rhel-7.4/replace-section-references.patch
+++ b/test/integration/rhel-7.4/replace-section-references.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:49.362170732 -0400
+@@ -248,6 +248,8 @@ static void shared_msr_update(unsigned s
+ 
+ void kvm_define_shared_msr(unsigned slot, u32 msr)
+ {
++	if (!jiffies)
++		printk("kpatch kvm define shared msr\n");
+ 	BUG_ON(slot >= KVM_NR_SHARED_MSRS);
+ 	shared_msrs_global.msrs[slot] = msr;
+ 	if (slot >= shared_msrs_global.nr)

--- a/test/integration/rhel-7.4/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-7.4/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-7.4/shadow-newpid.patch
+++ b/test/integration/rhel-7.4/shadow-newpid.patch
@@ -1,0 +1,69 @@
+diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
+--- src.orig/fs/proc/array.c	2017-09-22 16:52:10.597110096 -0400
++++ src/fs/proc/array.c	2017-09-22 16:59:40.799972178 -0400
+@@ -359,13 +359,20 @@ static inline void task_seccomp(struct s
+ #endif
+ }
+ 
++#include "kpatch.h"
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_printf(m,	"voluntary_ctxt_switches:\t%lu\n"
+ 			"nonvoluntary_ctxt_switches:\t%lu\n",
+ 			p->nvcsw,
+ 			p->nivcsw);
++
++	newpid = kpatch_shadow_get(p, "newpid");
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
+--- src.orig/kernel/exit.c	2017-09-22 16:52:10.506109720 -0400
++++ src/kernel/exit.c	2017-09-22 16:59:40.799972178 -0400
+@@ -715,6 +715,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include "kpatch.h"
+ void do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -812,6 +813,8 @@ void do_exit(long code)
+ 	check_stack_usage();
+ 	exit_thread();
+ 
++	kpatch_shadow_free(tsk, "newpid");
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2017-09-22 16:52:10.504109711 -0400
++++ src/kernel/fork.c	2017-09-22 17:00:44.938237460 -0400
+@@ -1700,6 +1700,7 @@ struct task_struct *fork_idle(int cpu)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include "kpatch.h"
+ long do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -1737,6 +1738,13 @@ long do_fork(unsigned long clone_flags,
+ 	if (!IS_ERR(p)) {
+ 		struct completion vfork;
+ 		struct pid *pid;
++		int *newpid;
++		static int ctr = 0;
++
++		newpid = kpatch_shadow_alloc(p, "newpid", sizeof(*newpid),
++					     GFP_KERNEL);
++		if (newpid)
++			*newpid = ctr++;
+ 
+ 		trace_sched_process_fork(current, p);
+ 

--- a/test/integration/rhel-7.4/smp-locks-section.patch
+++ b/test/integration/rhel-7.4/smp-locks-section.patch
@@ -1,0 +1,14 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2017-09-22 15:27:21.077053604 -0400
++++ src/drivers/tty/tty_buffer.c	2017-09-22 15:27:50.542175618 -0400
+@@ -217,6 +217,10 @@ int tty_buffer_request_room(struct tty_p
+ 	/* OPTIMISATION: We could keep a per tty "zero" sized buffer to
+ 	   remove this conditional if its worth it. This would be invisible
+ 	   to the callers */
++
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b != NULL)
+ 		left = b->size - b->used;

--- a/test/integration/rhel-7.4/special-static-2.patch
+++ b/test/integration/rhel-7.4/special-static-2.patch
@@ -1,0 +1,24 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:51.744180596 -0400
+@@ -2093,12 +2093,20 @@ static void record_steal_time(struct kvm
+ 		&vcpu->arch.st.steal, sizeof(struct kvm_steal_time));
+ }
+ 
++void kpatch_kvm_x86_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch kvm x86 foo\n");
++}
++
+ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ {
+ 	bool pr = false;
+ 	u32 msr = msr_info->index;
+ 	u64 data = msr_info->data;
+ 
++	kpatch_kvm_x86_foo();
++
+ 	switch (msr) {
+ 	case MSR_AMD64_NB_CFG:
+ 	case MSR_IA32_UCODE_REV:

--- a/test/integration/rhel-7.4/special-static.patch
+++ b/test/integration/rhel-7.4/special-static.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2017-09-22 15:27:21.600055769 -0400
++++ src/kernel/fork.c	2017-09-22 15:27:53.052186012 -0400
+@@ -1129,10 +1129,18 @@ static void posix_cpu_timers_init_group(
+ 	INIT_LIST_HEAD(&sig->cpu_timers[2]);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-7.4/tracepoints-section.patch
+++ b/test/integration/rhel-7.4/tracepoints-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/timer.c src/kernel/timer.c
+--- src.orig/kernel/timer.c	2017-09-22 15:27:21.600055769 -0400
++++ src/kernel/timer.c	2017-09-22 15:27:54.288191131 -0400
+@@ -1390,6 +1390,9 @@ static void run_timer_softirq(struct sof
+ {
+ 	struct tvec_base *base = __this_cpu_read(tvec_bases);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	if (time_after_eq(jiffies, base->timer_jiffies))
+ 		__run_timers(base);
+ }

--- a/test/integration/rhel-7.4/warn-detect-FAIL.patch
+++ b/test/integration/rhel-7.4/warn-detect-FAIL.patch
@@ -1,0 +1,8 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:55.489196104 -0400
+@@ -1,3 +1,4 @@
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *

--- a/test/integration/rhel-7.5/bug-table-section.patch
+++ b/test/integration/rhel-7.5/bug-table-section.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.769056469 -0400
+@@ -266,6 +266,8 @@ void sysctl_head_put(struct ctl_table_he
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-7.5/cmdline-string-LOADED.test
+++ b/test/integration/rhel-7.5/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-7.5/cmdline-string.patch
+++ b/test/integration/rhel-7.5/cmdline-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:22.955061380 -0400
+@@ -5,7 +5,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_printf(m, "%s\n", saved_command_line);
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-7.5/data-new-LOADED.test
+++ b/test/integration/rhel-7.5/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch: 5" /proc/meminfo

--- a/test/integration/rhel-7.5/data-new.patch
+++ b/test/integration/rhel-7.5/data-new.patch
@@ -1,0 +1,28 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:24.102066130 -0400
+@@ -20,6 +20,8 @@ void __attribute__((weak)) arch_report_m
+ {
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -106,6 +108,7 @@ static int meminfo_proc_show(struct seq_
+ #ifdef CONFIG_TRANSPARENT_HUGEPAGE
+ 		"AnonHugePages:  %8lu kB\n"
+ #endif
++		"kpatch: %d"
+ 		,
+ 		K(i.totalram),
+ 		K(i.freeram),
+@@ -167,6 +170,7 @@ static int meminfo_proc_show(struct seq_
+ 		,K(global_page_state(NR_ANON_TRANSPARENT_HUGEPAGES) *
+ 		   HPAGE_PMD_NR)
+ #endif
++		,foo
+ 		);
+ 
+ 	hugetlb_report_meminfo(m);

--- a/test/integration/rhel-7.5/data-read-mostly.patch
+++ b/test/integration/rhel-7.5/data-read-mostly.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/net/core/dev.c src/net/core/dev.c
+--- src.orig/net/core/dev.c	2017-09-22 15:27:21.759056428 -0400
++++ src/net/core/dev.c	2017-09-22 15:27:25.244070859 -0400
+@@ -4012,6 +4012,7 @@ ncls:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-7.5/fixup-section.patch
+++ b/test/integration/rhel-7.5/fixup-section.patch
@@ -1,0 +1,12 @@
+diff --git a/fs/readdir.c b/fs/readdir.c
+index febd02dfbe2d..064db7bd70d0 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -176,6 +176,7 @@ static int filldir(void * __buf, const char * name, int namlen, loff_t offset,
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-7.5/gcc-constprop.patch
+++ b/test/integration/rhel-7.5/gcc-constprop.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/time/timekeeping.c	2017-09-22 15:27:27.522080292 -0400
+@@ -877,6 +877,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-7.5/gcc-isra.patch
+++ b/test/integration/rhel-7.5/gcc-isra.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/proc_sysctl.c	2017-09-22 15:27:28.670085046 -0400
+@@ -24,6 +24,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-7.5/gcc-mangled-3.patch
+++ b/test/integration/rhel-7.5/gcc-mangled-3.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/slub.c src/mm/slub.c
+--- src.orig/mm/slub.c	2017-09-22 15:27:21.618055844 -0400
++++ src/mm/slub.c	2017-09-22 15:27:29.830089850 -0400
+@@ -5528,6 +5528,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	unsigned long nr_free = 0;
+ 	int node;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_online_node(node) {
+ 		struct kmem_cache_node *n = get_node(s, node);
+ 

--- a/test/integration/rhel-7.5/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var-2.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
+--- src.orig/mm/mmap.c	2017-09-22 15:27:21.618055844 -0400
++++ src/mm/mmap.c	2017-09-22 15:27:31.024094794 -0400
+@@ -1687,6 +1688,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-7.5/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var-3.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/kernel/sys.c src/kernel/sys.c
+--- src.orig/kernel/sys.c	2017-09-22 15:27:21.601055773 -0400
++++ src/kernel/sys.c	2017-09-22 15:27:32.170099540 -0400
+@@ -554,8 +554,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-7.5/gcc-static-local-var-4.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var-4.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2017-09-22 15:27:21.702056192 -0400
++++ src/fs/aio.c	2017-09-22 15:27:33.299104215 -0400
+@@ -219,9 +219,16 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
+ static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(aio_ring_file->f_inode, 0);
+ 

--- a/test/integration/rhel-7.5/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.5/gcc-static-local-var-4.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-7.5/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/audit.c	2017-09-22 15:27:34.429108894 -0400
+@@ -205,6 +205,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -215,6 +221,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -234,6 +241,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -282,6 +294,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(NULL, GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-7.5/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index a9d587a..23336ed 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -106,6 +106,8 @@ static int nf_ip6_reroute(struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -119,6 +121,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/rhel-7.5/gcc-static-local-var.patch
+++ b/test/integration/rhel-7.5/gcc-static-local-var.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/arch/x86/kernel/ldt.c src/arch/x86/kernel/ldt.c
+--- src.orig/arch/x86/kernel/ldt.c	2017-09-22 15:27:20.847052651 -0400
++++ src/arch/x86/kernel/ldt.c	2017-09-22 15:27:35.573113632 -0400
+@@ -98,6 +98,12 @@ static inline int copy_ldt(mm_context_t
+ 	return 0;
+ }
+ 
++void hi_there(void)
++{
++	if (!jiffies)
++		printk("hi there\n");
++}
++
+ /*
+  * we do not have to muck with descriptors here, that is
+  * done in switch_mm() as needed.
+@@ -107,6 +113,8 @@ int init_new_context(struct task_struct
+ 	struct mm_struct *old_mm;
+ 	int retval = 0;
+ 
++	hi_there();
++
+ 	mutex_init(&mm->context.lock);
+ 	mm->context.size = 0;
+ 	old_mm = current->mm;

--- a/test/integration/rhel-7.5/macro-callbacks.patch
+++ b/test/integration/rhel-7.5/macro-callbacks.patch
@@ -1,0 +1,160 @@
+kpatch/livepatch callback test patch:
+
+  vmlinux
+  pcspkr (mod)
+  joydev (mod)
+
+Note: update joydev's pre-patch callback to return -ENODEV to test failure path
+
+--- src.old/fs/aio.c	2018-02-26 11:07:51.522610407 -0500
++++ src/fs/aio.c	2018-03-05 11:17:21.560015449 -0500
+@@ -42,6 +42,50 @@
+ #include <asm/kmap_types.h>
+ #include <asm/uaccess.h>
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0
+--- src.old/drivers/input/joydev.c	2018-02-26 11:07:49.470610407 -0500
++++ src/drivers/input/joydev.c	2018-03-05 11:18:13.998015449 -0500
+@@ -954,3 +954,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+--- src.old/drivers/input/misc/pcspkr.c	2018-02-26 11:07:49.477610407 -0500
++++ src/drivers/input/misc/pcspkr.c	2018-03-05 11:18:23.411015449 -0500
+@@ -136,3 +136,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);

--- a/test/integration/rhel-7.5/macro-printk.patch
+++ b/test/integration/rhel-7.5/macro-printk.patch
@@ -1,0 +1,147 @@
+diff -Nupr src.orig/net/ipv4/fib_frontend.c src/net/ipv4/fib_frontend.c
+--- src.orig/net/ipv4/fib_frontend.c	2017-09-22 16:52:10.646110299 -0400
++++ src/net/ipv4/fib_frontend.c	2017-09-22 16:55:14.395870305 -0400
+@@ -633,6 +633,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+ {
+ 	struct net *net = sock_net(skb->sk);
+@@ -651,6 +652,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	}
+ 
+ 	err = fib_table_insert(net, tb, &cfg);
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+diff -Nupr src.orig/net/ipv4/fib_semantics.c src/net/ipv4/fib_semantics.c
+--- src.orig/net/ipv4/fib_semantics.c	2017-09-22 16:52:10.645110295 -0400
++++ src/net/ipv4/fib_semantics.c	2017-09-22 16:54:05.175584004 -0400
+@@ -925,6 +925,7 @@ fib_convert_metrics(struct fib_info *fi,
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg)
+ {
+ 	int err;
+@@ -949,6 +950,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -969,6 +971,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (fi == NULL)
+@@ -980,6 +983,7 @@ struct fib_info *fib_create_info(struct
+ 	} else
+ 		fi->fib_metrics = (u32 *) dst_default_metrics;
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
+ 
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+@@ -996,8 +1000,10 @@ struct fib_info *fib_create_info(struct
+ 		if (!nexthop_nh->nh_pcpu_rth_output)
+ 			goto failure;
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 
+ 	err = fib_convert_metrics(fi, cfg);
++	KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 	if (err)
+ 		goto failure;
+ 
+@@ -1048,6 +1054,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp)
+@@ -1065,6 +1072,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST)
+ 		goto err_inval;
+@@ -1087,6 +1095,7 @@ struct fib_info *fib_create_info(struct
+ 				goto failure;
+ 		} endfor_nexthops(fi)
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc) {
+ 		if (cfg->fc_type != RTN_LOCAL || !cfg->fc_dst ||
+@@ -1099,6 +1108,7 @@ struct fib_info *fib_create_info(struct
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 		fib_add_weight(fi, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1110,6 +1120,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	atomic_inc(&fi->fib_clntref);
+@@ -1133,6 +1144,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1143,6 +1155,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+diff -Nupr src.orig/net/ipv4/fib_trie.c src/net/ipv4/fib_trie.c
+--- src.orig/net/ipv4/fib_trie.c	2017-09-22 16:52:10.645110295 -0400
++++ src/net/ipv4/fib_trie.c	2017-09-22 16:55:39.940975963 -0400
+@@ -1191,6 +1191,7 @@ static int fib_insert_alias(struct trie
+ }
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg)
+ {
+@@ -1216,11 +1217,14 @@ int fib_table_insert(struct net *net, st
+ 	if ((plen < KEYLENGTH) && (key << plen))
+ 		return -EINVAL;
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority) : NULL;

--- a/test/integration/rhel-7.5/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-7.5/meminfo-init-FAIL.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:40.130132502 -0400
+@@ -191,6 +191,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.5/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-7.5/meminfo-init2-FAIL.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:38.972127707 -0400
+@@ -30,6 +30,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long pages[NR_LRU_LISTS];
+ 	int lru;
+ 
++	printk("a\n");
+ /*
+  * display in kilobytes.
+  */
+@@ -191,6 +192,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.5/meminfo-string-LOADED.test
+++ b/test/integration/rhel-7.5/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-7.5/meminfo-string.patch
+++ b/test/integration/rhel-7.5/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:41.274137239 -0400
+@@ -99,7 +99,7 @@ static int meminfo_proc_show(struct seq_
+ 		"Committed_AS:   %8lu kB\n"
+ 		"VmallocTotal:   %8lu kB\n"
+ 		"VmallocUsed:    %8lu kB\n"
+-		"VmallocChunk:   %8lu kB\n"
++		"VMALLOCCHUNK:   %8lu kB\n"
+ #ifdef CONFIG_MEMORY_FAILURE
+ 		"HardwareCorrupted: %5lu kB\n"
+ #endif

--- a/test/integration/rhel-7.5/module-call-external.patch
+++ b/test/integration/rhel-7.5/module-call-external.patch
@@ -1,0 +1,33 @@
+diff -Nupr src.orig/fs/nfsd/export.c src/fs/nfsd/export.c
+--- src.orig/fs/nfsd/export.c	2017-09-22 15:27:21.705056204 -0400
++++ src/fs/nfsd/export.c	2017-09-22 15:27:42.411141948 -0400
+@@ -1184,6 +1184,8 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+@@ -1193,6 +1195,7 @@ static int e_show(struct seq_file *m, vo
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2017-09-22 15:27:21.754056407 -0400
++++ src/net/netlink/af_netlink.c	2017-09-22 15:27:42.412141952 -0400
+@@ -3260,4 +3260,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-7.5/module-kvm-fixup.patch
+++ b/test/integration/rhel-7.5/module-kvm-fixup.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/arch/x86/kvm/vmx.c src/arch/x86/kvm/vmx.c
+--- src.orig/arch/x86/kvm/vmx.c	2017-09-22 15:27:20.853052676 -0400
++++ src/arch/x86/kvm/vmx.c	2017-09-22 15:27:43.583146801 -0400
+@@ -10597,6 +10597,8 @@ static int vmx_check_intercept(struct kv
+ 			       struct x86_instruction_info *info,
+ 			       enum x86_intercept_stage stage)
+ {
++	if (!jiffies)
++		printk("kpatch vmx_check_intercept\n");
+ 	return X86EMUL_CONTINUE;
+ }
+ 

--- a/test/integration/rhel-7.5/module-shadow.patch
+++ b/test/integration/rhel-7.5/module-shadow.patch
@@ -1,0 +1,25 @@
+Index: src/arch/x86/kvm/vmx.c
+===================================================================
+--- src.orig/arch/x86/kvm/vmx.c
++++ src/arch/x86/kvm/vmx.c
+@@ -11168,10 +11168,20 @@ static void vmx_leave_nested(struct kvm_
+  * It should only be called before L2 actually succeeded to run, and when
+  * vmcs01 is current (it doesn't leave_guest_mode() or switch vmcss).
+  */
++#include <linux/livepatch.h>
+ static void nested_vmx_entry_failure(struct kvm_vcpu *vcpu,
+ 			struct vmcs12 *vmcs12,
+ 			u32 reason, unsigned long qualification)
+ {
++	int *kpatch;
++
++	kpatch = klp_shadow_alloc(vcpu, 0, NULL, sizeof(*kpatch),
++				     GFP_KERNEL);
++	if (kpatch) {
++		klp_shadow_get(vcpu, 0);
++		klp_shadow_free(vcpu, 0);
++	}
++
+ 	load_vmcs12_host_state(vcpu, vmcs12);
+ 	vmcs12->vm_exit_reason = reason | VMX_EXIT_REASONS_FAILED_VMENTRY;
+ 	vmcs12->exit_qualification = qualification;

--- a/test/integration/rhel-7.5/multiple.test
+++ b/test/integration/rhel-7.5/multiple.test
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+KPATCH="sudo $ROOTDIR/kpatch/kpatch"
+
+MODULE_PREFIX="test-"
+MODULE_POSTFIX=".ko"
+TEST_POSTFIX="-LOADED.test"
+
+set -o errexit
+
+die() {
+	echo "ERROR: $@" >&2
+	exit 1
+}
+
+ko_to_test() {
+	tmp=${1%${MODULE_POSTFIX}}${TEST_POSTFIX}
+	echo ${tmp#${MODULE_PREFIX}}
+}
+
+# make sure any modules added here are disjoint
+declare -a modules
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+for file in "${SCRIPTDIR}"/*"${TEST_POSTFIX}"; do
+	name=$(basename ${file})
+	skip=0
+	for bname in "${blacklist[@]}"; do
+		if [ "${bname}" == "${name}" ]; then
+			skip=1
+			break
+		fi
+	done
+	if [ ${skip} -eq 0 ]; then
+		modules+=(${MODULE_PREFIX}${name%${TEST_POSTFIX}}${MODULE_POSTFIX})
+	fi
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded before loading any modules"
+done
+
+for mod in "${modules[@]}"; do
+	$KPATCH load $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog || die "$SCRIPTDIR/$testprog failed after loading modules"
+done
+
+for ((idx=${#modules[@]}-1 ; idx>=0 ; idx--)); do
+	mod=${modules[idx]}
+	$KPATCH unload $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded after unloading modules"
+done
+
+exit 0

--- a/test/integration/rhel-7.5/new-function.patch
+++ b/test/integration/rhel-7.5/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2017-09-22 15:27:21.084053633 -0400
++++ src/drivers/tty/n_tty.c	2017-09-22 15:27:45.888156346 -0400
+@@ -2016,7 +2016,7 @@ do_it_again:
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2098,6 +2098,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++			   const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-7.5/new-globals.patch
+++ b/test/integration/rhel-7.5/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:47.028161067 -0400
+@@ -27,3 +27,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ module_init(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:47.029161071 -0400
+@@ -16,6 +16,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -53,6 +55,7 @@ static int meminfo_proc_show(struct seq_
+ 	/*
+ 	 * Tagged format, for easy grepping and expansion.
+ 	 */
++	kpatch_print_message();
+ 	seq_printf(m,
+ 		"MemTotal:       %8lu kB\n"
+ 		"MemFree:        %8lu kB\n"

--- a/test/integration/rhel-7.5/parainstructions-section.patch
+++ b/test/integration/rhel-7.5/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/generic.c	2017-09-22 15:27:48.190165879 -0400
+@@ -194,6 +194,7 @@ int proc_alloc_inum(unsigned int *inum)
+ 	unsigned int i;
+ 	int error;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ retry:
+ 	if (!ida_pre_get(&proc_inum_ida, GFP_KERNEL))
+ 		return -ENOMEM;

--- a/test/integration/rhel-7.5/replace-section-references.patch
+++ b/test/integration/rhel-7.5/replace-section-references.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:49.362170732 -0400
+@@ -248,6 +248,8 @@ static void shared_msr_update(unsigned s
+ 
+ void kvm_define_shared_msr(unsigned slot, u32 msr)
+ {
++	if (!jiffies)
++		printk("kpatch kvm define shared msr\n");
+ 	BUG_ON(slot >= KVM_NR_SHARED_MSRS);
+ 	shared_msrs_global.msrs[slot] = msr;
+ 	if (slot >= shared_msrs_global.nr)

--- a/test/integration/rhel-7.5/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-7.5/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-7.5/shadow-newpid.patch
+++ b/test/integration/rhel-7.5/shadow-newpid.patch
@@ -1,0 +1,72 @@
+Index: src/fs/proc/array.c
+===================================================================
+--- src.orig/fs/proc/array.c
++++ src/fs/proc/array.c
+@@ -394,13 +394,20 @@ static inline void task_seccomp(struct s
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_printf(m,	"voluntary_ctxt_switches:\t%lu\n"
+ 			"nonvoluntary_ctxt_switches:\t%lu\n",
+ 			p->nvcsw,
+ 			p->nivcsw);
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+Index: src/kernel/exit.c
+===================================================================
+--- src.orig/kernel/exit.c
++++ src/kernel/exit.c
+@@ -715,6 +715,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include <linux/livepatch.h>
+ void do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -812,6 +813,8 @@ void do_exit(long code)
+ 	check_stack_usage();
+ 	exit_thread();
+ 
++	klp_shadow_free(tsk, 0);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+Index: src/kernel/fork.c
+===================================================================
+--- src.orig/kernel/fork.c
++++ src/kernel/fork.c
+@@ -1751,6 +1751,7 @@ struct task_struct *fork_idle(int cpu)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include <linux/livepatch.h>
+ long do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -1788,6 +1789,13 @@ long do_fork(unsigned long clone_flags,
+ 	if (!IS_ERR(p)) {
+ 		struct completion vfork;
+ 		struct pid *pid;
++		int *newpid;
++		static int ctr = 0;
++
++		newpid = klp_shadow_get_or_alloc(p, 0, NULL, sizeof(*newpid),
++					     GFP_KERNEL);
++		if (newpid)
++			*newpid = ctr++;
+ 
+ 		trace_sched_process_fork(current, p);
+ 

--- a/test/integration/rhel-7.5/smp-locks-section.patch
+++ b/test/integration/rhel-7.5/smp-locks-section.patch
@@ -1,0 +1,14 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2017-09-22 15:27:21.077053604 -0400
++++ src/drivers/tty/tty_buffer.c	2017-09-22 15:27:50.542175618 -0400
+@@ -217,6 +217,10 @@ int tty_buffer_request_room(struct tty_p
+ 	/* OPTIMISATION: We could keep a per tty "zero" sized buffer to
+ 	   remove this conditional if its worth it. This would be invisible
+ 	   to the callers */
++
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b != NULL)
+ 		left = b->size - b->used;

--- a/test/integration/rhel-7.5/special-static-2.patch
+++ b/test/integration/rhel-7.5/special-static-2.patch
@@ -1,0 +1,24 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:51.744180596 -0400
+@@ -2093,12 +2093,20 @@ static void record_steal_time(struct kvm
+ 		&vcpu->arch.st.steal, sizeof(struct kvm_steal_time));
+ }
+ 
++void kpatch_kvm_x86_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch kvm x86 foo\n");
++}
++
+ int kvm_set_msr_common(struct kvm_vcpu *vcpu, struct msr_data *msr_info)
+ {
+ 	bool pr = false;
+ 	u32 msr = msr_info->index;
+ 	u64 data = msr_info->data;
+ 
++	kpatch_kvm_x86_foo();
++
+ 	switch (msr) {
+ 	case MSR_AMD64_NB_CFG:
+ 	case MSR_IA32_UCODE_REV:

--- a/test/integration/rhel-7.5/special-static.patch
+++ b/test/integration/rhel-7.5/special-static.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2017-09-22 15:27:21.600055769 -0400
++++ src/kernel/fork.c	2017-09-22 15:27:53.052186012 -0400
+@@ -1129,10 +1129,18 @@ static void posix_cpu_timers_init_group(
+ 	INIT_LIST_HEAD(&sig->cpu_timers[2]);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-7.5/tracepoints-section.patch
+++ b/test/integration/rhel-7.5/tracepoints-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/timer.c src/kernel/timer.c
+--- src.orig/kernel/timer.c	2017-09-22 15:27:21.600055769 -0400
++++ src/kernel/timer.c	2017-09-22 15:27:54.288191131 -0400
+@@ -1390,6 +1390,9 @@ static void run_timer_softirq(struct sof
+ {
+ 	struct tvec_base *base = __this_cpu_read(tvec_bases);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	if (time_after_eq(jiffies, base->timer_jiffies))
+ 		__run_timers(base);
+ }

--- a/test/integration/rhel-7.5/warn-detect-FAIL.patch
+++ b/test/integration/rhel-7.5/warn-detect-FAIL.patch
@@ -1,0 +1,8 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:55.489196104 -0400
+@@ -1,3 +1,4 @@
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *

--- a/test/integration/rhel-7.6/bug-table-section.patch
+++ b/test/integration/rhel-7.6/bug-table-section.patch
@@ -1,0 +1,13 @@
+Index: kernel-rhel7/fs/proc/proc_sysctl.c
+===================================================================
+--- kernel-rhel7.orig/fs/proc/proc_sysctl.c
++++ kernel-rhel7/fs/proc/proc_sysctl.c
+@@ -301,6 +301,8 @@ void sysctl_head_put(struct ctl_table_he
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-7.6/cmdline-string-LOADED.test
+++ b/test/integration/rhel-7.6/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-7.6/cmdline-string.patch
+++ b/test/integration/rhel-7.6/cmdline-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:22.955061380 -0400
+@@ -5,7 +5,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_printf(m, "%s\n", saved_command_line);
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-7.6/data-new-LOADED.test
+++ b/test/integration/rhel-7.6/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch: 5" /proc/meminfo

--- a/test/integration/rhel-7.6/data-new.patch
+++ b/test/integration/rhel-7.6/data-new.patch
@@ -1,0 +1,29 @@
+Index: kernel-rhel7/fs/proc/meminfo.c
+===================================================================
+--- kernel-rhel7.orig/fs/proc/meminfo.c
++++ kernel-rhel7/fs/proc/meminfo.c
+@@ -20,6 +20,8 @@ void __attribute__((weak)) arch_report_m
+ {
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -110,6 +112,7 @@ static int meminfo_proc_show(struct seq_
+ 		"CmaTotal:       %8lu kB\n"
+ 		"CmaFree:        %8lu kB\n"
+ #endif
++		"kpatch: %d"
+ 		,
+ 		K(i.totalram),
+ 		K(i.freeram),
+@@ -175,6 +178,7 @@ static int meminfo_proc_show(struct seq_
+ 		, K(totalcma_pages)
+ 		, K(global_page_state(NR_FREE_CMA_PAGES))
+ #endif
++		,foo
+ 		);
+ 
+ 	hugetlb_report_meminfo(m);

--- a/test/integration/rhel-7.6/data-read-mostly.patch
+++ b/test/integration/rhel-7.6/data-read-mostly.patch
@@ -1,0 +1,12 @@
+Index: kernel-rhel7/net/core/dev.c
+===================================================================
+--- kernel-rhel7.orig/net/core/dev.c
++++ kernel-rhel7/net/core/dev.c
+@@ -4199,6 +4199,7 @@ skip_classify:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-7.6/fixup-section.patch
+++ b/test/integration/rhel-7.6/fixup-section.patch
@@ -1,0 +1,12 @@
+diff --git a/fs/readdir.c b/fs/readdir.c
+index febd02dfbe2d..064db7bd70d0 100644
+--- a/fs/readdir.c
++++ b/fs/readdir.c
+@@ -176,6 +176,7 @@ static int filldir(void * __buf, const char * name, int namlen, loff_t offset,
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-7.6/gcc-constprop.patch.disabled
+++ b/test/integration/rhel-7.6/gcc-constprop.patch.disabled
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/time/timekeeping.c	2017-09-22 15:27:27.522080292 -0400
+@@ -877,6 +877,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-7.6/gcc-isra.patch
+++ b/test/integration/rhel-7.6/gcc-isra.patch
@@ -1,0 +1,12 @@
+Index: kernel-rhel7/fs/proc/proc_sysctl.c
+===================================================================
+--- kernel-rhel7.orig/fs/proc/proc_sysctl.c
++++ kernel-rhel7/fs/proc/proc_sysctl.c
+@@ -46,6 +46,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-7.6/gcc-mangled-3.patch
+++ b/test/integration/rhel-7.6/gcc-mangled-3.patch
@@ -1,0 +1,14 @@
+Index: kernel-rhel7/mm/slub.c
+===================================================================
+--- kernel-rhel7.orig/mm/slub.c
++++ kernel-rhel7/mm/slub.c
+@@ -5611,6 +5611,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	unsigned long nr_free = 0;
+ 	int node;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_online_node(node) {
+ 		struct kmem_cache_node *n = get_node(s, node);
+ 

--- a/test/integration/rhel-7.6/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-7.6/gcc-static-local-var-2.patch
@@ -1,0 +1,14 @@
+Index: kernel-rhel7/mm/mmap.c
+===================================================================
+--- kernel-rhel7.orig/mm/mmap.c
++++ kernel-rhel7/mm/mmap.c
+@@ -1715,6 +1715,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-7.6/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-7.6/gcc-static-local-var-3.patch
@@ -1,0 +1,20 @@
+Index: kernel-rhel7/kernel/sys.c
+===================================================================
+--- kernel-rhel7.orig/kernel/sys.c
++++ kernel-rhel7/kernel/sys.c
+@@ -559,8 +559,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-7.6/gcc-static-local-var-4.patch
+++ b/test/integration/rhel-7.6/gcc-static-local-var-4.patch
@@ -1,0 +1,21 @@
+Index: kernel-rhel7/fs/aio.c
+===================================================================
+--- kernel-rhel7.orig/fs/aio.c
++++ kernel-rhel7/fs/aio.c
+@@ -223,9 +223,16 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
+ static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(aio_ring_file->f_inode, 0);
+ 

--- a/test/integration/rhel-7.6/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.6/gcc-static-local-var-4.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-7.6/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-7.6/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2017-09-22 15:27:21.602055778 -0400
++++ src/kernel/audit.c	2017-09-22 15:27:34.429108894 -0400
+@@ -205,6 +205,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -215,6 +221,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -234,6 +241,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -282,6 +294,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(NULL, GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-7.6/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-7.6/gcc-static-local-var-6.patch
@@ -1,0 +1,23 @@
+diff --git a/net/ipv6/netfilter.c b/net/ipv6/netfilter.c
+index a9d587a..23336ed 100644
+--- a/net/ipv6/netfilter.c
++++ b/net/ipv6/netfilter.c
+@@ -106,6 +106,8 @@ static int nf_ip6_reroute(struct sk_buff *skb,
+	return 0;
+ }
+
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+			struct flowi *fl, bool strict)
+ {
+@@ -119,6 +121,9 @@ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+	struct dst_entry *result;
+	int err;
+
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+	result = ip6_route_output(net, sk, &fl->u.ip6);
+	err = result->error;
+	if (err)

--- a/test/integration/rhel-7.6/macro-callbacks.patch
+++ b/test/integration/rhel-7.6/macro-callbacks.patch
@@ -1,0 +1,160 @@
+kpatch/livepatch callback test patch:
+
+  vmlinux
+  pcspkr (mod)
+  joydev (mod)
+
+Note: update joydev's pre-patch callback to return -ENODEV to test failure path
+
+--- src.old/fs/aio.c	2018-02-26 11:07:51.522610407 -0500
++++ src/fs/aio.c	2018-03-05 11:17:21.560015449 -0500
+@@ -42,6 +42,50 @@
+ #include <asm/kmap_types.h>
+ #include <asm/uaccess.h>
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0
+--- src.old/drivers/input/joydev.c	2018-02-26 11:07:49.470610407 -0500
++++ src/drivers/input/joydev.c	2018-03-05 11:18:13.998015449 -0500
+@@ -954,3 +954,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+--- src.old/drivers/input/misc/pcspkr.c	2018-02-26 11:07:49.477610407 -0500
++++ src/drivers/input/misc/pcspkr.c	2018-03-05 11:18:23.411015449 -0500
+@@ -136,3 +136,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);

--- a/test/integration/rhel-7.6/macro-printk.patch
+++ b/test/integration/rhel-7.6/macro-printk.patch
@@ -1,0 +1,151 @@
+Index: kernel-rhel7/net/ipv4/fib_frontend.c
+===================================================================
+--- kernel-rhel7.orig/net/ipv4/fib_frontend.c
++++ kernel-rhel7/net/ipv4/fib_frontend.c
+@@ -685,6 +685,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+ {
+ 	struct net *net = sock_net(skb->sk);
+@@ -703,6 +704,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	}
+ 
+ 	err = fib_table_insert(net, tb, &cfg);
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+Index: kernel-rhel7/net/ipv4/fib_semantics.c
+===================================================================
+--- kernel-rhel7.orig/net/ipv4/fib_semantics.c
++++ kernel-rhel7/net/ipv4/fib_semantics.c
+@@ -969,6 +969,7 @@ fib_convert_metrics(struct fib_info *fi,
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg)
+ {
+ 	int err;
+@@ -993,6 +994,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -1013,6 +1015,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (fi == NULL)
+@@ -1028,6 +1031,8 @@ struct fib_info *fib_create_info(struct
+ 		fi->fib_metrics = (struct dst_metrics *)&dst_default_metrics;
+ 	}
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
++
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+ 	fi->fib_scope = cfg->fc_scope;
+@@ -1043,8 +1048,10 @@ struct fib_info *fib_create_info(struct
+ 		if (!nexthop_nh->nh_pcpu_rth_output)
+ 			goto failure;
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 
+ 	err = fib_convert_metrics(fi, cfg);
++	KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 	if (err)
+ 		goto failure;
+ 
+@@ -1095,6 +1102,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp)
+@@ -1112,6 +1120,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST)
+ 		goto err_inval;
+@@ -1134,6 +1143,7 @@ struct fib_info *fib_create_info(struct
+ 				goto failure;
+ 		} endfor_nexthops(fi)
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc) {
+ 		if (cfg->fc_type != RTN_LOCAL || !cfg->fc_dst ||
+@@ -1146,6 +1156,7 @@ struct fib_info *fib_create_info(struct
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 		fib_add_weight(fi, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1157,6 +1168,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	atomic_inc(&fi->fib_clntref);
+@@ -1180,6 +1192,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1190,6 +1203,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+Index: kernel-rhel7/net/ipv4/fib_trie.c
+===================================================================
+--- kernel-rhel7.orig/net/ipv4/fib_trie.c
++++ kernel-rhel7/net/ipv4/fib_trie.c
+@@ -1105,6 +1105,7 @@ static int fib_insert_alias(struct trie
+ }
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg)
+ {
+@@ -1130,11 +1131,14 @@ int fib_table_insert(struct net *net, st
+ 	if ((plen < KEYLENGTH) && (key << plen))
+ 		return -EINVAL;
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority,

--- a/test/integration/rhel-7.6/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-7.6/meminfo-init-FAIL.patch
@@ -1,0 +1,12 @@
+Index: kernel-rhel7/fs/proc/meminfo.c
+===================================================================
+--- kernel-rhel7.orig/fs/proc/meminfo.c
++++ kernel-rhel7/fs/proc/meminfo.c
+@@ -199,6 +199,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.6/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-7.6/meminfo-init2-FAIL.patch
@@ -1,0 +1,20 @@
+Index: kernel-rhel7/fs/proc/meminfo.c
+===================================================================
+--- kernel-rhel7.orig/fs/proc/meminfo.c
++++ kernel-rhel7/fs/proc/meminfo.c
+@@ -30,6 +30,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long pages[NR_LRU_LISTS];
+ 	int lru;
+ 
++	printk("a\n");
+ /*
+  * display in kilobytes.
+  */
+@@ -199,6 +200,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.6/meminfo-string-LOADED.test
+++ b/test/integration/rhel-7.6/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-7.6/meminfo-string.patch
+++ b/test/integration/rhel-7.6/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:41.274137239 -0400
+@@ -99,7 +99,7 @@ static int meminfo_proc_show(struct seq_
+ 		"Committed_AS:   %8lu kB\n"
+ 		"VmallocTotal:   %8lu kB\n"
+ 		"VmallocUsed:    %8lu kB\n"
+-		"VmallocChunk:   %8lu kB\n"
++		"VMALLOCCHUNK:   %8lu kB\n"
+ #ifdef CONFIG_MEMORY_FAILURE
+ 		"HardwareCorrupted: %5lu kB\n"
+ #endif

--- a/test/integration/rhel-7.6/module-call-external.patch
+++ b/test/integration/rhel-7.6/module-call-external.patch
@@ -1,0 +1,35 @@
+Index: kernel-rhel7/fs/nfsd/export.c
+===================================================================
+--- kernel-rhel7.orig/fs/nfsd/export.c
++++ kernel-rhel7/fs/nfsd/export.c
+@@ -1184,6 +1184,8 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+@@ -1193,6 +1195,7 @@ static int e_show(struct seq_file *m, vo
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+Index: kernel-rhel7/net/netlink/af_netlink.c
+===================================================================
+--- kernel-rhel7.orig/net/netlink/af_netlink.c
++++ kernel-rhel7/net/netlink/af_netlink.c
+@@ -2568,4 +2568,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-7.6/multiple.test
+++ b/test/integration/rhel-7.6/multiple.test
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+KPATCH="sudo $ROOTDIR/kpatch/kpatch"
+
+MODULE_PREFIX="test-"
+MODULE_POSTFIX=".ko"
+TEST_POSTFIX="-LOADED.test"
+
+set -o errexit
+
+die() {
+	echo "ERROR: $@" >&2
+	exit 1
+}
+
+ko_to_test() {
+	tmp=${1%${MODULE_POSTFIX}}${TEST_POSTFIX}
+	echo ${tmp#${MODULE_PREFIX}}
+}
+
+# make sure any modules added here are disjoint
+declare -a modules
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+for file in "${SCRIPTDIR}"/*"${TEST_POSTFIX}"; do
+	name=$(basename ${file})
+	skip=0
+	for bname in "${blacklist[@]}"; do
+		if [ "${bname}" == "${name}" ]; then
+			skip=1
+			break
+		fi
+	done
+	if [ ${skip} -eq 0 ]; then
+		modules+=(${MODULE_PREFIX}${name%${TEST_POSTFIX}}${MODULE_POSTFIX})
+	fi
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded before loading any modules"
+done
+
+for mod in "${modules[@]}"; do
+	$KPATCH load $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog || die "$SCRIPTDIR/$testprog failed after loading modules"
+done
+
+for ((idx=${#modules[@]}-1 ; idx>=0 ; idx--)); do
+	mod=${modules[idx]}
+	$KPATCH unload $mod
+done
+
+for mod in "${modules[@]}"; do
+	testprog=$(ko_to_test $mod)
+	$SCRIPTDIR/$testprog && die "$SCRIPTDIR/$testprog succeeded after unloading modules"
+done
+
+exit 0

--- a/test/integration/rhel-7.6/new-function.patch
+++ b/test/integration/rhel-7.6/new-function.patch
@@ -1,0 +1,26 @@
+Index: kernel-rhel7/drivers/tty/n_tty.c
+===================================================================
+--- kernel-rhel7.orig/drivers/tty/n_tty.c
++++ kernel-rhel7/drivers/tty/n_tty.c
+@@ -2128,7 +2128,7 @@ do_it_again:
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2210,6 +2210,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++			   const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-7.6/new-globals.patch
+++ b/test/integration/rhel-7.6/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/cmdline.c	2017-09-22 15:27:47.028161067 -0400
+@@ -27,3 +27,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ module_init(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2017-09-22 15:27:21.699056179 -0400
++++ src/fs/proc/meminfo.c	2017-09-22 15:27:47.029161071 -0400
+@@ -16,6 +16,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -53,6 +55,7 @@ static int meminfo_proc_show(struct seq_
+ 	/*
+ 	 * Tagged format, for easy grepping and expansion.
+ 	 */
++	kpatch_print_message();
+ 	seq_printf(m,
+ 		"MemTotal:       %8lu kB\n"
+ 		"MemFree:        %8lu kB\n"

--- a/test/integration/rhel-7.6/parainstructions-section.patch
+++ b/test/integration/rhel-7.6/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2017-09-22 15:27:21.698056175 -0400
++++ src/fs/proc/generic.c	2017-09-22 15:27:48.190165879 -0400
+@@ -194,6 +194,7 @@ int proc_alloc_inum(unsigned int *inum)
+ 	unsigned int i;
+ 	int error;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ retry:
+ 	if (!ida_pre_get(&proc_inum_ida, GFP_KERNEL))
+ 		return -ENOMEM;

--- a/test/integration/rhel-7.6/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-7.6/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-7.6/shadow-newpid.patch
+++ b/test/integration/rhel-7.6/shadow-newpid.patch
@@ -1,0 +1,72 @@
+diff --git a/fs/proc/array.c b/fs/proc/array.c
+index 39684c79e8e2..138b60d1314d 100644
+--- a/fs/proc/array.c
++++ b/fs/proc/array.c
+@@ -394,13 +394,20 @@ static inline void task_seccomp(struct seq_file *m, struct task_struct *p)
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_printf(m,	"voluntary_ctxt_switches:\t%lu\n"
+ 			"nonvoluntary_ctxt_switches:\t%lu\n",
+ 			p->nvcsw,
+ 			p->nivcsw);
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff --git a/kernel/exit.c b/kernel/exit.c
+index 148a7842928d..e1dbab71b37d 100644
+--- a/kernel/exit.c
++++ b/kernel/exit.c
+@@ -791,6 +791,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include <linux/livepatch.h>
+ void do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -888,6 +889,8 @@ void do_exit(long code)
+ 	check_stack_usage();
+ 	exit_thread();
+ 
++	klp_shadow_free(tsk, 0, NULL);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff --git a/kernel/fork.c b/kernel/fork.c
+index 9bff3b28c357..529a2c943d7c 100644
+--- a/kernel/fork.c
++++ b/kernel/fork.c
+@@ -1757,6 +1757,7 @@ struct task_struct *fork_idle(int cpu)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include <linux/livepatch.h>
+ long do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -1794,6 +1795,13 @@ long do_fork(unsigned long clone_flags,
+ 	if (!IS_ERR(p)) {
+ 		struct completion vfork;
+ 		struct pid *pid;
++		int *newpid;
++		static int ctr = 0;
++
++		newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid), GFP_KERNEL,
++						NULL, NULL);
++		if (newpid)
++			*newpid = ctr++;
+ 
+ 		trace_sched_process_fork(current, p);
+ 

--- a/test/integration/rhel-7.6/smp-locks-section.patch
+++ b/test/integration/rhel-7.6/smp-locks-section.patch
@@ -1,0 +1,14 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2017-09-22 15:27:21.077053604 -0400
++++ src/drivers/tty/tty_buffer.c	2017-09-22 15:27:50.542175618 -0400
+@@ -217,6 +217,10 @@ int tty_buffer_request_room(struct tty_p
+ 	/* OPTIMISATION: We could keep a per tty "zero" sized buffer to
+ 	   remove this conditional if its worth it. This would be invisible
+ 	   to the callers */
++
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b != NULL)
+ 		left = b->size - b->used;

--- a/test/integration/rhel-7.6/special-static.patch
+++ b/test/integration/rhel-7.6/special-static.patch
@@ -1,0 +1,23 @@
+Index: kernel-rhel7/kernel/fork.c
+===================================================================
+--- kernel-rhel7.orig/kernel/fork.c
++++ kernel-rhel7/kernel/fork.c
+@@ -1146,10 +1146,18 @@ static void posix_cpu_timers_init_group(
+ 	INIT_LIST_HEAD(&sig->cpu_timers[2]);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-7.6/tracepoints-section.patch
+++ b/test/integration/rhel-7.6/tracepoints-section.patch
@@ -1,0 +1,14 @@
+Index: kernel-rhel7/kernel/timer.c
+===================================================================
+--- kernel-rhel7.orig/kernel/timer.c
++++ kernel-rhel7/kernel/timer.c
+@@ -1454,6 +1454,9 @@ static void run_timer_softirq(struct sof
+ {
+ 	struct tvec_base *base = __this_cpu_read(tvec_bases);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	if (time_after_eq(jiffies, base->timer_jiffies))
+ 		__run_timers(base);
+ }

--- a/test/integration/rhel-7.6/warn-detect-FAIL.patch
+++ b/test/integration/rhel-7.6/warn-detect-FAIL.patch
@@ -1,0 +1,8 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2017-09-22 15:27:20.852052672 -0400
++++ src/arch/x86/kvm/x86.c	2017-09-22 15:27:55.489196104 -0400
+@@ -1,3 +1,4 @@
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *


### PR DESCRIPTION
This commit contains centos-7 patches rebased and adjusted to work with
recent rhel minors so that integration tests actually pass on those.

P.S. Please don't merge as some downstream changes will be needed as well, so I'll do it myself when all 'approves' are there.