### PR TITLE
test/integration: add rhel-8.3 rebased patches

### DIFF
--- a/test/integration/rhel-8.3/bug-table-section.patch
+++ b/test/integration/rhel-8.3/bug-table-section.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/proc_sysctl.c	2020-03-17 01:12:59.269209033 -0400
+@@ -338,6 +338,8 @@ static void start_unregistering(struct c
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-8.3/cmdline-string-LOADED.test
+++ b/test/integration/rhel-8.3/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-8.3/cmdline-string.patch
+++ b/test/integration/rhel-8.3/cmdline-string.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2020-03-17 01:12:55.154895731 -0400
++++ src/fs/proc/cmdline.c	2020-03-17 01:13:02.339442827 -0400
+@@ -6,8 +6,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_puts(m, saved_command_line);
+-	seq_putc(m, '\n');
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-8.3/data-new-LOADED.test
+++ b/test/integration/rhel-8.3/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch:         5" /proc/meminfo

--- a/test/integration/rhel-8.3/data-new.patch
+++ b/test/integration/rhel-8.3/data-new.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/meminfo.c	2020-03-17 01:13:05.297668094 -0400
+@@ -31,6 +31,8 @@ static void show_val_kb(struct seq_file
+ 	seq_write(m, " kB\n", 4);
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -143,6 +145,7 @@ static int meminfo_proc_show(struct seq_
+ 	show_val_kb(m, "CmaFree:        ",
+ 		    global_zone_page_state(NR_FREE_CMA_PAGES));
+ #endif
++	seq_printf(m, "kpatch:         %d\n", foo);
+ 
+ 	hugetlb_report_meminfo(m);
+ 

--- a/test/integration/rhel-8.3/data-read-mostly.patch.disabled
+++ b/test/integration/rhel-8.3/data-read-mostly.patch.disabled
@@ -1,0 +1,13 @@
+Disabled due to https://github.com/dynup/kpatch/issues/940
+---
+diff -Nupr src.orig/net/core/dev.c src/net/core/dev.c
+--- src.orig/net/core/dev.c	2020-03-17 01:12:55.619931143 -0400
++++ src/net/core/dev.c	2020-03-17 01:13:57.999681305 -0400
+@@ -4893,6 +4893,7 @@ skip_classify:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-8.3/fixup-section.patch
+++ b/test/integration/rhel-8.3/fixup-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/readdir.c src/fs/readdir.c
+--- src.orig/fs/readdir.c	2020-03-17 01:12:55.087890628 -0400
++++ src/fs/readdir.c	2020-03-17 01:13:08.214890238 -0400
+@@ -189,6 +189,7 @@ static int filldir(struct dir_context *c
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-8.3/gcc-constprop.patch
+++ b/test/integration/rhel-8.3/gcc-constprop.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2020-03-17 01:12:55.498921929 -0400
++++ src/kernel/time/timekeeping.c	2020-03-17 01:14:00.935904896 -0400
+@@ -1221,6 +1221,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-8.3/gcc-isra.patch
+++ b/test/integration/rhel-8.3/gcc-isra.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/proc_sysctl.c	2020-03-17 01:13:11.117111239 -0400
+@@ -53,6 +53,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-8.3/gcc-mangled-3.patch
+++ b/test/integration/rhel-8.3/gcc-mangled-3.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/slub.c src/mm/slub.c
+--- src.orig/mm/slub.c	2020-03-17 01:12:57.341062206 -0400
++++ src/mm/slub.c	2020-03-17 01:13:14.023332546 -0400
+@@ -5852,6 +5852,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	int node;
+ 	struct kmem_cache_node *n;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_kmem_cache_node(s, node, n) {
+ 		nr_slabs += node_nr_slabs(n);
+ 		nr_objs += node_nr_objs(n);

--- a/test/integration/rhel-8.3/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-8.3/gcc-static-local-var-2.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
+--- src.orig/mm/mmap.c	2020-03-17 01:12:57.337061902 -0400
++++ src/mm/mmap.c	2020-03-17 01:13:16.949555374 -0400
+@@ -1679,6 +1679,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, vm_flags, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-8.3/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-8.3/gcc-static-local-var-3.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/kernel/reboot.c src/kernel/reboot.c
+--- src.orig/kernel/reboot.c	2020-03-17 01:12:55.495921700 -0400
++++ src/kernel/reboot.c	2020-03-17 01:13:19.875778203 -0400
+@@ -393,8 +393,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-8.3/gcc-static-local-var-4.patch.disabled
+++ b/test/integration/rhel-8.3/gcc-static-local-var-4.patch.disabled
@@ -1,0 +1,24 @@
+Disabled due to https://github.com/dynup/kpatch/issues/940
+---
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2020-03-17 01:12:55.092891009 -0400
++++ src/fs/aio.c	2020-03-17 01:14:03.844126354 -0400
+@@ -251,11 +251,18 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
+ static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
+ 	struct address_space *i_mapping;
+ 
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(file_inode(aio_ring_file), 0);
+ 

--- a/test/integration/rhel-8.3/gcc-static-local-var-4.test.disabled
+++ b/test/integration/rhel-8.3/gcc-static-local-var-4.test.disabled
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-8.3/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-8.3/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2020-03-17 13:21:09.547745268 -0400
++++ src/kernel/audit.c	2020-03-17 13:57:21.709885683 -0400
+@@ -321,6 +321,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -331,6 +337,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -350,6 +357,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -396,6 +408,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(audit_context(), GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-8.3/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-8.3/gcc-static-local-var-6.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/net/ipv6/netfilter.c src/net/ipv6/netfilter.c
+--- src.orig/net/ipv6/netfilter.c	2020-10-21 11:19:40.261740227 -0400
++++ src/net/ipv6/netfilter.c	2020-10-21 11:21:09.055020262 -0400
+@@ -86,6 +86,8 @@ static int nf_ip6_reroute(struct sk_buff
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
++
+ int __nf_ip6_route(struct net *net, struct dst_entry **dst,
+ 		   struct flowi *fl, bool strict)
+ {
+@@ -99,6 +101,9 @@ int __nf_ip6_route(struct net *net, stru
+ 	struct dst_entry *result;
+ 	int err;
+ 
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+ 	result = ip6_route_output(net, sk, &fl->u.ip6);
+ 	err = result->error;
+ 	if (err)

--- a/test/integration/rhel-8.3/macro-callbacks.patch
+++ b/test/integration/rhel-8.3/macro-callbacks.patch
@@ -1,0 +1,155 @@
+diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
+--- src.orig/drivers/input/joydev.c	2020-03-17 01:12:57.827099217 -0400
++++ src/drivers/input/joydev.c	2020-03-17 01:13:25.725223634 -0400
+@@ -1084,3 +1084,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
+--- src.orig/drivers/input/misc/pcspkr.c	2020-03-17 01:12:57.831099522 -0400
++++ src/drivers/input/misc/pcspkr.c	2020-03-17 01:13:25.725223634 -0400
+@@ -133,3 +133,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2020-03-17 01:12:55.092891009 -0400
++++ src/fs/aio.c	2020-03-17 01:13:25.726223710 -0400
+@@ -49,6 +49,50 @@
+ 
+ #define KIOCB_KEY		0
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0

--- a/test/integration/rhel-8.3/macro-printk.patch
+++ b/test/integration/rhel-8.3/macro-printk.patch
@@ -1,0 +1,148 @@
+diff -Nupr src.orig/net/ipv4/fib_frontend.c src/net/ipv4/fib_frontend.c
+--- src.orig/net/ipv4/fib_frontend.c	2020-03-17 01:12:55.534924670 -0400
++++ src/net/ipv4/fib_frontend.c	2020-03-17 01:14:06.756348118 -0400
+@@ -789,6 +789,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh,
+ 			     struct netlink_ext_ack *extack)
+ {
+@@ -810,6 +811,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	err = fib_table_insert(net, tb, &cfg, extack);
+ 	if (!err && cfg.fc_type == RTN_LOCAL)
+ 		net->ipv4.fib_has_custom_local_routes = true;
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+diff -Nupr src.orig/net/ipv4/fib_semantics.c src/net/ipv4/fib_semantics.c
+--- src.orig/net/ipv4/fib_semantics.c	2020-03-17 01:12:55.534924670 -0400
++++ src/net/ipv4/fib_semantics.c	2020-03-17 01:14:06.756348118 -0400
+@@ -1025,6 +1025,7 @@ fib_convert_metrics(struct fib_info *fi,
+ 				  fi->fib_metrics->metrics);
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg,
+ 				 struct netlink_ext_ack *extack)
+ {
+@@ -1058,6 +1059,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -1078,6 +1080,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (!fi)
+@@ -1093,6 +1096,8 @@ struct fib_info *fib_create_info(struct
+ 		fi->fib_metrics = (struct dst_metrics *)&dst_default_metrics;
+ 	}
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
++
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+ 	fi->fib_scope = cfg->fc_scope;
+@@ -1109,8 +1114,10 @@ struct fib_info *fib_create_info(struct
+ 		if (!nexthop_nh->nh_pcpu_rth_output)
+ 			goto failure;
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 
+ 	err = fib_convert_metrics(fi, cfg);
++	KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 	if (err)
+ 		goto failure;
+ 
+@@ -1172,6 +1179,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp) {
+@@ -1193,6 +1201,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST) {
+ 		NL_SET_ERR_MSG(extack, "Invalid scope");
+@@ -1231,6 +1240,7 @@ struct fib_info *fib_create_info(struct
+ 		if (linkdown == fi->fib_nhs)
+ 			fi->fib_flags |= RTNH_F_LINKDOWN;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc && !fib_valid_prefsrc(cfg, fi->fib_prefsrc)) {
+ 		NL_SET_ERR_MSG(extack, "Invalid prefsrc address");
+@@ -1240,6 +1250,7 @@ struct fib_info *fib_create_info(struct
+ 	change_nexthops(fi) {
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1251,6 +1262,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	refcount_set(&fi->fib_clntref, 1);
+@@ -1274,6 +1286,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1284,6 +1297,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+diff -Nupr src.orig/net/ipv4/fib_trie.c src/net/ipv4/fib_trie.c
+--- src.orig/net/ipv4/fib_trie.c	2020-03-17 01:12:55.541925203 -0400
++++ src/net/ipv4/fib_trie.c	2020-03-17 01:14:06.756348118 -0400
+@@ -1121,6 +1121,7 @@ static bool fib_valid_key_len(u32 key, u
+ }
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg, struct netlink_ext_ack *extack)
+ {
+@@ -1143,11 +1144,14 @@ int fib_table_insert(struct net *net, st
+ 
+ 	pr_debug("Insert table=%u %08x/%d\n", tb->tb_id, key, plen);
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg, extack);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority,

--- a/test/integration/rhel-8.3/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-8.3/meminfo-init-FAIL.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/meminfo.c	2020-03-17 01:13:31.599670967 -0400
+@@ -153,6 +153,7 @@ static int meminfo_proc_show(struct seq_
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create_single("meminfo", 0, NULL, meminfo_proc_show);
+ 	return 0;
+ }

--- a/test/integration/rhel-8.3/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-8.3/meminfo-init2-FAIL.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/meminfo.c	2020-03-17 01:13:28.655446767 -0400
+@@ -41,6 +41,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long sreclaimable, sunreclaim;
+ 	int lru;
+ 
++	printk("a\n");
+ 	si_meminfo(&i);
+ 	si_swapinfo(&i);
+ 	committed = percpu_counter_read_positive(&vm_committed_as);
+@@ -153,6 +154,7 @@ static int meminfo_proc_show(struct seq_
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create_single("meminfo", 0, NULL, meminfo_proc_show);
+ 	return 0;
+ }

--- a/test/integration/rhel-8.3/meminfo-string-LOADED.test
+++ b/test/integration/rhel-8.3/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-8.3/meminfo-string.patch
+++ b/test/integration/rhel-8.3/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-03-17 13:21:08.363654606 -0400
++++ src/fs/proc/meminfo.c	2020-03-17 13:22:47.153218616 -0400
+@@ -121,7 +121,7 @@ static int meminfo_proc_show(struct seq_
+ 	seq_printf(m, "VmallocTotal:   %8lu kB\n",
+ 		   (unsigned long)VMALLOC_TOTAL >> 10);
+ 	show_val_kb(m, "VmallocUsed:    ", 0ul);
+-	show_val_kb(m, "VmallocChunk:   ", 0ul);
++	show_val_kb(m, "VMALLOCCHUNK:   ", 0ul);
+ 	show_val_kb(m, "Percpu:         ", pcpu_nr_pages());
+ 
+ #ifdef CONFIG_MEMORY_FAILURE

--- a/test/integration/rhel-8.3/module-LOADED.test
+++ b/test/integration/rhel-8.3/module-LOADED.test
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+
+sudo modprobe nfsd
+sleep 5
+grep -q kpatch /proc/fs/nfs/exports
+
+# TODO: This will trigger a printk on newer kernels which have the .klp.arch
+# removal.  Don't actually do the grep until running on a newer kernel.
+echo "file fs/nfsd/export.c +p" > /sys/kernel/debug/dynamic_debug/control
+cat /proc/fs/nfs/exports > /dev/null
+# dmesg | grep -q "kpatch: pr_debug"

--- a/test/integration/rhel-8.3/module.patch
+++ b/test/integration/rhel-8.3/module.patch
@@ -1,0 +1,85 @@
+From 08078d00ab1749a6f84148a00d8d26572af4ec97 Mon Sep 17 00:00:00 2001
+Message-Id: <08078d00ab1749a6f84148a00d8d26572af4ec97.1586900628.git.jpoimboe@redhat.com>
+From: Josh Poimboeuf <jpoimboe@redhat.com>
+Date: Tue, 14 Apr 2020 15:17:51 -0500
+Subject: [PATCH] kpatch module integration test
+
+This tests several things related to the patching of modules:
+
+- 'kpatch_string' tests the referencing of a symbol which is outside the
+  .o, but inside the patch module.
+
+- alternatives patching (.altinstructions)
+
+- paravirt patching (.parainstructions)
+
+- jump labels (5.8+ kernels only) -- including dynamic printk
+
+Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>
+---
+ fs/nfsd/export.c         | 30 ++++++++++++++++++++++++++++++
+ net/netlink/af_netlink.c |  5 +++++
+ 2 files changed, 35 insertions(+)
+
+diff -Nupr src.orig/fs/nfsd/export.c src/fs/nfsd/export.c
+--- src.orig/fs/nfsd/export.c	2020-05-12 11:14:29.230792719 -0400
++++ src/fs/nfsd/export.c	2020-05-12 11:15:17.078719042 -0400
+@@ -1196,15 +1196,45 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++#include <linux/version.h>
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+ 	struct svc_export *exp = container_of(cp, struct svc_export, h);
+ 	struct cache_detail *cd = m->private;
++#ifdef CONFIG_X86_64
++	unsigned long long sched_clock;
++
++	alternative("ud2", "call yield", X86_FEATURE_ALWAYS);
++	alternative("call yield", "ud2", X86_FEATURE_IA64);
++
++	sched_clock = paravirt_sched_clock();
++	if (!jiffies)
++		printk("kpatch: sched_clock: %llu\n", sched_clock);
++#endif
++
++	pr_debug("kpatch: pr_debug() test\n");
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++{
++	static DEFINE_STATIC_KEY_TRUE(kpatch_key);
++
++	if (static_branch_unlikely(&mcsafe_key))
++		printk("kpatch: mcsafe_key\n");
++
++	BUG_ON(!static_branch_likely(&kpatch_key));
++	static_branch_disable(&kpatch_key);
++	BUG_ON(static_branch_likely(&kpatch_key));
++	static_branch_enable(&kpatch_key);
++}
++#endif
+ 
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2020-05-12 11:14:29.780768884 -0400
++++ src/net/netlink/af_netlink.c	2020-05-12 11:15:17.078719042 -0400
+@@ -2788,4 +2788,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-8.3/multiple.test
+++ b/test/integration/rhel-8.3/multiple.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+source ${SCRIPTDIR}/../common/multiple.template

--- a/test/integration/rhel-8.3/new-function.patch
+++ b/test/integration/rhel-8.3/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2020-03-17 01:12:58.001112468 -0400
++++ src/drivers/tty/n_tty.c	2020-03-17 01:13:37.546123784 -0400
+@@ -2296,7 +2296,7 @@ static ssize_t n_tty_read(struct tty_str
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2383,6 +2383,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
++			   							     const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-8.3/new-globals.patch
+++ b/test/integration/rhel-8.3/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2020-03-17 01:12:55.154895731 -0400
++++ src/fs/proc/cmdline.c	2020-03-17 01:13:40.492348137 -0400
+@@ -17,3 +17,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ fs_initcall(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-03-17 01:12:55.155895808 -0400
++++ src/fs/proc/meminfo.c	2020-03-17 01:13:40.492348137 -0400
+@@ -21,6 +21,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -57,6 +59,7 @@ static int meminfo_proc_show(struct seq_
+ 	sreclaimable = global_node_page_state(NR_SLAB_RECLAIMABLE);
+ 	sunreclaim = global_node_page_state(NR_SLAB_UNRECLAIMABLE);
+ 
++	kpatch_print_message();
+ 	show_val_kb(m, "MemTotal:       ", i.totalram);
+ 	show_val_kb(m, "MemFree:        ", i.freeram);
+ 	show_val_kb(m, "MemAvailable:   ", available);

--- a/test/integration/rhel-8.3/parainstructions-section.patch
+++ b/test/integration/rhel-8.3/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2020-03-17 01:12:55.154895731 -0400
++++ src/fs/proc/generic.c	2020-03-17 01:13:43.430571880 -0400
+@@ -205,6 +205,7 @@ int proc_alloc_inum(unsigned int *inum)
+ {
+ 	int i;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ 	i = ida_simple_get(&proc_inum_ida, 0, UINT_MAX - PROC_DYNAMIC_FIRST + 1,
+ 			   GFP_KERNEL);
+ 	if (i < 0)

--- a/test/integration/rhel-8.3/shadow-newpid-LOADED.test.disabled
+++ b/test/integration/rhel-8.3/shadow-newpid-LOADED.test.disabled
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-8.3/shadow-newpid.patch.disabled
+++ b/test/integration/rhel-8.3/shadow-newpid.patch.disabled
@@ -1,0 +1,77 @@
+Disabled due to https://github.com/dynup/kpatch/issues/940
+---
+diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
+--- src.orig/fs/proc/array.c	2020-03-17 01:12:55.154895731 -0400
++++ src/fs/proc/array.c	2020-03-17 01:14:09.668569881 -0400
+@@ -370,12 +370,19 @@ static inline void task_seccomp(struct s
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_put_decimal_ull(m, "voluntary_ctxt_switches:\t", p->nvcsw);
+ 	seq_put_decimal_ull(m, "\nnonvoluntary_ctxt_switches:\t", p->nivcsw);
+ 	seq_putc(m, '\n');
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
+--- src.orig/kernel/exit.c	2020-03-17 01:12:55.490921320 -0400
++++ src/kernel/exit.c	2020-03-17 01:14:09.668569881 -0400
+@@ -762,6 +762,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include <linux/livepatch.h>
+ void __noreturn do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -868,6 +869,8 @@ void __noreturn do_exit(long code)
+ 	exit_thread(tsk);
+ 	exit_umh(tsk);
+ 
++	klp_shadow_free(tsk, 0, NULL);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2020-03-17 01:12:55.500922081 -0400
++++ src/kernel/fork.c	2020-03-17 01:14:09.668569881 -0400
+@@ -2206,6 +2206,7 @@ struct task_struct *fork_idle(int cpu)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include <linux/livepatch.h>
+ long _do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -2218,6 +2219,8 @@ long _do_fork(unsigned long clone_flags,
+ 	struct task_struct *p;
+ 	int trace = 0;
+ 	long nr;
++	int *newpid;
++	static int ctr = 0;
+ 
+ 	/*
+ 	 * Determine whether and which event to report to ptracer.  When
+@@ -2244,6 +2247,11 @@ long _do_fork(unsigned long clone_flags,
+ 	if (IS_ERR(p))
+ 		return PTR_ERR(p);
+ 
++	newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid), GFP_KERNEL,
++					 NULL, NULL);
++	if (newpid)
++		*newpid = ctr++;
++
+ 	/*
+ 	 * Do this prior waking up the new thread - the thread pointer
+ 	 * might get invalid after that point, if the thread exits quickly.

--- a/test/integration/rhel-8.3/smp-locks-section.patch
+++ b/test/integration/rhel-8.3/smp-locks-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2020-03-17 01:12:58.012113306 -0400
++++ src/drivers/tty/tty_buffer.c	2020-03-17 01:13:46.342793643 -0400
+@@ -256,6 +256,9 @@ static int __tty_buffer_request_room(str
+ 	struct tty_buffer *b, *n;
+ 	int left, change;
+ 
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b->flags & TTYB_NORMAL)
+ 		left = 2 * b->size - b->used;

--- a/test/integration/rhel-8.3/special-static.patch.disabled
+++ b/test/integration/rhel-8.3/special-static.patch.disabled
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2020-03-17 01:12:55.500922081 -0400
++++ src/kernel/fork.c	2020-03-17 01:13:49.230013502 -0400
+@@ -1523,10 +1523,18 @@ static void posix_cpu_timers_init_group(
+ static inline void posix_cpu_timers_init_group(struct signal_struct *sig) { }
+ #endif
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-8.3/symvers-disagreement-FAIL.patch
+++ b/test/integration/rhel-8.3/symvers-disagreement-FAIL.patch
@@ -1,0 +1,51 @@
+From 2d6b7bce089e52563bd9c67df62f48e90b48047d Mon Sep 17 00:00:00 2001
+From: Julien Thierry <jthierry@redhat.com>
+Date: Wed, 6 May 2020 14:30:57 +0100
+Subject: [PATCH] Symbol version change
+
+This change causes:
+1) Some exported symbols in drivers/base/core.c to see their CRCs
+   change.
+2) Changes usb_get_dev() referencing a get_device() whose CRC has
+   changed, causing the symbol and the new CRC to be included in the
+   __version section of the final module.
+
+This makes the final module unloadable for the target kernel.
+
+See "Exported symbol versioning" of the patch author guide for more
+detail.
+
+---
+ drivers/base/core.c    | 2 ++
+ drivers/usb/core/usb.c | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/drivers/base/core.c b/drivers/base/core.c
+index 26bae20f0553..506ebbf0a210 100644
+--- a/drivers/base/core.c
++++ b/drivers/base/core.c
+@@ -30,6 +30,8 @@
+ #include "base.h"
+ #include "power/power.h"
+ 
++#include <linux/blktrace_api.h>
++
+ #ifdef CONFIG_SYSFS_DEPRECATED
+ #ifdef CONFIG_SYSFS_DEPRECATED_V2
+ long sysfs_deprecated = 1;
+diff --git a/drivers/usb/core/usb.c b/drivers/usb/core/usb.c
+index f74e6bda1788..86f7d453549c 100644
+--- a/drivers/usb/core/usb.c
++++ b/drivers/usb/core/usb.c
+@@ -685,6 +685,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
+  */
+ struct usb_device *usb_get_dev(struct usb_device *dev)
+ {
++	barrier();
++
+ 	if (dev)
+ 		get_device(&dev->dev);
+ 	return dev;
+-- 
+2.21.3
+

--- a/test/integration/rhel-8.3/tracepoints-section.patch
+++ b/test/integration/rhel-8.3/tracepoints-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timer.c src/kernel/time/timer.c
+--- src.orig/kernel/time/timer.c	2020-03-17 01:12:55.499922005 -0400
++++ src/kernel/time/timer.c	2020-03-17 01:13:52.157236408 -0400
+@@ -1696,6 +1696,9 @@ static __latent_entropy void run_timer_s
+ {
+ 	struct timer_base *base = this_cpu_ptr(&timer_bases[BASE_STD]);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	__run_timers(base);
+ 	if (IS_ENABLED(CONFIG_NO_HZ_COMMON))
+ 		__run_timers(this_cpu_ptr(&timer_bases[BASE_DEF]));

--- a/test/integration/rhel-8.3/warn-detect-FAIL.patch
+++ b/test/integration/rhel-8.3/warn-detect-FAIL.patch
@@ -1,0 +1,8 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2020-03-17 01:12:56.596005471 -0400
++++ src/arch/x86/kvm/x86.c	2020-03-17 01:13:55.095460151 -0400
+@@ -1,3 +1,4 @@
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *


### PR DESCRIPTION
Rebased against the RHEL-8.3 DEVEL kernel.

Start working on an updated version of the integration tests for the upcoming RHEL8.3 kernel.

This will get updated as necessary until it's GA'ed.