### PR TITLE
test/integration: add rhel-7.9

### DIFF
--- a/test/integration/rhel-7.9/bug-table-section.patch
+++ b/test/integration/rhel-7.9/bug-table-section.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/proc_sysctl.c	2020-09-03 11:48:31.009727724 -0400
+@@ -331,6 +331,8 @@ static void start_unregistering(struct c
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-7.9/cmdline-string-LOADED.test
+++ b/test/integration/rhel-7.9/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-7.9/cmdline-string.patch
+++ b/test/integration/rhel-7.9/cmdline-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2020-09-03 11:48:30.496726119 -0400
++++ src/fs/proc/cmdline.c	2020-09-03 11:48:33.073734181 -0400
+@@ -5,7 +5,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_printf(m, "%s\n", saved_command_line);
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-7.9/data-new-LOADED.test
+++ b/test/integration/rhel-7.9/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch: 5" /proc/meminfo

--- a/test/integration/rhel-7.9/data-new.patch
+++ b/test/integration/rhel-7.9/data-new.patch
@@ -1,0 +1,28 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/meminfo.c	2020-09-03 11:48:35.069740426 -0400
+@@ -21,6 +21,8 @@ void __attribute__((weak)) arch_report_m
+ {
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -112,6 +114,7 @@ static int meminfo_proc_show(struct seq_
+ 		"CmaTotal:       %8lu kB\n"
+ 		"CmaFree:        %8lu kB\n"
+ #endif
++		"kpatch: %d"
+ 		,
+ 		K(i.totalram),
+ 		K(i.freeram),
+@@ -178,6 +181,7 @@ static int meminfo_proc_show(struct seq_
+ 		, K(totalcma_pages)
+ 		, K(global_page_state(NR_FREE_CMA_PAGES))
+ #endif
++		,foo
+ 		);
+ 
+ 	hugetlb_report_meminfo(m);

--- a/test/integration/rhel-7.9/data-read-mostly.patch.disabled
+++ b/test/integration/rhel-7.9/data-read-mostly.patch.disabled
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/net/core/dev.c src/net/core/dev.c
+--- src.orig/net/core/dev.c	2020-09-03 11:48:30.763726955 -0400
++++ src/net/core/dev.c	2020-09-03 11:49:21.514885728 -0400
+@@ -4327,6 +4327,7 @@ skip_classify:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-7.9/fixup-section.patch
+++ b/test/integration/rhel-7.9/fixup-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/readdir.c src/fs/readdir.c
+--- src.orig/fs/readdir.c	2020-09-03 11:48:30.499726129 -0400
++++ src/fs/readdir.c	2020-09-03 11:48:37.119746839 -0400
+@@ -176,6 +176,7 @@ static int filldir(void * __buf, const c
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-7.9/gcc-constprop.patch
+++ b/test/integration/rhel-7.9/gcc-constprop.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2020-09-03 11:48:30.726726839 -0400
++++ src/kernel/time/timekeeping.c	2020-09-03 11:49:23.433891731 -0400
+@@ -852,6 +852,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-7.9/gcc-isra.patch
+++ b/test/integration/rhel-7.9/gcc-isra.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/proc_sysctl.c	2020-09-03 11:48:39.089753002 -0400
+@@ -46,6 +46,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-7.9/gcc-mangled-3.patch
+++ b/test/integration/rhel-7.9/gcc-mangled-3.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/slub.c src/mm/slub.c
+--- src.orig/mm/slub.c	2020-09-03 11:48:30.747726905 -0400
++++ src/mm/slub.c	2020-09-03 11:48:41.106759312 -0400
+@@ -5716,6 +5716,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	unsigned long nr_free = 0;
+ 	int node;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_online_node(node) {
+ 		struct kmem_cache_node *n = get_node(s, node);
+ 

--- a/test/integration/rhel-7.9/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-7.9/gcc-static-local-var-2.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
+--- src.orig/mm/mmap.c	2020-09-03 11:48:30.745726898 -0400
++++ src/mm/mmap.c	2020-09-03 11:48:43.078765482 -0400
+@@ -1721,6 +1721,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-7.9/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-7.9/gcc-static-local-var-3.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/kernel/sys.c src/kernel/sys.c
+--- src.orig/kernel/sys.c	2020-09-03 11:48:30.725726836 -0400
++++ src/kernel/sys.c	2020-09-03 11:48:45.101771811 -0400
+@@ -559,8 +559,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-7.9/gcc-static-local-var-4.patch
+++ b/test/integration/rhel-7.9/gcc-static-local-var-4.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2020-09-03 11:48:30.426725900 -0400
++++ src/fs/aio.c	2020-09-03 11:48:47.163778261 -0400
+@@ -223,9 +223,16 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
+ static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(aio_ring_file->f_inode, 0);
+ 

--- a/test/integration/rhel-7.9/gcc-static-local-var-4.test
+++ b/test/integration/rhel-7.9/gcc-static-local-var-4.test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-7.9/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-7.9/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2020-09-03 11:48:30.713726798 -0400
++++ src/kernel/audit.c	2020-09-03 11:48:49.166784528 -0400
+@@ -205,6 +205,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -215,6 +221,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -234,6 +241,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -282,6 +294,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(NULL, GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-7.9/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-7.9/gcc-static-local-var-6.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/net/ipv6/netfilter.c src/net/ipv6/netfilter.c
+--- src.orig/net/ipv6/netfilter.c	2020-09-03 11:48:30.779727005 -0400
++++ src/net/ipv6/netfilter.c	2020-09-03 11:48:51.172790803 -0400
+@@ -112,6 +112,8 @@ static int nf_ip6_reroute(struct sk_buff
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
++
+ static int nf_ip6_route(struct net *net, struct dst_entry **dst,
+ 			struct flowi *fl, bool strict)
+ {
+@@ -125,6 +127,9 @@ static int nf_ip6_route(struct net *net,
+ 	struct dst_entry *result;
+ 	int err;
+ 
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+ 	result = ip6_route_output(net, sk, &fl->u.ip6);
+ 	err = result->error;
+ 	if (err)

--- a/test/integration/rhel-7.9/macro-callbacks.patch
+++ b/test/integration/rhel-7.9/macro-callbacks.patch
@@ -1,0 +1,163 @@
+kpatch/livepatch callback test patch:
+
+  vmlinux
+  pcspkr (mod)
+  joydev (mod)
+
+Note: update joydev's pre-patch callback to return -ENODEV to test failure path
+
+diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
+--- src.orig/drivers/input/joydev.c	2020-09-03 11:48:29.019721499 -0400
++++ src/drivers/input/joydev.c	2020-09-03 11:48:53.152796998 -0400
+@@ -954,3 +954,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
+--- src.orig/drivers/input/misc/pcspkr.c	2020-09-03 11:48:29.025721517 -0400
++++ src/drivers/input/misc/pcspkr.c	2020-09-03 11:48:53.152796998 -0400
+@@ -136,3 +136,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2020-09-03 11:48:30.426725900 -0400
++++ src/fs/aio.c	2020-09-03 11:48:53.153797001 -0400
+@@ -42,6 +42,50 @@
+ #include <asm/kmap_types.h>
+ #include <asm/uaccess.h>
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0

--- a/test/integration/rhel-7.9/macro-printk.patch
+++ b/test/integration/rhel-7.9/macro-printk.patch
@@ -1,0 +1,148 @@
+diff -Nupr src.orig/net/ipv4/fib_frontend.c src/net/ipv4/fib_frontend.c
+--- src.orig/net/ipv4/fib_frontend.c	2020-09-03 11:48:30.771726980 -0400
++++ src/net/ipv4/fib_frontend.c	2020-09-03 11:48:55.130803186 -0400
+@@ -690,6 +690,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh)
+ {
+ 	struct net *net = sock_net(skb->sk);
+@@ -708,6 +709,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	}
+ 
+ 	err = fib_table_insert(net, tb, &cfg);
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+diff -Nupr src.orig/net/ipv4/fib_semantics.c src/net/ipv4/fib_semantics.c
+--- src.orig/net/ipv4/fib_semantics.c	2020-09-03 11:48:30.771726980 -0400
++++ src/net/ipv4/fib_semantics.c	2020-09-03 11:48:55.130803186 -0400
+@@ -985,6 +985,7 @@ fib_convert_metrics(struct fib_info *fi,
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg)
+ {
+ 	int err;
+@@ -1009,6 +1010,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -1029,6 +1031,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (fi == NULL)
+@@ -1044,6 +1047,8 @@ struct fib_info *fib_create_info(struct
+ 		fi->fib_metrics = (struct dst_metrics *)&dst_default_metrics;
+ 	}
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
++
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+ 	fi->fib_scope = cfg->fc_scope;
+@@ -1059,8 +1064,10 @@ struct fib_info *fib_create_info(struct
+ 		if (!nexthop_nh->nh_pcpu_rth_output)
+ 			goto failure;
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 
+ 	err = fib_convert_metrics(fi, cfg);
++	KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 	if (err)
+ 		goto failure;
+ 
+@@ -1111,6 +1118,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp)
+@@ -1128,6 +1136,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST)
+ 		goto err_inval;
+@@ -1150,6 +1159,7 @@ struct fib_info *fib_create_info(struct
+ 				goto failure;
+ 		} endfor_nexthops(fi)
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc) {
+ 		if (cfg->fc_type != RTN_LOCAL || !cfg->fc_dst ||
+@@ -1162,6 +1172,7 @@ struct fib_info *fib_create_info(struct
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 		fib_add_weight(fi, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1173,6 +1184,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	atomic_inc(&fi->fib_clntref);
+@@ -1196,6 +1208,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1206,6 +1219,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+diff -Nupr src.orig/net/ipv4/fib_trie.c src/net/ipv4/fib_trie.c
+--- src.orig/net/ipv4/fib_trie.c	2020-09-03 11:48:30.771726980 -0400
++++ src/net/ipv4/fib_trie.c	2020-09-03 11:48:55.131803189 -0400
+@@ -1105,6 +1105,7 @@ static int fib_insert_alias(struct trie
+ }
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg)
+ {
+@@ -1130,11 +1131,14 @@ int fib_table_insert(struct net *net, st
+ 	if ((plen < KEYLENGTH) && (key << plen))
+ 		return -EINVAL;
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority,

--- a/test/integration/rhel-7.9/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-7.9/meminfo-init-FAIL.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/meminfo.c	2020-09-03 11:48:59.106815625 -0400
+@@ -202,6 +202,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.9/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-7.9/meminfo-init2-FAIL.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/meminfo.c	2020-09-03 11:48:57.163809546 -0400
+@@ -31,6 +31,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long pages[NR_LRU_LISTS];
+ 	int lru;
+ 
++	printk("a\n");
+ /*
+  * display in kilobytes.
+  */
+@@ -202,6 +203,7 @@ static const struct file_operations memi
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create("meminfo", 0, NULL, &meminfo_proc_fops);
+ 	return 0;
+ }

--- a/test/integration/rhel-7.9/meminfo-string-LOADED.test
+++ b/test/integration/rhel-7.9/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-7.9/meminfo-string.patch
+++ b/test/integration/rhel-7.9/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/meminfo.c	2020-09-03 11:49:01.546823258 -0400
+@@ -100,7 +100,7 @@ static int meminfo_proc_show(struct seq_
+ 		"Committed_AS:   %8lu kB\n"
+ 		"VmallocTotal:   %8lu kB\n"
+ 		"VmallocUsed:    %8lu kB\n"
+-		"VmallocChunk:   %8lu kB\n"
++		"VMALLOCCHUNK:   %8lu kB\n"
+ 		"Percpu:         %8lu kB\n"
+ #ifdef CONFIG_MEMORY_FAILURE
+ 		"HardwareCorrupted: %5lu kB\n"

--- a/test/integration/rhel-7.9/module-call-external.patch
+++ b/test/integration/rhel-7.9/module-call-external.patch
@@ -1,0 +1,38 @@
+diff -Nupr src.orig/fs/nfsd/export.c src/fs/nfsd/export.c
+--- src.orig/fs/nfsd/export.c	2020-09-03 11:48:30.477726060 -0400
++++ src/fs/nfsd/export.c	2020-09-03 11:49:03.743830132 -0400
+@@ -1184,7 +1184,13 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++extern char *kpatch_string(void);
++
++#ifdef CONFIG_PPC64
++static int __attribute__((optimize("-fno-optimize-sibling-calls"))) e_show(struct seq_file *m, void *p)
++#else
+ static int e_show(struct seq_file *m, void *p)
++#endif
+ {
+ 	struct cache_head *cp = p;
+ 	struct svc_export *exp = container_of(cp, struct svc_export, h);
+@@ -1193,6 +1199,7 @@ static int e_show(struct seq_file *m, vo
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2020-09-03 11:48:30.802727077 -0400
++++ src/net/netlink/af_netlink.c	2020-09-03 11:49:03.743830132 -0400
+@@ -2573,4 +2573,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-7.9/multiple.test
+++ b/test/integration/rhel-7.9/multiple.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+source ${SCRIPTDIR}/../common/multiple.template

--- a/test/integration/rhel-7.9/new-function.patch
+++ b/test/integration/rhel-7.9/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2020-09-03 11:48:29.609723344 -0400
++++ src/drivers/tty/n_tty.c	2020-09-03 11:49:05.751836414 -0400
+@@ -2175,7 +2175,7 @@ do_it_again:
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2264,6 +2264,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
++			   const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-7.9/new-globals.patch
+++ b/test/integration/rhel-7.9/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2020-09-03 11:48:30.496726119 -0400
++++ src/fs/proc/cmdline.c	2020-09-03 11:49:07.740842636 -0400
+@@ -27,3 +27,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ module_init(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2020-09-03 11:48:30.497726123 -0400
++++ src/fs/proc/meminfo.c	2020-09-03 11:49:07.740842636 -0400
+@@ -17,6 +17,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -54,6 +56,7 @@ static int meminfo_proc_show(struct seq_
+ 	/*
+ 	 * Tagged format, for easy grepping and expansion.
+ 	 */
++	kpatch_print_message();
+ 	seq_printf(m,
+ 		"MemTotal:       %8lu kB\n"
+ 		"MemFree:        %8lu kB\n"

--- a/test/integration/rhel-7.9/parainstructions-section.patch
+++ b/test/integration/rhel-7.9/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2020-09-03 11:48:30.496726119 -0400
++++ src/fs/proc/generic.c	2020-09-03 11:49:09.715848815 -0400
+@@ -194,6 +194,7 @@ int proc_alloc_inum(unsigned int *inum)
+ 	unsigned int i;
+ 	int error;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ retry:
+ 	if (!ida_pre_get(&proc_inum_ida, GFP_KERNEL))
+ 		return -ENOMEM;

--- a/test/integration/rhel-7.9/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-7.9/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-7.9/shadow-newpid.patch
+++ b/test/integration/rhel-7.9/shadow-newpid.patch
@@ -1,0 +1,69 @@
+diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
+--- src.orig/fs/proc/array.c	2020-09-03 11:48:30.496726119 -0400
++++ src/fs/proc/array.c	2020-09-03 11:49:11.696855012 -0400
+@@ -395,13 +395,20 @@ static inline void task_seccomp(struct s
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_printf(m,	"voluntary_ctxt_switches:\t%lu\n"
+ 			"nonvoluntary_ctxt_switches:\t%lu\n",
+ 			p->nvcsw,
+ 			p->nivcsw);
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
+--- src.orig/kernel/exit.c	2020-09-03 11:48:30.717726811 -0400
++++ src/kernel/exit.c	2020-09-03 11:49:11.696855012 -0400
+@@ -791,6 +791,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include <linux/livepatch.h>
+ void do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -888,6 +889,8 @@ void do_exit(long code)
+ 	check_stack_usage();
+ 	exit_thread();
+ 
++	klp_shadow_free(tsk, 0, NULL);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2020-09-03 11:48:30.717726811 -0400
++++ src/kernel/fork.c	2020-09-03 11:49:11.697855015 -0400
+@@ -1784,6 +1784,7 @@ struct task_struct *fork_idle(int cpu)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include <linux/livepatch.h>
+ long do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -1821,6 +1822,13 @@ long do_fork(unsigned long clone_flags,
+ 	if (!IS_ERR(p)) {
+ 		struct completion vfork;
+ 		struct pid *pid;
++		int *newpid;
++		static int ctr = 0;
++
++		newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid), GFP_KERNEL,
++						NULL, NULL);
++		if (newpid)
++			*newpid = ctr++;
+ 
+ 		trace_sched_process_fork(current, p);
+ 

--- a/test/integration/rhel-7.9/smp-locks-section.patch
+++ b/test/integration/rhel-7.9/smp-locks-section.patch
@@ -1,0 +1,14 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2020-09-03 11:48:29.616723366 -0400
++++ src/drivers/tty/tty_buffer.c	2020-09-03 11:49:13.626861050 -0400
+@@ -217,6 +217,10 @@ int tty_buffer_request_room(struct tty_p
+ 	/* OPTIMISATION: We could keep a per tty "zero" sized buffer to
+ 	   remove this conditional if its worth it. This would be invisible
+ 	   to the callers */
++
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b != NULL)
+ 		left = b->size - b->used;

--- a/test/integration/rhel-7.9/special-static.patch
+++ b/test/integration/rhel-7.9/special-static.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2020-09-03 11:48:30.717726811 -0400
++++ src/kernel/fork.c	2020-09-03 11:49:15.602867232 -0400
+@@ -1153,10 +1153,18 @@ static void posix_cpu_timers_init_group(
+ 	INIT_LIST_HEAD(&sig->cpu_timers[2]);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-7.9/symvers-disagreement-FAIL.patch
+++ b/test/integration/rhel-7.9/symvers-disagreement-FAIL.patch
@@ -1,0 +1,49 @@
+From da109d66a890373d0aa831f97b49aaffcc4eeb45 Mon Sep 17 00:00:00 2001
+From: Julien Thierry <jthierry@redhat.com>
+Date: Wed, 6 May 2020 14:30:57 +0100
+Subject: [PATCH] Symbol version change
+
+This change causes:
+1) Some exported symbols in drivers/base/core.c to see their CRCs
+   change.
+2) Changes a function referencing a function whose CRC has changed,
+   causing the symbol and the new CRC to be included in the __version
+   section of the final module.
+
+See "Exported symbol versioning" of the patch author guide for more
+detail.
+
+---
+ drivers/base/core.c    | 2 ++
+ drivers/usb/core/usb.c | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/drivers/base/core.c b/drivers/base/core.c
+index b9a71137208..4af27e069c2 100644
+--- a/drivers/base/core.c
++++ b/drivers/base/core.c
+@@ -31,6 +31,8 @@
+ #include "base.h"
+ #include "power/power.h"
+ 
++#include <linux/blktrace_api.h>
++
+ #ifdef CONFIG_SYSFS_DEPRECATED
+ #ifdef CONFIG_SYSFS_DEPRECATED_V2
+ long sysfs_deprecated = 1;
+diff --git a/drivers/usb/core/usb.c b/drivers/usb/core/usb.c
+index 8b1c4a5ee78..1b7997b58c0 100644
+--- a/drivers/usb/core/usb.c
++++ b/drivers/usb/core/usb.c
+@@ -693,6 +693,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
+  */
+ struct usb_device *usb_get_dev(struct usb_device *dev)
+ {
++	barrier();
++
+ 	if (dev)
+ 		get_device(&dev->dev);
+ 	return dev;
+-- 
+2.21.3
+

--- a/test/integration/rhel-7.9/tracepoints-section.patch
+++ b/test/integration/rhel-7.9/tracepoints-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/timer.c src/kernel/timer.c
+--- src.orig/kernel/timer.c	2020-09-03 11:48:30.726726839 -0400
++++ src/kernel/timer.c	2020-09-03 11:49:17.588873445 -0400
+@@ -1454,6 +1454,9 @@ static void run_timer_softirq(struct sof
+ {
+ 	struct tvec_base *base = __this_cpu_read(tvec_bases);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	if (time_after_eq(jiffies, base->timer_jiffies))
+ 		__run_timers(base);
+ }

--- a/test/integration/rhel-7.9/warn-detect-FAIL.patch
+++ b/test/integration/rhel-7.9/warn-detect-FAIL.patch
@@ -1,0 +1,8 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2020-09-03 11:48:30.386725775 -0400
++++ src/arch/x86/kvm/x86.c	2020-09-03 11:49:19.587879699 -0400
+@@ -1,3 +1,4 @@
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *


### PR DESCRIPTION
Rebased against kernel-3.10.0-1160.el7.

data-read-mostly.patch.disabled remains disabled as we hit several build
errors like:

  "Found a jump label at __netif_receive_skb_core()+0x50, using key
  netstamp_needed.  Jump labels aren't supported with this kernel.  Use
  static_key_enabled() instead."

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>