### PR TITLE
kmod/patch: add kpatch.lds as a dependency for $(KPATCH_NAME).o

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -12,7 +12,7 @@ endif
 
 obj-m += $(KPATCH_NAME).o
 ldflags-y += -T $(src)/kpatch.lds
-extra-y := kpatch.lds
+targets += kpatch.lds
 
 $(KPATCH_NAME)-objs += patch-hook.o output.o
 
@@ -20,6 +20,8 @@ all: $(KPATCH_NAME).ko
 
 $(KPATCH_NAME).ko:
 	$(KPATCH_MAKE)
+
+$(obj)/$(KPATCH_NAME).o: $(src)/kpatch.lds
 
 patch-hook.o: patch-hook.c kpatch-patch-hook.c livepatch-patch-hook.c
 	$(KPATCH_MAKE) patch-hook.o


### PR DESCRIPTION
Starting with v5.10 kbuild no longer builds built-in targets for
external modules (including extra-y). Further it wasn't guaranteed that
extra-y targets were going to be built before linking.
Do a proper thing and add kpatch.lds as a dependency for $(KPATCH_NAME).o.


Fixes: #1148