### PR TITLE
integration/rhel-*: fix multiple.test

### DIFF
--- a/test/integration/rhel-7.4/multiple.test
+++ b/test/integration/rhel-7.4/multiple.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../../..)"
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 
 MODULE_PREFIX="test-"

--- a/test/integration/rhel-7.5/multiple.test
+++ b/test/integration/rhel-7.5/multiple.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../../..)"
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 
 MODULE_PREFIX="test-"

--- a/test/integration/rhel-7.6/multiple.test
+++ b/test/integration/rhel-7.6/multiple.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../../..)"
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 
 MODULE_PREFIX="test-"

--- a/test/integration/rhel-7.7/multiple.test
+++ b/test/integration/rhel-7.7/multiple.test
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+ROOTDIR="$(readlink -f $SCRIPTDIR/../../..)"
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 
 MODULE_PREFIX="test-"


### PR DESCRIPTION
When these from internal depths of Red Hat upstream paths changed and
now we are one level deeper in directory tree.

The issue probably also exist in rhel8.0 rebase pr #993.