### PR TITLE
test/unit: Fix symtab generation for ppc64le

### DIFF
--- a/test/unit/Makefile.include
+++ b/test/unit/Makefile.include
@@ -43,7 +43,8 @@ clean:
 	rm -f *.$(EXT_TEST_OUTPUT) *.$(EXT_OUTPUT)
 
 %.$(EXT_SYMTAB):
-	readelf -s --wide $(patsubst %.$(EXT_SYMTAB),%.$(EXT_ORIG),$(@)) >$@
+	readelf -s --wide $(patsubst %.$(EXT_SYMTAB),%.$(EXT_ORIG),$(@)) | \
+		sed -r 's/\s+\[<localentry>: 8\]//' >$@
 
 %.$(EXT_TEST_OUTPUT): %.$(EXT_OUTPUT) %.$(EXT_TEST) $(TEST_LIBRARY)
 	@echo "TEST $(@:.$(EXT_TEST_OUTPUT)=)"


### PR DESCRIPTION
The ppc64le unit tests are failing because the lookup code is getting
confused by the "[<localentry>: 8]" string in the readelf symbol table
output.

Remove the string so the lookup code can parse it correctly.
kpatch-build already uses the same sed, so they should match.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>