### PR TITLE
core: remove the callbacks from kpatch_apply_patch and kpatch_remove_patch

### DIFF
--- a/kmod/core/core.c
+++ b/kmod/core/core.c
@@ -705,7 +705,7 @@ static int kpatch_write_relocations(struct kpatch_module *kpmod,
 			break;
 		case R_X86_64_64:
 			loc = dynrela->dest;
-			val = dynrela->src;
+			val = dynrela->src + dynrela->addend;
 			size = 8;
 			break;
 		default:


### PR DESCRIPTION
We encountered a problem refered to #1077 and  #1120. After analysis, we believe that the main reason is that the callbacks are placed in the context of stop_machine. Because there is no data-dependy, so we remove the callbacks from the functions of kpatch_apply_patch and kpatch_remove_patch. We will avoid being trapped into a dead lock while a sleep appears in callbacks and exactly a process sending IPI was scheduled.
