### PR TITLE
kmod: don't build module by default

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -17,10 +17,5 @@ MANDIR     = $(DESTDIR)$(PREFIX)/share/man/man1
 SYSTEMDDIR = $(DESTDIR)$(PREFIX)/lib/systemd/system
 UPSTARTDIR = $(DESTDIR)/etc/init
 
-# The core module is only supported on x86_64
-ifeq ($(ARCH),x86_64)
-BUILDMOD  ?= yes
-endif
-
 .PHONY: all install clean
 .DEFAULT: all


### PR DESCRIPTION
The stacktrace internal interface has been updated for v5.2. On x86,
among others, this means that stack_trace_save_tsk* is to be used
instead of instantiating a stack_trace struct. Those routines are
currently not exported for module use.

See linux kernel: <25e39e32b0a3> (livepatch: Simplify stack trace retrieval)
for more info about the stacktrace interface changes.

The kernel/livepatch subsystem is the way forward for using kpatch and
there are plans to phase out 'kmod' altogether in the near future.

It is still possible to build and use kmod by doing something like:
$ env BUILDMOD="yes" make

Closes #966

Signed-off-by: Yannick Cote <ycote@redhat.com>