### PR TITLE
gcc-plugin: Fix build failure with GCC 10

### DIFF
--- a/kpatch-build/gcc-plugins/gcc-common.h
+++ b/kpatch-build/gcc-plugins/gcc-common.h
@@ -34,7 +34,9 @@
 #include "ggc.h"
 #include "timevar.h"
 
+#if BUILDING_GCC_VERSION < 10000
 #include "params.h"
+#endif
 
 #if BUILDING_GCC_VERSION <= 4009
 #include "pointer-set.h"
@@ -836,6 +838,7 @@ static inline gimple gimple_build_assign_with_ops(enum tree_code subcode, tree l
 	return gimple_build_assign(lhs, subcode, op1, op2 PASS_MEM_STAT);
 }
 
+#if BUILDING_GCC_VERSION < 10000
 template <>
 template <>
 inline bool is_a_helper<const ggoto *>::test(const_gimple gs)
@@ -849,6 +852,7 @@ inline bool is_a_helper<const greturn *>::test(const_gimple gs)
 {
 	return gs->code == GIMPLE_RETURN;
 }
+#endif
 
 static inline gasm *as_a_gasm(gimple stmt)
 {


### PR DESCRIPTION
Building on Fedora 32 with GCC 10.1.1, triggers build failures:

In file included from gcc-plugins/ppc64le-plugin.c:1:
gcc-plugins/gcc-common.h:37:10: fatal error: params.h: No such file or directory
   37 | #include "params.h"
      |          ^~~~~~~~~~
compilation terminated.

In file included from gcc-plugins/ppc64le-plugin.c:1:
gcc-plugins/gcc-common.h:841:13: error: redefinition of ‘static bool is_a_helper<T>::test(U*) [with U = const gimple; T = const ggoto*]’
  841 | inline bool is_a_helper<const ggoto *>::test(const_gimple gs)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from gcc-plugins/gcc-common.h:124,
                 from gcc-plugins/ppc64le-plugin.c:1:
/usr/lib/gcc/ppc64le-redhat-linux/10/plugin/include/gimple.h:1037:1:
note: ‘static bool is_a_helper<T>::test(U*) [with U = const gimple; T = const ggoto*]’ previously declared here
 1037 | is_a_helper <const ggoto *>::test (const gimple *gs)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from gcc-plugins/ppc64le-plugin.c:1:
gcc-plugins/gcc-common.h:848:13: error: redefinition of ‘static bool is_a_helper<T>::test(U*) [with U = const gimple; T = const greturn*]’
  848 | inline bool is_a_helper<const greturn *>::test(const_gimple gs)
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from gcc-plugins/gcc-common.h:124,
                 from gcc-plugins/ppc64le-plugin.c:1:
/usr/lib/gcc/ppc64le-redhat-linux/10/plugin/include/gimple.h:1489:1:
note: ‘static bool is_a_helper<T>::test(U*) [with U = const gimple; T = const greturn*]’ previously declared here
 1489 | is_a_helper <const greturn *>::test (const gimple *gs)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

as per kernel commit c7527373fe28 ("gcc-common.h: Update for GCC 10")
 "params.h header file has been dropped from GCC 10 and is_a_helper()
  macro is now defined in gimple.h"

this patch fix them by guarding the both param.h header file and
is_a_helper() with #ifdef checking for gcc version < 10000.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>