### PR TITLE
test/unit: Don't automatically rebase submodule

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -4,7 +4,9 @@ OBJDIR ?= objs/$(ARCH)
 .PHONY: all clean
 
 all: Makefile.include
-	cd $(shell git rev-parse --show-toplevel) && git submodule update --init --rebase
+	@cd $(shell git rev-parse --show-toplevel) && \
+		git diff-index --quiet HEAD test/unit/objs || \
+		echo -e "\nWARNING: unit tests are out of date - run \"git submodule update\"\n"
 	$(MAKE) -C $(OBJDIR)
 
 clean: Makefile.include


### PR DESCRIPTION
"make unit" automatically rebases the submodule, which causes a lot of
surprises.  Instead, just print a warning if it's out of date.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>