### PR TITLE
create-diff-object: show all jump labels before reporting failure

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2142,6 +2142,7 @@ static void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 	char *src, *dest;
 	unsigned int group_size, src_offset, dest_offset, include;
 	int jump_table = !strcmp(special->name, "__jump_table");
+	int jump_labels_found = 0;
 
 	LIST_HEAD(newrelas);
 
@@ -2218,9 +2219,9 @@ static void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 			if (is_dynamic_debug_symbol(key->sym))
 				continue;
 
-			ERROR("Found a jump label at %s()+0x%lx, using key %s.  Jump labels aren't currently supported.  Use static_key_enabled() instead.",
-			      code->sym->name, code->addend, key->sym->name);
-
+			jump_labels_found++;
+			log_normal("Found a jump label at %s+0x%lx, key: %s.\n",
+				   code->sym->name, code->addend, key->sym->name);
 			continue;
 		}
 
@@ -2254,6 +2255,10 @@ static void kpatch_regenerate_special_section(struct kpatch_elf *kelf,
 		memcpy(dest + dest_offset, src + src_offset, group_size);
 		dest_offset += group_size;
 	}
+
+	if (jump_labels_found)
+		ERROR("Found %d jump label(s) in the patched code. Jump labels aren't currently supported. Use static_key_enabled() instead.",
+		      jump_labels_found);
 
 	if (!dest_offset) {
 		/* no changed or global functions referenced */


### PR DESCRIPTION
We have recently encountered a situation when a patched function
had more than one jump label (static branches with the same static key
used to turn on/off some debugging feature). As it is often the case
with jump labels, their locations were far from obvious in the source
code, hidden in the chains of inline functions.

create-diff-object, however, exits after it has reported one jump label.
This is inconvenient, because, after one updates the patch to avoid
that jump label, the next build of the binary patch reveals another
one and fails again, and so on. It can be very time-consuming.

Let us report all jump labels first.

Before this commit the messages looked like this:

    kpatch-build/create-diff-object: ERROR: dev.o:
    kpatch_regenerate_special_section: 2084:
    Found a jump label at ploop_req_state_process()+0x220, using key css_stacks_on.
    Jump labels aren't currently supported.  Use static_key_enabled() instead.

After:

    dev.o: Found a jump label at ploop_req_state_process+0x220, key: css_stacks_on.
    dev.o: Found a jump label at ploop_ioctl+0x2708, key: css_stacks_on.
    kpatch-build/create-diff-object: ERROR: dev.o:
    kpatch_regenerate_special_section: 2123:
    Found 2 jump label(s) in the patched code.
    Jump labels aren't currently supported. Use static_key_enabled() instead.
