### PR TITLE
fix compile error on aarch64

### DIFF
--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -10,11 +10,7 @@ SOURCES = create-diff-object.c kpatch-elf.c \
 		  create-kpatch-module.c \
 		  create-kpatch-module.c lookup.c
 
-ifeq ($(ARCH),x86_64)
-SOURCES += insn/insn.c insn/inat.c
-INSN     = insn/insn.o insn/inat.o
-insn/%.o: CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
-else ifeq ($(ARCH),ppc64le)
+ifeq ($(ARCH),ppc64le)
 SOURCES += gcc-plugins/ppc64le-plugin.c
 PLUGIN   = gcc-plugins/ppc64le-plugin.so
 TARGETS += $(PLUGIN)
@@ -22,6 +18,10 @@ GCC_PLUGINS_DIR := $(shell gcc -print-file-name=plugin)
 PLUGIN_CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
+else
+SOURCES += insn/insn.c insn/inat.c
+INSN     = insn/insn.o insn/inat.o
+insn/%.o: CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 endif
 
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1389,7 +1389,7 @@ static void kpatch_compare_correlated_elements(struct kpatch_elf *kelf)
 	kpatch_compare_symbols(&kelf->symbols);
 }
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 static void rela_insn(const struct section *sec, const struct rela *rela,
 		      struct insn *insn)
 {


### PR DESCRIPTION
We got compile error on aarch64:

[root@localhost kpatch]# make
make -C kpatch-build
make[1]: Entering directory '/home/opensource/kpatch/kpatch-build'
gcc -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare -Wconversion -Wno-sign-conversion -g -Werror   -c -o create-diff-object.o create-diff-object.c
create-diff-object.c: In function ‘kpatch_replace_sections_syms’:
create-diff-object.c:1493:5: error: implicit declaration of function ‘rela_insn’; did you mean ‘rela_equal’? [-Werror=implicit-function-declaration]
     rela_insn(sec, rela, &insn);
     ^~~~~~~~~
     rela_equal
cc1: all warnings being treated as errors
make[1]: *** [<builtin>: create-diff-object.o] Error 1
make[1]: Leaving directory '/home/opensource/kpatch/kpatch-build'
make: *** [Makefile:22: build-kpatch-build] Error 2
