### PR TITLE
kpatch-elf: pass new ELF output file mode to kpatch_write_output_elf()

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3796,7 +3796,7 @@ int main(int argc, char *argv[])
 	kpatch_create_strtab(kelf_out);
 	kpatch_create_symtab(kelf_out);
 	kpatch_dump_kelf(kelf_out);
-	kpatch_write_output_elf(kelf_out, kelf_patched->elf, output_obj);
+	kpatch_write_output_elf(kelf_out, kelf_patched->elf, output_obj, 0664);
 
 	lookup_close(lookup);
 	kpatch_elf_free(kelf_patched);

--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -503,7 +503,7 @@ int main(int argc, char *argv[])
 	kpatch_create_strtab(kelf);
 	kpatch_create_symtab(kelf);
 
-	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1]);
+	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1], 0664);
 	kpatch_elf_teardown(kelf);
 	kpatch_elf_free(kelf);
 

--- a/kpatch-build/create-kpatch-module.c
+++ b/kpatch-build/create-kpatch-module.c
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
 	kpatch_create_strtab(kelf);
 	kpatch_create_symtab(kelf);
 
-	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1]);
+	kpatch_write_output_elf(kelf, kelf->elf, arguments.args[1], 0664);
 	kpatch_elf_teardown(kelf);
 	kpatch_elf_free(kelf);
 

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -759,7 +759,8 @@ void kpatch_rebuild_rela_section_data(struct section *sec)
 		ERROR("size mismatch in rebuilt rela section");
 }
 
-void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile)
+void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile,
+			     mode_t mode)
 {
 	int fd;
 	struct section *sec;
@@ -770,8 +771,7 @@ void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile)
 	Elf_Data *data;
 	GElf_Shdr sh;
 
-	/* TODO make this argv */
-	fd = creat(outfile, 0777);
+	fd = creat(outfile, mode);
 	if (fd == -1)
 		ERROR("creat");
 

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -164,7 +164,8 @@ struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
 void kpatch_remove_and_free_section(struct kpatch_elf *kelf, char *secname);
 void kpatch_reindex_elements(struct kpatch_elf *kelf);
 void kpatch_rebuild_rela_section_data(struct section *sec);
-void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile);
+void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile,
+			     mode_t mode);
 void kpatch_elf_teardown(struct kpatch_elf *kelf);
 void kpatch_elf_free(struct kpatch_elf *kelf);
 #endif /* _KPATCH_ELF_H_ */


### PR DESCRIPTION
Currently all the callers of kpatch_write_output_elf() are creating
.o object files or .ko kernel modules.  Neither of these filetypes are
executable on their own, so enhance kpatch_write_output_elf() to accept
file creation flags and update its callers to pass 0664 to match
the expected permissions.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>