### PR TITLE
kpatch-build: avoid modpost .output.o.cmd complaints

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -963,6 +963,8 @@ ld -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") 2>&1 | logg
 
 if [[ "$USE_KLP" -eq 1 ]]; then
 	cp "$TEMPDIR"/patch/tmp_output.o "$TEMPDIR"/patch/output.o || die
+	# Avoid MODPOST warning (pre-v5.8) and error (v5.8+) with an empty .cmd file
+	touch "$TEMPDIR"/patch/.output.o.cmd || die
 else
 	# Add .kpatch.checksum for kpatch script
 	md5sum ../patch/tmp_output.o | awk '{printf "%s\0", $1}' > checksum.tmp || die


### PR DESCRIPTION
The modpost step complains about one of our generated files, output.o
and that it can't find a corresponding .cmd file for it (full path names
stripped):

	WARNING: could not find .output.o.cmd for output.o

This was turned into an error in v5.8:

	.output.o.cmd: No such file or directory

Avoid this by creating an empty .cmd file so that modpost acknowledges
that the file exists, but doesn't parse anything out of it.

Fixes #1125
Reported-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com> (for v5.8+)
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>