### PR TITLE
Correlation rename fixes

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -760,7 +760,7 @@ static void kpatch_compare_symbols(struct list_head *symlist)
 	}
 }
 
-#define CORRELATE_ELEMENT(_e1_, _e2_)				\
+#define CORRELATE_ELEMENT(_e1_, _e2_, kindstr)			\
 do {								\
 	typeof(_e1_) e1 = (_e1_);				\
 	typeof(_e2_) e2 = (_e2_);				\
@@ -768,16 +768,22 @@ do {								\
 	e2->twin = e1;						\
 	/* set initial status, might change */			\
 	e1->status = e2->status = SAME;				\
+	if (strcmp(e1->name, e2->name)) {			\
+		/* Rename mangled element */			\
+		log_debug("renaming %s %s to %s\n",		\
+			  kindstr, e2->name, e1->name);		\
+		e2->name = strdup(e1->name);			\
+	}							\
 } while (0)
 
 static void __kpatch_correlate_section(struct section *sec1, struct section *sec2)
 {
-	CORRELATE_ELEMENT(sec1, sec2);
+	CORRELATE_ELEMENT(sec1, sec2, "section");
 }
 
 static void kpatch_correlate_symbol(struct symbol *sym1, struct symbol *sym2)
 {
-	CORRELATE_ELEMENT(sym1, sym2);
+	CORRELATE_ELEMENT(sym1, sym2, "symbol");
 }
 
 static void kpatch_correlate_section(struct section *sec1, struct section *sec2)

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -847,6 +847,8 @@ void kpatch_elf_teardown(struct kpatch_elf *kelf)
 	struct rela *rela, *saferela;
 
 	list_for_each_entry_safe(sec, safesec, &kelf->sections, list) {
+		if (sec->twin)
+			sec->twin->twin = NULL;
 		if (is_rela_section(sec)) {
 			list_for_each_entry_safe(rela, saferela, &sec->relas, list) {
 				memset(rela, 0, sizeof(*rela));
@@ -858,6 +860,8 @@ void kpatch_elf_teardown(struct kpatch_elf *kelf)
 	}
 
 	list_for_each_entry_safe(sym, safesym, &kelf->symbols, list) {
+		if (sym->twin)
+			sym->twin->twin = NULL;
 		memset(sym, 0, sizeof(*sym));
 		free(sym);
 	}


### PR DESCRIPTION
As mentioned on https://github.com/dynup/kpatch/pull/1043.

This change actually breaks some tests I was rebasing for rhel-8.0 with the following kind of error:
(this is on gcc-static-local-var-4.patch)
ERROR: aio.o: kpatch_create_patches_sections: 2708: lookup_local_symbol put_aio_ring_file.isra.19

The issue is due to the fact that we dropped symbol renaming when correlating. For symbols that end with status "SAME" there is no problem as we don't include those in the final object. For symbols that have status "CHANGED", we need to lookup the original symbols to know their address/position in the kernel/module getting patched, but at the point of the lookup, we only have the name from the patched object.
In the above example, put_aio_ring_file.isra.19 from the patched object gets correlated to put_aio_ring_file.isra.20 from the original object. But when creating the patch module itself, we no longer have the information of the original name.

My suggestion is to always rename mangled elements with the name of the object they get correlated to (last patch).

I also took the opportunity to do some cleanup related to correlation.