### PR TITLE
create-diff-object: disable DWARF compression explicitly

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -748,7 +748,7 @@ if [[ "$ARCH" = "ppc64le" ]]; then
 	ARCH_KCFLAGS="-mcmodel=large -fplugin=$PLUGINDIR/ppc64le-plugin.so"
 fi
 
-export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections $ARCH_KCFLAGS"
+export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections -gz=none $ARCH_KCFLAGS"
 
 echo "Reading special section data"
 find_special_section_data


### PR DESCRIPTION
On some systems the linker produces compressed debug sections by
default. It is not supported by create-diff-object for now.

Fixes: #877

Signed-off-by: Stefan Strogin <steils@gentoo.org>