### PR TITLE
create-diff-object/ppc64le: Don't allow sibling calls

### DIFF
--- a/test/integration/rhel-7.5/new-function.patch
+++ b/test/integration/rhel-7.5/new-function.patch
@@ -14,7 +14,7 @@ diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
  	return (b - buf) ? b - buf : retval;
  }
  
-+static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
 +			   const unsigned char *buf, size_t nr)
 +{
 +	return kpatch_n_tty_write(tty, file, buf, nr);

--- a/test/integration/rhel-7.6/new-function.patch
+++ b/test/integration/rhel-7.6/new-function.patch
@@ -15,7 +15,7 @@ Index: kernel-rhel7/drivers/tty/n_tty.c
  	return (b - buf) ? b - buf : retval;
  }
  
-+static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
 +			   const unsigned char *buf, size_t nr)
 +{
 +	return kpatch_n_tty_write(tty, file, buf, nr);


### PR DESCRIPTION
Before doing a sibling call, the patched function restores the stack to
its caller's stack.  The kernel-generated call stub then writes the
patch module's r2 (toc) value to the caller's stack, corrupting it,
eventually causing a panic after it returns to the caller.

Fix it by disallowing sibling calls from patched functions on ppc64le.

In theory we could instead a) generate a custom stub, or b) modify the
kernel livepatch_handler code to save/restore the stack r2 value, but
this is easier.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>