### PR TITLE
Fix parent matches for kernels newer than 5.3

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -354,6 +354,14 @@ find_special_section_data() {
 	return
 }
 
+filter_parent_obj()
+{
+  local dir="${1}"
+  local file="${2}"
+
+  grep -v "\.mod\.cmd$" | grep -Fv "${dir}/.${file}.cmd"
+}
+
 find_parent_obj() {
 	dir="$(dirname "$1")"
 	absdir="$(readlink -f "$dir")"
@@ -365,17 +373,17 @@ find_parent_obj() {
 	if [[ "$DEEP_FIND" -eq 1 ]]; then
 		num=0
 		if [[ -n "$last_deep_find" ]]; then
-			parent="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | grep -Fv "$pdir/.${file}.cmd" | head -n1)"
-			num="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | grep -Fvc "$pdir/.${file}.cmd")"
+			parent="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | head -n1)"
+			num="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | wc -l)"
 		fi
 		if [[ "$num" -eq 0 ]]; then
-			parent="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fv "$pdir/.${file}.cmd" | cut -c3- | head -n1)"
-			num="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | grep -Fvc "$pdir/.${file}.cmd")"
+			parent="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | filter_parent_obj "${pdir}" "${file}" | cut -c3- | head -n1)"
+			num="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | filter_parent_obj "${pdir}" "${file}" | wc -l)"
 			[[ "$num" -eq 1 ]] && last_deep_find="$(dirname "$parent")"
 		fi
 	else
-		parent="$(grep -l "$grepname" "$dir"/.*.cmd | grep -Fv "$dir/.${file}.cmd" | head -n1)"
-		num="$(grep -l "$grepname" "$dir"/.*.cmd | grep -Fvc "$dir/.${file}.cmd")"
+		parent="$(grep -l "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | head -n1)"
+		num="$(grep -l "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | wc -l)"
 	fi
 
 	[[ "$num" -eq 0 ]] && PARENT="" && return


### PR DESCRIPTION
Somewhere starting with 5.3 (probably with 9f69a496f100 "kbuild: split
out *.mod out of {single,multi}-used-m rules", but that is not
confirmed) .mod and correcponding .mod.cmd files started showing up
during module builds throwing off kpatch-build's find_parent_obj() func.

Filter out any files ending with .mod.cmd as they are definitely not the
parent.