### PR TITLE
Revert "create-diff-object: Check for *_fixup sections changes"

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -82,7 +82,6 @@ enum loglevel loglevel = NORMAL;
 struct special_section {
 	char *name;
 	int (*group_size)(struct kpatch_elf *kelf, int offset);
-	int unsupported;
 };
 
 /*************
@@ -1956,27 +1955,22 @@ static struct special_section special_sections[] = {
 	{
 		.name		= "__ftr_fixup",
 		.group_size	= fixup_entry_group_size,
-		.unsupported	= 1,
 	},
 	{
 		.name		= "__mmu_ftr_fixup",
 		.group_size	= fixup_entry_group_size,
-		.unsupported	= 1,
 	},
 	{
 		.name		= "__fw_ftr_fixup",
 		.group_size	= fixup_entry_group_size,
-		.unsupported	= 1,
 	},
 	{
 		.name		= "__lwsync_fixup",
 		.group_size	= fixup_lwsync_group_size,
-		.unsupported	= 1,
 	},
 	{
 		.name		= "__barrier_nospec_fixup",
 		.group_size	= fixup_barrier_nospec_group_size,
-		.unsupported	= 1,
 	},
 #endif
 	{},
@@ -2074,9 +2068,6 @@ static void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 
 		if (!include)
 			continue;
-
-		if (special->unsupported)
-			DIFF_FATAL("unsupported reference to special section %s", sec->base->name);
 
 		/*
 		 * Jump labels (aka static keys or static branches) aren't


### PR DESCRIPTION
We are seeing the following error on a real world patch:

  unsupported reference to special section __barrier_nospec_fixup

The kpatch commit bb444c2168d1 ("create-diff-object: Check for *_fixup
sections changes") created this error because we were trying to be
future proof.  However, that may have been overly paranoid, as it
doesn't seem likely that those fixup sections will need relocations
anytime soon, because the replacement instructions are manually
generated in code.  And anyway that "future proof" commit breaks the
present.

Also we decided at LPC that we are going to remove .klp.arch sections
anyway, so once that happens we will be fully future-proof anyway.

This reverts commit bb444c2168d17ba7a67a2329ea7ed6f9b37b45cc.

Fixes #974.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>