### PR TITLE
kpatch-elf: Free sections in elf teardown

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -852,9 +852,9 @@ void kpatch_elf_teardown(struct kpatch_elf *kelf)
 				memset(rela, 0, sizeof(*rela));
 				free(rela);
 			}
-			memset(sec, 0, sizeof(*sec));
-			free(sec);
 		}
+		memset(sec, 0, sizeof(*sec));
+		free(sec);
 	}
 
 	list_for_each_entry_safe(sym, safesym, &kelf->symbols, list) {


### PR DESCRIPTION
Currently, only rela section get freed. This seems like a simple
scope mistake.

Free all sections regardless of their nature in kpatch_elf_teardown()

Signed-off-by: Julien Thierry <jthierry@redhat.com>