### PR TITLE
create-diff-object: ignore .altinstr_replacement when not included

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2712,8 +2712,10 @@ static void kpatch_process_special_sections(struct kpatch_elf *kelf,
 		 * Only include .altinstr_replacement if .altinstructions
 		 * is also included.
 		 */
-		if (!altinstr)
+		if (!altinstr) {
+			sec->status = SAME;
 			break;
+		}
 
 		/* include base section */
 		sec->include = 1;


### PR DESCRIPTION
When .altinstructions is not included and .altinstr_replacement status
is CHANGED, we got error ".altinstr_replacement not selected for inclusion".

Signed-off-by: Zhipeng Xie <xiezhipeng1@huawei.com>