### PR TITLE
tests/integration: fetch pull-request data

### DIFF
--- a/test/integration/vm-integration-run
+++ b/test/integration/vm-integration-run
@@ -47,6 +47,7 @@ git clone "${KPATCH_GIT}" || exit 1
 
 cd kpatch || exit 1
 
+git fetch origin +refs/pull/*:refs/pull/*
 git reset --hard "${KPATCH_REV}" || exit 1
 
 # shellcheck disable=SC1091


### PR DESCRIPTION
Fetch pull-request data before resetting to a specified commit. This
will allow us to run integration tests on pull-request using master
repo, without cloning the original.