### PR TITLE
kpatch-build: Make local static twining stricter

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -975,18 +975,26 @@ static struct symbol *kpatch_find_static_twin(struct section *sec,
 
 	/* find the patched object's corresponding variable */
 	list_for_each_entry(rela, &sec->twin->relas, list) {
+		struct symbol *patched_sym;
 
 		rela_toc = toc_rela(rela);
 		if (!rela_toc)
 			continue; /* skip toc constants */
 
-		if (rela_toc->sym->twin)
+		patched_sym = rela_toc->sym;
+
+		if (patched_sym->twin)
 			continue;
 
-		if (kpatch_mangled_strcmp(rela_toc->sym->name, sym->name))
+		if (sym->type != patched_sym->type ||
+		    (sym->type == STT_OBJECT &&
+		     sym->sym.st_size != patched_sym->sym.st_size))
 			continue;
 
-		return rela_toc->sym;
+		if (kpatch_mangled_strcmp(patched_sym->name, sym->name))
+			continue;
+
+		return patched_sym;
 	}
 
 	return NULL;


### PR DESCRIPTION
The current code to find the twin of a local static variable allows two
variables of the same name to be wrongly matched with the other's twin.

While there isn't a magic formula to avoid this, make stricter
requirements for twining static local from the original object with
a symbol from the patched object. This reduces the risk of erroneous
matches.

Signed-off-by: Julien Thierry <jthierry@redhat.com>