### PR TITLE
create-diff-object: Ignore kpatch_ignored functions/sections missing …

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3666,12 +3666,11 @@ int main(int argc, char *argv[])
 	 */
 	kpatch_mark_ignored_sections(kelf_patched);
 	kpatch_compare_correlated_elements(kelf_patched);
+	kpatch_mark_ignored_functions_same(kelf_patched);
+	kpatch_mark_ignored_sections_same(kelf_patched);
 	kpatch_check_func_profiling_calls(kelf_patched);
 	kpatch_elf_teardown(kelf_base);
 	kpatch_elf_free(kelf_base);
-
-	kpatch_mark_ignored_functions_same(kelf_patched);
-	kpatch_mark_ignored_sections_same(kelf_patched);
 
 	kpatch_include_standard_elements(kelf_patched);
 	num_changed = kpatch_include_changed_functions(kelf_patched);


### PR DESCRIPTION
…ftrace hook

Some theoretically unchanged functions can have undesired changes if the
compiler decides to perform inlining in a different way (e.g. because of
newly added references). In such a case, it can be useful to discard
changes to functions that don't actually need modification.

Sadly, this currently doesn't work for functions missing the ftrace hook
(e.g. notrace code) as presence of the hook is checked before
identifying elements to ignore.

Look for functions/sections to ignore earlier.

Signed-off-by: Julien Thierry <jthierry@redhat.com>