### PR TITLE
Bump version to v0.8.0

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -1,6 +1,6 @@
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.7.1
+Version: 0.8.0
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch
@@ -93,6 +93,13 @@ rm -rf %{buildroot}
 %{_mandir}/man1/kpatch-build.1*
 
 %changelog
+* Wed Aug 21 2019 Artem Savkov <asavkov@redhat.com> - 0.8.0
+- kpatch.ko atomic replace fixes
+- Fixes for potential problems found by covscan
+- Remove manual signaling logic from kpatch utility
+- Don't strip callback symbols
+- Allow dynamic debug static keys
+
 * Wed Jul 24 2019 Josh Poimboeuf <jpoimboe@redhat.com> - 0.7.1
 - Fix several powerpc-specific bugs, including two which can result in kernel
   panics

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
-VERSION="0.7.1"
+VERSION="0.8.0"
 POST_ENABLE_WAIT=15	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 


### PR DESCRIPTION
Increment version to v0.8.0 due to manual signaling logic being removed
from kpatch util. Full list of changes:

- kpatch.ko atomic replace fixes
- Fixes for potential problems found by covscan
- Remove manual signaling logic from kpatch utility
- Don't strip callback symbols
- Allow dynamic debug static keys

Signed-off-by: Artem Savkov <asavkov@redhat.com>