### PR TITLE
kpatch-build/Makefile: Fail build on unsupported architectures

### DIFF
--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -22,6 +22,8 @@ GCC_PLUGINS_DIR := $(shell gcc -print-file-name=plugin)
 PLUGIN_CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
+else
+$(error Unsupported architecture ${ARCH}, check https://github.com/dynup/kpatch/#supported-architectures)
 endif
 
 


### PR DESCRIPTION
Fail the kpatch build, while attempted to build on unsupported
architecture. The build will eventually fail but with the error that
doesn't hint the user clearly about the support status of kpatch, on the
architecture.  This patch forces the build error with the message about
the unsupported status, avoiding confusion to the user.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>