### PR TITLE
Keep build.log on --skip-cleanup

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1016,6 +1016,6 @@ UNDEFINED=$(comm -23 <(sort -u "${TEMPDIR}"/undefined_references) \
 
 cp -f "$TEMPDIR/patch/$MODNAME.ko" "$BASE" || die
 
-[[ "$DEBUG" -eq 0 ]] && rm -f "$LOGFILE"
+[[ "$DEBUG" -eq 0 && "$SKIPCLEANUP" -eq 0 ]] && rm -f "$LOGFILE"
 
 echo "SUCCESS"


### PR DESCRIPTION
Before kpatch-build would only keep build.log with --debug option
specified, but it also makes sense to keep it if --skip-cleanup is
specified.