### PR TITLE
create-diff-object: fix failed in kpatch_check_relocations for compre…

### DIFF
--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -48,6 +48,7 @@ struct section {
 	struct list_head list;
 	struct section *twin;
 	GElf_Shdr sh;
+	unsigned int size;
 	Elf_Data *data;
 	char *name;
 	unsigned int index;


### PR DESCRIPTION
…ss section

If using the CFLAGS of "-gz=zlib", the section would be compressed,
and the section's sh_flags is set with "SHF_COMPRESSED", so the
rela->addend may be bigger than sdata->d_size, which cause
ERROR in kpatch_check_relocations of "out-of-range relocation".

The section infomation as follow:

Relocation section '.rela.debug_info' at offset 0xac8 contains 76 entries:
Offset          Info           Type           Sym. Value    Sym. Name + Addend
000000000006  00080000000a R_X86_64_32       0000000000000000 .debug_abbrev + 0
00000000000c  000c0000000a R_X86_64_32       0000000000000000 .debug_str + 326
000000000011  000c0000000a R_X86_64_32       0000000000000000 .debug_str + 657
000000000015  000c0000000a R_X86_64_32       0000000000000000 .debug_str + 748

[16] .debug_str        PROGBITS         0000000000000000  00000424
00000000000003f7  0000000000000001 MSC       0     0     1

Therefore, we may check whether the "SHF_COMPRESSED" is set, if so
we can get the section uncompressed size by "ch_size", and compare
with "ch_size".

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>