### PR TITLE
lookup: Add __UNIQUE_ID_ to maybe_discarded_sym list

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -83,7 +83,8 @@ static int maybe_discarded_sym(const char *name)
 	if (!strncmp(name, "__exitcall_", 11) ||
 	    !strncmp(name, "__brk_reservation_fn_", 21) ||
 	    !strncmp(name, "__func_stack_frame_non_standard_", 32) ||
-	    !strncmp(name, "__addressable_", 14))
+	    !strncmp(name, "__addressable_", 14) ||
+	    !strncmp(name, "__UNIQUE_ID_", 12))
 		return 1;
 
 	return 0;


### PR DESCRIPTION
Linux kernel tristate config options allows selected feature, either to
be built-in to the kernel or to be built as a kernel module. When built
as a kernel module, it's expected that the module, will be built with
module information such as author, license, description and others.

For each of the modinfo, a corresponding __UNIQUE_ID_ symbol is
generated.  Their lookup succeeds in the case of module but fails when
selected to built-in to the kernel, the reason being that the kernel
discards these __UNIQUE_ID_ symbols during linking. Add __UNIQUE_ID_
symbols to maybe_discarded_sym list, to avoid failure in case of
table->object is vmlinux.

i.e.:
 ```# cat .config|grep IOSCHED_BFQ (can be compiled as module too)
 CONFIG_IOSCHED_BFQ=y
#   readelf -sW ./block/bfq-iosched.o|grep UNIQUE
   219: 0000000000000000    54 OBJECT  LOCAL  DEFAULT  267 __UNIQUE_ID_description223
   220: 0000000000000036    16 OBJECT  LOCAL  DEFAULT  267 __UNIQUE_ID_license222
   221: 0000000000000046    19 OBJECT  LOCAL  DEFAULT  267 __UNIQUE_ID_file221
   222: 0000000000000059    25 OBJECT  LOCAL  DEFAULT  267 __UNIQUE_ID_author220
   223: 0000000000000072    22 OBJECT  LOCAL  DEFAULT  267 __UNIQUE_ID_alias219
```
the line below before the kpatch error, is a debug printf to find the failing lookup symbol:
Failed lookup for __UNIQUE_ID_description223
/root/kpatch/kpatch-build/create-diff-object: ERROR: bfq-iosched.o: find_local_syms: 180: couldn't find matching bfq-iosched.c local symbols in ./vmlinux symbol table

with the patch, it successfully builds with both y/m config options:
```
...
bfq-iosched.o: changed function: bfq_idle_slice_timer
Patched objects: vmlinux
Building patch module:
livepatch-0001-block-bfq-fix-use-after-free-in-b.ko
SUCCESS
```
Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>