### PR TITLE
kmod/core: apply dynrela addend for R_X86_64_64

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -742,7 +742,7 @@ static int kpatch_write_relocations(struct kpatch_module *kpmod,
 			break;
 		case R_X86_64_64:
 			loc = dynrela->dest;
-			val = dynrela->src;
+			val = dynrela->src + dynrela->addend;
 			size = 8;
 			break;
 		default:


### PR DESCRIPTION
User stettberger noticed that the kpatch support module does not
apply the addend for R_X86_64_64 in kpatch_write_relocations().

The AMD64 ABI draft doc [1], Table 4.10: Relocation Types lists that
relocation type as:

  Name         Value  Field   Calculation
  R_X86_64_64  1      word64  S + A

where:

  S : Represents the value of the symbol whose index resides in the
      relocation entry.

  A : Represents the addend used to compute the value of the relocatable
      field.

[1] http://refspecs.linuxfoundation.org/elf/x86_64-abi-0.99.pdf

Fixes: #1093
Reported-by: Christian Dietrich <stettberger@dokucode.de>
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>