### PR TITLE
Bump version to v0.7.1

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,6 +1,6 @@
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.7.0
+Version: 0.7.1
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch
@@ -93,6 +93,12 @@ rm -rf %{buildroot}
 %{_mandir}/man1/kpatch-build.1*
 
 %changelog
+* Wed Jul 24 2019 Josh Poimboeuf <jpoimboe@redhat.com> - 0.7.1
+- Fix several powerpc-specific bugs, including two which can result in kernel
+  panics
+- Use rpmbuild --nodeps for installing srpm on Fedora/RHEL
+- Fix inconsistent unit test failures for FAIL tests
+
 * Thu Jul 18 2019 Artem Savkov <asavkov@redhat.com> - 0.7.0
 - Multiple memory leak fixes in kpatch-build
 - livepatch-patch-hook compatability fixes for kernels 5.1+

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
-VERSION="0.7.0"
+VERSION="0.7.1"
 POST_ENABLE_WAIT=15	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 


### PR DESCRIPTION
- Fix several powerpc-specific bugs, including two which can result in
  kernel panics
- Use rpmbuild --nodeps for installing srpm on Fedora/RHEL
- Fix inconsistent unit test failures for FAIL tests

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>