### PR TITLE
create-diff-object: fixup memleak in kpatch_create_mcount_sections()

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3161,6 +3161,7 @@ static void kpatch_create_mcount_sections(struct kpatch_elf *kelf)
 			ERROR("malloc");
 
 		memcpy(newdata, sym->sec->data->d_buf, sym->sec->data->d_size);
+		free(sym->sec->data->d_buf);
 		sym->sec->data->d_buf = newdata;
 		insn = newdata;
 


### PR DESCRIPTION
It's necessary free the old buffer,before it's updated.
Otherwise, it cause memleak.

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>