### PR TITLE
kpatch: remove manual signaling logic

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -230,21 +230,8 @@ signal_stalled_processes() {
 	[[ -z "$module" ]] && return
 
 	if [[ -e "/sys/kernel/livepatch/$module/signal" ]] ; then
+		echo "signaling stalled process(es):"
 		echo 1 > "/sys/kernel/livepatch/$module/signal"
-	else
-		for proc_task in /proc/[0-9]*/task/[0-9]*; do
-			tid=${proc_task#*/task/}
-			if is_stalled "$module" "$tid" ; then
-				if [[ "$tid" -eq "$$" ]] ; then
-					echo "skipping pid $tid $(cat "$proc_task"/comm 2>/dev/null)"
-				else
-					echo "signaling pid $tid $(cat "$proc_task"/comm 2>/dev/null)"
-					kill -SIGSTOP "$tid"
-					sleep .1
-					kill -SIGCONT "$tid"
-				fi
-			fi
-		done
 	fi
 }
 
@@ -263,7 +250,7 @@ wait_for_patch_transition() {
 		sleep 1s
 	done
 
-	echo "patch transition has stalled, signaling stalled process(es):"
+	echo "patch transition has stalled!"
 	signal_stalled_processes
 
 	echo "waiting (up to $POST_SIGNAL_WAIT seconds) for patch transition to complete..."


### PR DESCRIPTION
Ever since upstream v5.1 (specifically commits 0b3d52790e1c ("livepatch:
Remove signal sysfs attribute") and cba82dea3061 ("livepatch: Send a
fake signal periodically") the kpatch utility script's
signal_stalled_processes() functionality has been redundant.

Remove this code from the script to avoid user confusion or potentially
weird user vs. kernel signalling race conditions.

Fixes: #1022

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>