### PR TITLE
ppc64le: Feature fixup

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1825,7 +1825,7 @@ static int fixup_entry_group_size(struct kpatch_elf *kelf, int offset)
 
 static int fixup_lwsync_group_size(struct kpatch_elf *kelf, int offset)
 {
-	return 4;
+	return 8;
 }
 #endif
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -82,6 +82,7 @@ enum loglevel loglevel = NORMAL;
 struct special_section {
 	char *name;
 	int (*group_size)(struct kpatch_elf *kelf, int offset);
+	int unsupported;
 };
 
 /*************
@@ -1913,22 +1914,27 @@ static struct special_section special_sections[] = {
 	{
 		.name		= "__ftr_fixup",
 		.group_size	= fixup_entry_group_size,
+		.unsupported	= 1,
 	},
 	{
 		.name		= "__mmu_ftr_fixup",
 		.group_size	= fixup_entry_group_size,
+		.unsupported	= 1,
 	},
 	{
 		.name		= "__fw_ftr_fixup",
 		.group_size	= fixup_entry_group_size,
+		.unsupported	= 1,
 	},
 	{
 		.name		= "__lwsync_fixup",
 		.group_size	= fixup_lwsync_group_size,
+		.unsupported	= 1,
 	},
 	{
 		.name		= "__barrier_nospec_fixup",
 		.group_size	= fixup_barrier_nospec_group_size,
+		.unsupported	= 1,
 	},
 #endif
 	{},
@@ -2026,6 +2032,9 @@ static void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 
 		if (!include)
 			continue;
+
+		if (special->unsupported)
+			DIFF_FATAL("unsupported reference to special section %s", sec->base->name);
 
 		/*
 		 * Copy all relas in the group.  It's possible that the relas

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1827,6 +1827,11 @@ static int fixup_lwsync_group_size(struct kpatch_elf *kelf, int offset)
 {
 	return 8;
 }
+
+static int fixup_barrier_nospec_group_size(struct kpatch_elf *kelf, int offset)
+{
+	return 8;
+}
 #endif
 
 /*
@@ -1920,6 +1925,10 @@ static struct special_section special_sections[] = {
 	{
 		.name		= "__lwsync_fixup",
 		.group_size	= fixup_lwsync_group_size,
+	},
+	{
+		.name		= "__barrier_nospec_fixup",
+		.group_size	= fixup_barrier_nospec_group_size,
 	},
 #endif
 	{},


### PR DESCRIPTION
This patch series implements the phase 1 and other powerpc related quirks discussed at #974.
1. First patch fixes the group size of lwsync fixup special section
2. Second patch add support for __barrier_nospec_fixup special section
3. The last patch adds checks to assert if the function being patched, calls any of the *_fixup section and error out for such patches.