### PR TITLE
kpatch-build: fix two parent matches error

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -373,17 +373,17 @@ find_parent_obj() {
 	if [[ "$DEEP_FIND" -eq 1 ]]; then
 		num=0
 		if [[ -n "$last_deep_find" ]]; then
-			parent="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | head -n1)"
-			num="$(grep -l "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | wc -l)"
+			parent="$(grep -lw "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | head -n1)"
+			num="$(grep -lw "$grepname" "$last_deep_find"/.*.cmd | filter_parent_obj "${pdir}" "${file}" | wc -l)"
 		fi
 		if [[ "$num" -eq 0 ]]; then
-			parent="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | filter_parent_obj "${pdir}" "${file}" | cut -c3- | head -n1)"
-			num="$(find . -name ".*.cmd" -print0 | xargs -0 grep -l "$grepname" | filter_parent_obj "${pdir}" "${file}" | wc -l)"
+			parent="$(find . -name ".*.cmd" -print0 | xargs -0 grep -lw "$grepname" | filter_parent_obj "${pdir}" "${file}" | cut -c3- | head -n1)"
+			num="$(find . -name ".*.cmd" -print0 | xargs -0 grep -lw "$grepname" | filter_parent_obj "${pdir}" "${file}" | wc -l)"
 			[[ "$num" -eq 1 ]] && last_deep_find="$(dirname "$parent")"
 		fi
 	else
-		parent="$(grep -l "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | head -n1)"
-		num="$(grep -l "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | wc -l)"
+		parent="$(grep -lw "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | head -n1)"
+		num="$(grep -lw "$grepname" "$dir"/.*.cmd | filter_parent_obj "${dir}" "${file}" | wc -l)"
 	fi
 
 	[[ "$num" -eq 0 ]] && PARENT="" && return
@@ -393,7 +393,7 @@ find_parent_obj() {
 	PARENT="$(basename "$parent")"
 	PARENT="${PARENT#.}"
 	PARENT="${PARENT%.cmd}"
-	PARENT="$dir/$PARENT"
+	[[ $dir != "." ]] && PARENT="$dir/$PARENT"
 	[[ ! -e "$PARENT" ]] && die "ERROR: can't find parent $PARENT for $1"
 }
 


### PR DESCRIPTION
when I make a patch for a module, cause the error as follow:
ERROR: two parent matches for hello.o. Check /tmp/kpatch-build.log for more details.

The Makefile is as follow:
	obj-m += m_hello.o
	m_hello-y = hello.o
	default:
        	$(MAKE) -C /lib/modules/4.4.21-69-default/build M=$(shell pwd) modules
	clean:
        	$(MAKE) -C /lib/modules/4.4.21-69-default/build M=$(shell pwd) clean

and than cmd "grep -l hello.o ./.*.cmd | grep -Fv hello.o" would get two parant
	.m_hello.ko.cmd
	.m_hello.o.cmd
but the ".m_hello.ko.cmd" is the parant for "m_hello.o", and ".m_hello.o.cmd" is the
parant for "hello.o".

because the "hello.o" is a substring of "m_hello.o", which will cause the "m_hello.o"
matched for the "hello.o".

Signed-off-by: chenzefeng <chenzefeng2@huawei.com>