### PR TITLE
kpatch.service: make sure it starts before networking services

### DIFF
--- a/contrib/kpatch.service
+++ b/contrib/kpatch.service
@@ -1,6 +1,8 @@
 [Unit]
 Description="Apply kpatch kernel patches"
 ConditionKernelCommandLine=!kpatch.enable=0
+Before=network-pre.target
+Wants=network-pre.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
A binary patch may be used to fix network-related issues, so it is better to
apply it before networking services have started.

We encountered a situation in Virtuozzo 7, when the older kernels
conflicted with a new NetworkManager, ip utility and other system
components (https://www.mail-archive.com/devel@openvz.org/msg35123.html).

Binary patches were provided for these kernels to fix the issue but were
loaded after networking services in some cases. As a result, NetworkManager
and some other system components failed to work properly.

Let us make sure the patches are applied earlier during boot.