### PR TITLE
Patch replacement fixes for the old KPatch core

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -212,7 +212,8 @@ static inline int kpatch_compare_addresses(unsigned long stack_addr,
 }
 
 static int kpatch_backtrace_address_verify(struct kpatch_module *kpmod,
-					   unsigned long address)
+					   unsigned long address,
+					   bool replace)
 {
 	struct kpatch_func *func;
 	int i;
@@ -247,8 +248,11 @@ static int kpatch_backtrace_address_verify(struct kpatch_module *kpmod,
 	} while_for_each_linked_func();
 
 	/* in the replace case, need to check the func hash as well */
-	hash_for_each_rcu(kpatch_func_hash, i, func, node) {
-		if (func->op == KPATCH_OP_UNPATCH && !func->force) {
+	if (replace) {
+		hash_for_each_rcu(kpatch_func_hash, i, func, node) {
+			if (func->op != KPATCH_OP_UNPATCH || func->force)
+				continue;
+
 			ret = kpatch_compare_addresses(address,
 						       func->new_addr,
 						       func->new_size,
@@ -267,7 +271,8 @@ static int kpatch_backtrace_address_verify(struct kpatch_module *kpmod,
  *
  * This function is called from stop_machine() context.
  */
-static int kpatch_verify_activeness_safety(struct kpatch_module *kpmod)
+static int kpatch_verify_activeness_safety(struct kpatch_module *kpmod,
+					   bool replace)
 {
 	struct task_struct *g, *t;
 	int i;
@@ -289,7 +294,8 @@ static int kpatch_verify_activeness_safety(struct kpatch_module *kpmod)
 			if (trace.entries[i] == ULONG_MAX)
 				break;
 			ret = kpatch_backtrace_address_verify(kpmod,
-							      trace.entries[i]);
+							      trace.entries[i],
+							      replace);
 			if (ret)
 				goto out;
 		}
@@ -365,7 +371,7 @@ static int kpatch_apply_patch(void *data)
 
 	kpmod = args->kpmod;
 
-	ret = kpatch_verify_activeness_safety(kpmod);
+	ret = kpatch_verify_activeness_safety(kpmod, args->replace);
 	if (ret) {
 		kpatch_state_finish(KPATCH_STATE_FAILURE);
 		return ret;
@@ -440,7 +446,7 @@ static int kpatch_remove_patch(void *data)
 	struct kpatch_object *object;
 	int ret;
 
-	ret = kpatch_verify_activeness_safety(kpmod);
+	ret = kpatch_verify_activeness_safety(kpmod, false);
 	if (ret) {
 		kpatch_state_finish(KPATCH_STATE_FAILURE);
 		return ret;

--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -83,6 +83,11 @@ struct kpatch_kallsyms_args {
 	unsigned long pos;
 };
 
+struct kpatch_apply_patch_args {
+	struct kpatch_module *kpmod;
+	bool replace;
+};
+
 /* this is a double loop, use goto instead of break */
 #define do_for_each_linked_func(kpmod, func) {				\
 	struct kpatch_object *_object;					\
@@ -350,10 +355,13 @@ static inline void post_unpatch_callback(struct kpatch_object *object)
 /* Called from stop_machine */
 static int kpatch_apply_patch(void *data)
 {
-	struct kpatch_module *kpmod = data;
+	struct kpatch_apply_patch_args *args = data;
+	struct kpatch_module *kpmod;
 	struct kpatch_func *func;
 	struct kpatch_object *object;
 	int ret;
+
+	kpmod = args->kpmod;
 
 	ret = kpatch_verify_activeness_safety(kpmod);
 	if (ret) {
@@ -980,6 +988,11 @@ int kpatch_register(struct kpatch_module *kpmod, bool replace)
 	struct kpatch_object *object, *object_err = NULL;
 	struct kpatch_func *func;
 
+	struct kpatch_apply_patch_args args = {
+		.kpmod = kpmod,
+		.replace = replace,
+	};
+
 	if (!kpmod->mod || list_empty(&kpmod->objects))
 		return -EINVAL;
 
@@ -1031,7 +1044,7 @@ int kpatch_register(struct kpatch_module *kpmod, bool replace)
 	 * Idle the CPUs, verify activeness safety, and atomically make the new
 	 * functions visible to the ftrace handler.
 	 */
-	ret = stop_machine(kpatch_apply_patch, kpmod, NULL);
+	ret = stop_machine(kpatch_apply_patch, &args, NULL);
 
 	/*
 	 * For the replace case, remove any obsolete funcs from the hash and


### PR DESCRIPTION
Virtuozzo uses the old KPatch core (kpatch.ko) for binary patches for the older kernels and relies on atomic replacement of patches.

When I was trying to replace a loaded binary patch (P1) with a new one (P2) that changed a smaller set of kernel functions (a faulty part was removed in P2), kernel crashed in certain cases.

Assume that patch P1 changes functions F1(), F2() and F3() while patch P2 - F1() only. I saw in the crash reports that the kernel was executing its original variant of F2() and the variant of F3() from P1 at that moment. This inconsistency caused problems because F2() and F3() were dependent on one another.

kpatch_apply_patch() does check if the functions from the patch to be replaced are currently running. However, the functions are removed from
'kpatch_func_hash' in kpatch_register() only after stop_machine() and kpatch_apply_patch() have finished. So, they can be running at that point, which is bad.

While investigating this, I also found that kpatch_backtrace_address_verify() searched the whole
set of functions for the ones being replaced (func->op == KPATCH_OP_UNPATCH). This is a waste of time when the patch is loaded or unloaded rather than replaced, because the search is done for each stack entry being checked.

This patchset fixes both issues.

I doubt that Livepatch has the same issues, its implementation of atomic replacement is completely different. I haven't checked though.
