### PR TITLE
create-diff-object: Handle ppc64le toc with only constants

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -177,6 +177,10 @@ static struct rela *toc_rela(const struct rela *rela)
 	    rela->type != R_PPC64_TOC16_LO_DS)
 		return (struct rela *)rela;
 
+	/* Only constants in toc */
+	if (!rela->sym->sec->rela)
+		return NULL;
+
 	/* Will return NULL for .toc constant entries */
 	return find_rela_by_offset(rela->sym->sec->rela,
 				   (unsigned int)rela->addend);


### PR DESCRIPTION
When a ppcle64 ".toc" section contains only constants, the compiler
might not (won't?) create a corresponding ".rela.toc" section.

In such cases, create-diff-object crashes, assuming ".rela.toc" exists
whenever .toc exists. Simply report that no rela are available when
looking up possible relocations in .toc.

Fixes #1078.
Signed-off-by: Julien Thierry <jthierry@redhat.com>