### PR TITLE
gcc-plugin: ppc64le - GCC 10 fixes

### DIFF
--- a/kpatch-build/gcc-plugins/ppc64le-plugin.c
+++ b/kpatch-build/gcc-plugins/ppc64le-plugin.c
@@ -3,6 +3,18 @@
 
 #define PLUGIN_NAME "ppc64le-plugin"
 
+#if BUILDING_GCC_VERSION < 10000
+#define CALL_LOCAL		"*call_local_aixdi"
+#define CALL_NONLOCAL		"*call_nonlocal_aixdi"
+#define CALL_VALUE_LOCAL	"*call_value_local_aixdi"
+#define CALL_VALUE_NONLOCAL	"*call_value_nonlocal_aixdi"
+#else
+#define CALL_LOCAL		"*call_localdi"
+#define CALL_NONLOCAL		"*call_nonlocal_aixdi"
+#define CALL_VALUE_LOCAL	"*call_value_localdi"
+#define CALL_VALUE_NONLOCAL	"*call_value_nonlocal_aixdi"
+#endif
+
 int plugin_is_GPL_compatible;
 
 struct plugin_info plugin_info = {
@@ -29,13 +41,13 @@ static unsigned int ppc64le_plugin_execute(void)
 		if (!name)
 			continue;
 
-		if (!strcmp(name , "*call_local_aixdi"))
+		if (!strcmp(name , CALL_LOCAL))
 			local_code = code;
-		else if (!strcmp(name , "*call_nonlocal_aixdi"))
+		else if (!strcmp(name , CALL_NONLOCAL))
 			nonlocal_code = code;
-		else if (!strcmp(name, "*call_value_local_aixdi"))
+		else if (!strcmp(name, CALL_VALUE_LOCAL))
 			value_local_code = code;
-		else if (!strcmp(name, "*call_value_nonlocal_aixdi"))
+		else if (!strcmp(name, CALL_VALUE_NONLOCAL))
 			value_nonlocal_code = code;
 
 		if (nonlocal_code != -1 && local_code != -1 &&

--- a/kpatch-build/gcc-plugins/ppc64le-plugin.c
+++ b/kpatch-build/gcc-plugins/ppc64le-plugin.c
@@ -46,8 +46,7 @@ static unsigned int ppc64le_plugin_execute(void)
 found:
 	if (nonlocal_code == -1 || local_code == -1 ||
 	    value_nonlocal_code == -1 || value_local_code == -1) {
-		fprintf(stderr, PLUGIN_NAME ": can't find call instruction codes");
-		return 1;
+		error("%s: cannot find call instruction codes", PLUGIN_NAME);
 	}
 
 	/* Convert local calls to non-local */


### PR DESCRIPTION
While trying to build a module for [cve-2020-8992](https://patchwork.ozlabs.org/project/linux-ext4/patch/20200211011752.29242-1-luoshijie1@huawei.com/), the gcc-plugin would report the error about the local/non-local calls code not found in `build.log` and continue building the livepatching module, which would not load due to expected `nop` instruction, missing after a call to a non-local function.   The `nop` instruction is replaced with `TOC` restore instruction by the kernel during to module load->relocation parsing.  The plugin would run as a gcc-pass, converting the local call to non-local call, resulting in a `nop` instruction inserted after the call, for more details on why this is required refer to the thread at https://lkml.kernel.org/r/1508217523-18885-1-git-send-email-kamalesh@linux.vnet.ibm.com.

This issue is not specific to this patch but GCC 10 broke the plugin.  GCC 10 merged a couple of instruction code definitions, which the plugin relies on to find the local/non-local function.  This patch series has two patches.  The first patch teaches plugin to abort the build in case of missing codes and the second patch updates the code names to match GCC 10, while preserving the old name for the older version of GCC.