### PR TITLE
Shellcheck fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,7 @@ vagrant-integration-quick:
 
 check:
 	shellcheck kpatch/kpatch kpatch-build/kpatch-build kpatch-build/kpatch-gcc
+	shellcheck test/difftree.sh test/integration/kpatch-test		\
+		   test/integration/lib.sh test/integration/rebase-patches	\
+		   test/integration/test-vagrant				\
+		   test/integration/vm-integration-run

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -14,6 +14,7 @@
 #set -x
 
 OBJDIR="$HOME/.kpatch/obj"
+# shellcheck disable=SC2046
 SCRIPTDIR=$(readlink -f $(dirname $(type -p "$0")))
 TEMPDIR=$(mktemp -d)
 RESULTSDIR="$TEMPDIR/results"
@@ -52,6 +53,7 @@ do
 	# expect RETCODE to be 3 indicating no change
 	[[ $RETCODE -eq 3 ]] && continue
 	# otherwise record error
+	# shellcheck disable=SC2046
 	mkdir -p "$RESULTSDIR"/$(dirname "$i") || exit 1
 	cp "$i" "$RESULTSDIR/$i" || exit 1
 	case $RETCODE in

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -17,7 +17,6 @@ OBJDIR="$HOME/.kpatch/obj"
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 TEMPDIR=$(mktemp -d)
 RESULTSDIR="$TEMPDIR/results"
-VMVLINUX="/usr/lib/debug/lib/modules/$(uname -r)/vmlinux" # path for F20
 
 if [[ ! -d $OBJDIR ]]; then
 	echo "please run kpatch-build to populate the object tree in $OBJDIR"

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -14,7 +14,7 @@
 #set -x
 
 OBJDIR="$HOME/.kpatch/obj"
-SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+SCRIPTDIR=$(readlink -f $(dirname $(type -p "$0")))
 TEMPDIR=$(mktemp -d)
 RESULTSDIR="$TEMPDIR/results"
 
@@ -46,13 +46,13 @@ do
 		;;
 	esac
 	# skip objects that are the linked product of more than one object file
-	[[ $(readelf -s $i | awk '$4=="FILE" {n++} END {print n}') -ne 1 ]] && continue
-	$SCRIPTDIR/../kpatch-build/create-diff-object $i $i /usr/lib/debug/lib/modules/$(uname -r)/vmlinux "$TEMPDIR/output.o" > "$TEMPDIR/log.txt" 2>&1
+	[[ $(readelf -s "$i" | awk '$4=="FILE" {n++} END {print n}') -ne 1 ]] && continue
+	"$SCRIPTDIR"/../kpatch-build/create-diff-object "$i" "$i" "/usr/lib/debug/lib/modules/$(uname -r)/vmlinux" "$TEMPDIR/output.o" > "$TEMPDIR/log.txt" 2>&1
 	RETCODE=$?
 	# expect RETCODE to be 3 indicating no change
 	[[ $RETCODE -eq 3 ]] && continue
 	# otherwise record error
-	mkdir -p $RESULTSDIR/$(dirname $i) || exit 1
+	mkdir -p "$RESULTSDIR"/$(dirname "$i") || exit 1
 	cp "$i" "$RESULTSDIR/$i" || exit 1
 	case $RETCODE in
 		139)

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -83,7 +83,7 @@ echo ""
 echo "Results:"
 for i in $(find ./* -iname '*.log')
 do
-	echo $(cat $i | head -1 | cut -f2-3 -d':')
+	head -1 "$i" | cut -f2-3 -d':'
 done | sort | uniq -c | sort -n -r | tee "$TEMPDIR/results.log"
 
 echo "results are in $TEMPDIR"

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -23,7 +23,7 @@ if [[ ! -d $OBJDIR ]]; then
 fi
 
 cd "$OBJDIR" || exit 1
-for i in $(find * -name '*.o')
+for i in $(find ./* -name '*.o')
 do
 	# copied from kpatch-build/kpatch-gcc; keep in sync
 	case $i in
@@ -81,7 +81,7 @@ rm -f "$TEMPDIR/log.txt" > /dev/null 2>&1
 cd "$RESULTSDIR" || exit 1
 echo ""
 echo "Results:"
-for i in $(find * -iname '*.log')
+for i in $(find ./* -iname '*.log')
 do
 	echo $(cat $i | head -1 | cut -f2-3 -d':')
 done | sort | uniq -c | sort -n -r | tee "$TEMPDIR/results.log"

--- a/test/difftree.sh
+++ b/test/difftree.sh
@@ -23,6 +23,7 @@ if [[ ! -d $OBJDIR ]]; then
 fi
 
 cd "$OBJDIR" || exit 1
+# shellcheck disable=SC2044
 for i in $(find ./* -name '*.o')
 do
 	# copied from kpatch-build/kpatch-gcc; keep in sync
@@ -81,6 +82,7 @@ rm -f "$TEMPDIR/log.txt" > /dev/null 2>&1
 cd "$RESULTSDIR" || exit 1
 echo ""
 echo "Results:"
+# shellcheck disable=SC2044
 for i in $(find ./* -iname '*.log')
 do
 	head -1 "$i" | cut -f2-3 -d':'

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -40,6 +40,7 @@
 
 shopt -s nullglob
 
+# shellcheck disable=SC2046
 SCRIPTDIR=$(readlink -f $(dirname $(type -p "$0")))
 ROOTDIR=$(readlink -f "$SCRIPTDIR/../..")
 # TODO: option to use system-installed binaries instead

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -40,8 +40,8 @@
 
 shopt -s nullglob
 
-SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
-ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
+SCRIPTDIR=$(readlink -f $(dirname $(type -p "$0")))
+ROOTDIR=$(readlink -f "$SCRIPTDIR/../..")
 # TODO: option to use system-installed binaries instead
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 unset CCACHE_HASHDIR
@@ -93,8 +93,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ ${#PATCH_LIST[@]} = 0 ]]; then
-	PATCH_LIST=($PATCHDIR/*.patch)
-	TEST_LIST=($PATCHDIR/*.test)
+	PATCH_LIST=("$PATCHDIR"/*.patch)
+	TEST_LIST=("$PATCHDIR"/*.test)
 	if [[ ${#PATCH_LIST[@]} = 0 ]]; then
 		echo "No patches found!"
 		exit 1
@@ -122,7 +122,7 @@ unload_all() {
 
 build_module() {
 	file=$1
-	prefix=$(basename ${file%%.patch})
+	prefix=$(basename "${file%%.patch}")
 	modname="test-$prefix"
 	module="${modname}.ko"
 
@@ -141,10 +141,10 @@ build_module() {
 
 	log "build: $prefix"
 
-	if ! $KPATCHBUILD -n $modname $file >> $LOG 2>&1; then
+	if ! $KPATCHBUILD -n "$modname" "$file" >> $LOG 2>&1; then
 		if [[ $shouldfail -eq 0 ]]; then
 			error "$prefix: build failed"
-			cp $HOME/.kpatch/build.log $prefix.log
+			cp "$HOME/.kpatch/build.log" "$prefix.log"
 		fi
 	else
 		[[ $shouldfail -eq 1 ]] && error "$prefix: build succeeded when it should have failed"
@@ -153,10 +153,10 @@ build_module() {
 
 run_load_test() {
 	file=$1
-	prefix=$(basename ${file%%.patch})
+	prefix=$(basename "${file%%.patch}")
 	modname="test-$prefix"
 	module="${modname}.ko"
-	testprog="$(dirname $1)/$prefix-LOADED.test"
+	testprog=$(dirname "$1")/"$prefix-LOADED.test"
 
 	[[ $prefix =~ -FAIL ]] && return
 
@@ -177,7 +177,7 @@ run_load_test() {
 		return
 	fi
 
-	if ! $KPATCH load $module >> $LOG 2>&1; then
+	if ! $KPATCH load "$module" >> $LOG 2>&1; then
 		error "$prefix: kpatch load failed"
 		return
 	fi
@@ -186,7 +186,7 @@ run_load_test() {
 		error "$prefix: $testprog failed after kpatch load"
 	fi
 
-	if ! $KPATCH unload $module >> $LOG 2>&1; then
+	if ! $KPATCH unload "$module" >> $LOG 2>&1; then
 		error "$prefix: kpatch unload failed"
 		return
 	fi
@@ -199,7 +199,7 @@ run_load_test() {
 
 run_custom_test() {
 	testprog=$1
-	prefix=$(basename ${testprog%%.test})
+	prefix=$(basename "${testprog%%.test}")
 
 	[[ $testprog = *-LOADED.test ]] && return
 
@@ -220,7 +220,7 @@ build_combined_module() {
 	declare -a COMBINED_LIST
 	for file in "${PATCH_LIST[@]}"; do
 		[[ $file =~ -FAIL ]] && log "combine: skipping $file" && continue
-		COMBINED_LIST+=($file)
+		COMBINED_LIST+=("$file")
 	done
 	if [[ ${#COMBINED_LIST[@]} -le 1 ]]; then
 		log "skipping build: combined (only ${#PATCH_LIST[@]} patch(es))"
@@ -231,7 +231,7 @@ build_combined_module() {
 
 	if ! $KPATCHBUILD -n test-COMBINED "${COMBINED_LIST[@]}" >> $LOG 2>&1; then
 		error "combined build failed"
-		cp $HOME/.kpatch/build.log combined.log
+		cp "$HOME/.kpatch/build.log" combined.log
 	fi
 }
 
@@ -260,7 +260,7 @@ run_combined_test() {
 
 	for testprog in "${TEST_LIST[@]}"; do
 		[[ $testprog != *-LOADED.test ]] && continue
-		[ -e ${testprog/"-LOADED.test"/".patch.disabled"} ] && continue
+		[ -e "${testprog/-LOADED.test/.patch.disabled}" ] && continue
 		if ! $testprog >> $LOG 2>&1; then
 			error "combined: $testprog failed after kpatch load"
 		fi
@@ -285,8 +285,8 @@ echo "clearing printk buffer"
 sudo dmesg -C
 
 for file in "${PATCH_LIST[@]}"; do
-	if [[ $QUICK != 1 || $file =~ -FAIL ]]; then
-		build_module $file
+	if [[ $QUICK != 1 || "$file" =~ -FAIL ]]; then
+		build_module "$file"
 	fi
 done
 
@@ -299,7 +299,7 @@ echo "func klp_try_switch_task +p" >"${DYNDEBUG_CONTROL}" 2>/dev/null
 
 if [[ $QUICK != 1 ]]; then
 	for file in "${PATCH_LIST[@]}"; do
-		run_load_test $file
+		run_load_test "$file"
 	done
 fi
 
@@ -309,7 +309,7 @@ if [[ $QUICK != 1 ]]; then
 	for testprog in "${TEST_LIST[@]}"; do
 		if [[ ! $testprog =~ -FAIL ]]; then
 			unload_all
-			run_custom_test $testprog
+			run_custom_test "$testprog"
 		fi
 	done
 fi

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -108,7 +108,7 @@ else
 fi
 
 error() {
-	echo "ERROR: $@" |tee -a $LOG >&2
+	echo "ERROR: $*" |tee -a $LOG >&2
 	ERROR=$((ERROR + 1))
 }
 

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -49,7 +49,7 @@ KPATCHBUILD="$ROOTDIR"/kpatch-build/kpatch-build
 ERROR=0
 LOG=test.log
 DYNDEBUG_CONTROL=/sys/kernel/debug/dynamic_debug/control
-rm -f *.log
+rm -f ./*.log
 
 PATCHDIR="${PATCHDIR:-$PWD}"
 declare -a PATCH_LIST

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -44,7 +44,6 @@ SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 ROOTDIR="$(readlink -f $SCRIPTDIR/../..)"
 # TODO: option to use system-installed binaries instead
 KPATCH="sudo $ROOTDIR/kpatch/kpatch"
-RMMOD="sudo rmmod"
 unset CCACHE_HASHDIR
 KPATCHBUILD="$ROOTDIR"/kpatch-build/kpatch-build
 ERROR=0

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -229,6 +229,7 @@ kpatch_install_vagrant()
 kpatch_check_install_vagrant()
 {
 	local image_path=${1}
+	# shellcheck disable=SC2230
 	[ "$(which vagrant)" == "" ] && kpatch_install_vagrant "${image_path}"
 	return 0
 }

--- a/test/integration/vm-integration-run
+++ b/test/integration/vm-integration-run
@@ -64,6 +64,7 @@ if [[ -d "${HOME}/src" && -f "${HOME}/src/version" ]]; then
   mv "${HOME}/src" "${HOME}/.kpatch/"
 fi
 
+# shellcheck disable=SC1091
 source /etc/os-release
 
 if [[ "${NAME}" == "Fedora" ]] && [[ "${VERSION_ID}" -lt 30 ]]; then


### PR DESCRIPTION
After realizing that some of the bash/sh code used in the kpatch tree is not checked by `make check`, here's a bunch of fixes or ignores on shellcheck warnings.