### PR TITLE
[RFC] Enable -Wconversion/-Wno-sign-conversion flags

### DIFF
--- a/kmod/patch/kpatch-patch.h
+++ b/kmod/patch/kpatch-patch.h
@@ -40,7 +40,7 @@ struct kpatch_patch_dynrela {
 	char *name;
 	char *objname;
 	int external;
-	int addend;
+	long addend;
 };
 
 struct kpatch_pre_patch_callback {

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -13,12 +13,14 @@ SOURCES = create-diff-object.c kpatch-elf.c \
 ifeq ($(ARCH),x86_64)
 SOURCES += insn/insn.c insn/inat.c
 INSN     = insn/insn.o insn/inat.o
+insn/%.o: CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 else ifeq ($(ARCH),ppc64le)
 SOURCES += gcc-plugins/ppc64le-plugin.c
 PLUGIN   = gcc-plugins/ppc64le-plugin.so
 TARGETS += $(PLUGIN)
 GCC_PLUGINS_DIR := $(shell gcc -print-file-name=plugin)
-PLUGIN_CFLAGS    = -shared $(CFLAGS) -I$(GCC_PLUGINS_DIR)/include \
+PLUGIN_CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
+PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
 endif
 

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.inc
 
-CFLAGS += -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare -g -Werror
+CFLAGS += -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare \
+	  -Wconversion -Wno-sign-conversion -g -Werror
 LDLIBS = -lelf
 
 TARGETS = create-diff-object create-klp-module create-kpatch-module

--- a/kpatch-build/kpatch-intermediate.h
+++ b/kpatch-build/kpatch-intermediate.h
@@ -35,8 +35,8 @@ struct kpatch_symbol {
 struct kpatch_relocation {
 	unsigned long dest;
 	unsigned int type;
-	int addend;
 	int external;
+	long addend;
 	char *objname; /* object to which this rela applies to */
 	struct kpatch_symbol *ksym;
 };


### PR DESCRIPTION
#1065 exposed a bug due to GCC's implicit conversion of data types.  Enable `-Wconversion` and `-Wno-sign-conversion` flags to warn about conversions.  This patch series, also adds explicit type casts to the warnings triggered by enabling the flags.