### PR TITLE
tests/unit: fix inconsistent FAIL test failures

### DIFF
--- a/test/unit/Makefile.include
+++ b/test/unit/Makefile.include
@@ -36,6 +36,7 @@ define check_all =
 	$(if $(findstring NOSTRIP,$(1)), , $(call check_stripped,$(1)))
 endef
 
+.DELETE_ON_ERROR: %.$(EXT_OUTPUT)
 
 all: $(TARGETS) $(TEST_TARGETS)
 


### PR DESCRIPTION
Use make's .DELETE_ON_ERROR special target to make sure we don't have
any .OUTPUT.o leftovers for failed tests.

Fixes: #999

Signed-off-by: Artem Savkov <asavkov@redhat.com>