### PR TITLE
create-diff-object: cleanup maybe-uninitialized compiler complaints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libelf-dev linux-headers-$(uname -r) shellcheck elfutils
 
+jobs:
+  include:
+    - name: "Default"
+    - name: "-O2"
+      env: CFLAGS="-O2"
+    - name: "-O3"
+      env: CFLAGS="-O3"
+
 script:
   - make
   - make unit

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2135,7 +2135,7 @@ static bool should_keep_jump_label(struct lookup_table *lookup,
 				   unsigned int group_size,
 				   int *jump_labels_found)
 {
-	struct rela *code, *key, *rela;
+	struct rela *code = NULL, *key = NULL, *rela;
 	bool tracepoint = false, dynamic_debug = false;
 	struct lookup_result symbol;
 	int i = 0;
@@ -2156,7 +2156,7 @@ static bool should_keep_jump_label(struct lookup_table *lookup,
 		}
 	}
 
-	if (i != 3)
+	if (i != 3 || !key || !code)
 		ERROR("BUG: __jump_table has an unexpected format");
 
 	if (!strncmp(key->sym->name, "__tracepoint_", 13))


### PR DESCRIPTION
User disaster123 reports the following build errors:

  create-diff-object.c: In function 'kpatch_process_special_sections':
  create-diff-object.c:2215:41: error: 'key' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         code->sym->name, code->addend, key->sym->name);
                                           ^~
  create-diff-object.c:2138:22: note: 'key' was declared here
    struct rela *code, *key, *rela;
                        ^~~
  In file included from kpatch-elf.h:26,
                   from create-diff-object.c:53:
  log.h:20:3: error: 'code' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     printf(format, ##__VA_ARGS__); \
     ^~~~~~
  create-diff-object.c:2138:15: note: 'code' was declared here
    struct rela *code, *key, *rela;
                 ^~~~
  cc1: all warnings being treated as errors

These are reproducible when building with 9.3.1 and 8.3.1 when building
with optimization level > 2 ( CFLAGS=-O2 make ).  Fix them by
initializing the reported variables to NULL and verifying that they are
infact non-NULL after processing the __jump_table.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>