### PR TITLE
integration: update gcc-static-local-var-4.test

### DIFF
--- a/test/integration/centos-7/gcc-static-local-var-4.test
+++ b/test/integration/centos-7/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/rhel-7.4/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.4/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/rhel-7.5/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.5/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/rhel-7.6/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.6/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/rhel-7.7/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.7/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/rhel-8.0/gcc-static-local-var-4.test
+++ b/test/integration/rhel-8.0/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0

--- a/test/integration/ubuntu-16.04/gcc-static-local-var-4.test
+++ b/test/integration/ubuntu-16.04/gcc-static-local-var-4.test
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if $(nm test-gcc-static-local-var-4.ko | grep -q free_ioctx); then
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
 	exit 1
 else
 	exit 0


### PR DESCRIPTION
The gcc-static-local-var-4.patch and test check that unmodified functions
that contain dynamic debugging printk's aren't incorrectly included in
the resulting livepatch .ko.

Note that on RHEL-7.7 ppc64le, the gcc-static-local-var-4.ko livepatch
module may include klp-relocation references to free_ioctx(), a function
that would match the above criteria.  These klp-relocation symbols are
OK as they are only used for referencing said functions, they are not
copies that the check should FAIL on.

Modify gcc-static-local-var-4.test in a few ways:

  - Convert it to a LOADED test so that we can ...

  - Search /proc/kallsyms instead of using binutils or elfutils (which
    may have issues parsing klp-relocations).

  - Instead of a grep regex, use awk to string compare exact function
    and module names.  This avoids matching on .klp.sym prefixed
    klp-relocation symbols.

Fixes #1069.
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>