### PR TITLE
kpatch-build: remove localentry info from ppc64le new_symbols file

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -952,6 +952,7 @@ if ! "$KPATCH_MODULE"; then
 fi
 
 readelf --wide --symbols "$TEMPDIR/patch/$MODNAME.ko" 2>/dev/null | \
+	sed -r 's/\s+\[<localentry>: 8\]//' | \
 	awk '($4=="FUNC" || $4=="OBJECT") && ($5=="GLOBAL" || $5=="WEAK") && $7!="UND" {print $NF}' \
 	>"${TEMPDIR}"/new_symbols
 


### PR DESCRIPTION
Apply a sed filter to remove "[<localentry>: 8] " info from
readelf --wide --symbols output.  This ensures consistent column
data for the awk script creating the new_symbols file.

Fixes #994
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>