### PR TITLE
integration test: more debug info on stalled transition

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -217,7 +217,7 @@ show_stalled_processes() {
 	echo "Stalled processes:"
 	for proc_task in /proc/[0-9]*/task/[0-9]*; do
 		tid=${proc_task#*/task/}
-		is_stalled "$module" "$tid" && echo "$tid $(cat "$proc_task"/comm 2>/dev/null)"
+		is_stalled "$module" "$tid" && echo -e "$tid $(cat "$proc_task"/comm 2>/dev/null)\nstack:\n$(cat "$proc_task"/stack 2>/dev/null)"
 	done
 }
 

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -291,6 +291,7 @@ load_module () {
 				echo "module already loaded, re-enabling"
 				echo 1 > "${moddir}/enabled" || die "failed to re-enable module $modname"
 				if ! wait_for_patch_transition "$modname" ; then
+					show_stalled_processes
 					echo "module $modname did not complete its transition, disabling..."
 					echo 0 > "${moddir}/enabled" || die "failed to disable module $modname"
 					wait_for_patch_transition "$modname"
@@ -327,6 +328,7 @@ load_module () {
 	fi
 
 	if ! wait_for_patch_transition "$modname" ; then
+		show_stalled_processes
 		echo "module $modname did not complete its transition, unloading..."
 		unload_module "$modname"
 		die "error: failed to load module $modname (transition stalled)"

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -49,6 +49,7 @@ unset CCACHE_HASHDIR
 KPATCHBUILD="$ROOTDIR"/kpatch-build/kpatch-build
 ERROR=0
 LOG=test.log
+DYNDEBUG_CONTROL=/sys/kernel/debug/dynamic_debug/control
 rm -f *.log
 
 PATCHDIR="${PATCHDIR:-$PWD}"
@@ -294,6 +295,9 @@ build_combined_module
 
 unload_all
 
+prev_dyndebug=$(grep klp_try_switch_task "${DYNDEBUG_CONTROL}" | awk '{print $3;}')
+echo "func klp_try_switch_task +p" >"${DYNDEBUG_CONTROL}" 2>/dev/null
+
 if [[ $QUICK != 1 ]]; then
 	for file in "${PATCH_LIST[@]}"; do
 		run_load_test $file
@@ -313,6 +317,8 @@ fi
 
 
 unload_all
+
+echo "func klp_try_switch_task ${prev_dyndebug}" >"${DYNDEBUG_CONTROL}" 2>/dev/null
 
 if dmesg | grep -q "Call Trace"; then
 	dmesg > dmesg.log


### PR DESCRIPTION
We can be a bit more verbose when reporting a stalled transition. These implement some of the suggestions on the topic.