### PR TITLE
patch-author-guide: mention issue #1124 __LINE__ shift

### DIFF
--- a/doc/patch-author-guide.md
+++ b/doc/patch-author-guide.md
@@ -548,7 +548,7 @@ Some examples:
   any new functions to the bottom of source files, using newline whitespace to
   maintain original line counts, etc. A more exact fix can be employed by
   modifying the source code that invokes `__LINE__` and hard-coding the
-  original line number in place.
+  original line number in place.  This occurred in issue #1124 for example.
 
 Removing references to static local variables
 ---------------------------------------------


### PR DESCRIPTION
Issue #1124 ("Jump label issues are triggered from an unrelated
function") was caused by a minor __LINE__ change in a pr_warn statement.
Reference it here in the author guide for future reference.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>