### PR TITLE
[RFC] kmod/patch: merge .text.* and .rodata.* sections for new and patched functions

### DIFF
--- a/kmod/patch/kpatch.lds.S
+++ b/kmod/patch/kpatch.lds.S
@@ -9,6 +9,29 @@ __kpatch_checksum = ADDR(.kpatch.checksum);
 
 SECTIONS
 {
+  .text.unlikely.livepatch : {
+    *(.text.unlikely.*)
+  }
+
+  .text.livepatch : {
+    *(.text.*)
+  }
+
+  .rodata.str1.1 : {
+    *(.rodata.str1.1)
+    *(.rodata.*.str1.1)
+  }
+
+  .rodata.str1.8 : {
+    *(.rodata.str1.8)
+    *(.rodata.*.str1.8)
+  }
+
+  .rodata : {
+    *(.rodata)
+    *(.rodata.__func__.*)
+  }
+
   .kpatch.callbacks.pre_patch : {
     __kpatch_callbacks_pre_patch = . ;
     *(.kpatch.callbacks.pre_patch)


### PR DESCRIPTION
This is a request for comments, because the relevant code is quite complex and I may be missing something important.
Reviews and suggestions are welcome.

When a kernel module is loaded, sysfs attributes are created for its ELF
sections (visible as /sys/module/<module_name>/sections/\*). and contain
the start addresses of the ELF sections. A single memory chunk is allocated
for all these, see add_sect_attrs(), kernel/module.c:
```
        size[0] = ALIGN(sizeof(*sect_attrs)
                        + nloaded * sizeof(sect_attrs->attrs[0]),
                        sizeof(sect_attrs->grp.attrs[0]));
        size[1] = (nloaded + 1) * sizeof(sect_attrs->grp.attrs[0]);
        sect_attrs = kzalloc(size[0] + size[1], GFP_KERNEL);
```
'nloaded' is the number of loaded ELF section in the module.

As of the kernel 4.18.0-193.6.3 from RHEL 8, x86_64, the total allocation
size is (80 * nloaded + 56).

Cumulative livepatches can easily get hundreds of new and changed
functions. Each such function will be placed into a separate .text.\*,
.text.unlikely.\* or a similar section, R/O data for each function will
also be stored in a separate section, same for .klp.rela.* sections.

Testing had shown that a patch that added 120+ new functions and touched
a handful of existing ones got 450+ loaded sections, so more than 450 *
80 == 36000 bytes of kmalloc'ed memory was requested. This is a 4th
order allocation, which might fail (and fail loading of the patch) or
become slow when the memory is fragmented.

The thing is, the addresses of these ELF sections of a livepatch module
are unlikely to be needed once the module has been loaded, so that kernel
memory is wasted.

If I understand it right, keeping functions and data in separate
sections is no longer needed after the patch module has been built. The
kernel code that handles loading of livepatch modules does not require
that. It requires that .klp.rela\* and .klp.sym\* sections have proper
names but that is preserved here.

create-klp-module and create-kpatch-module seem to be fine with that as
well.

The linker script for the patch module has been updated to merge:
* all .text.unlikely.\* sections into .text.unlikely.livepatch;
* all other .text.\* sections into .text.livepatch;
* .rodata.\_\_func\_\_.\*, .rodata.*.str1.1, .rodata.\*.str1.8 into respective
    sections.

As for .klp.rela sections, create-klp-module already does the right
thing and generates these as follows:
* .klp.rela.vmlinux..text.livepatch
* .klp.rela.vmlinux..text.unlikely.livepatch

This way, the number of loaded sections in the test patch mentioned above
shrinks from 454 to 29 and the amount of requested memory -
from 36376 to 2376 bytes.

To check the amount of requested memory, one can use 'mm_page_alloc'
tracepoint:

(Assuming debugfs is mounted to /sys/kernel/debug.)
```
  # echo nop > /sys/kernel/debug/tracing/current_tracer
  # echo 'order > 3' > /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/filter
  # echo 1 > /sys/kernel/debug/tracing/events/kmem/mm_page_alloc/enable
  # echo 1 > /sys/kernel/debug/tracing/tracing_on

  <... load the patch module with lots of sections ... >
  # kpatch load test-patch.ko

  <shortened output>
  # cat /sys/kernel/debug/tracing/trace
  TASK-PID   CPU#    ||||    TIMESTAMP  FUNCTION
    |   |       |    ||||       |         |
  <...>-189468 [001] .... 1110159.836398: mm_page_alloc: <...> order=4 <...>
  <...>-189468 [001] .... 1110159.836653: mm_page_alloc: <...> order=4 <...>

  # echo 0 > /sys/kernel/debug/tracing/tracing_on
```
In this example, 4th order allocations have been detected when loading
the patch.