### PR TITLE
kpatch-build: replace all '-' to '_' in KOBJFILE_NAME

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -900,7 +900,7 @@ for i in $FILES; do
 			awk '{ print $1 "\t" $2 "\t" $3 "\t" $4}' "${BUILDDIR}/Module.symvers" >> "$SYMVERS_FILE"
 		else
 			KOBJFILE_NAME=$(basename "${KOBJFILE%.ko}")
-			KOBJFILE_NAME="${KOBJFILE_NAME/-/_}"
+			KOBJFILE_NAME="${KOBJFILE_NAME//-/_}"
 			KOBJFILE_PATH="${TEMPDIR}/module/$KOBJFILE"
 			SYMTAB="${KOBJFILE_PATH}.symtab"
 			SYMVERS_FILE="$SRCDIR/Module.symvers"


### PR DESCRIPTION
When patching kernel module dm-persistent-data, I found
that the KOBJFILE_NAME is incorrectly replaced to
dm_persistent-data while the module name in kernel is
dm_persistent_data.

Signed-off-by: Zhipeng Xie <xiezhipeng1@huawei.com>