### PR TITLE
kpatch: Inform user when signal subcommand is unnecessary

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -237,6 +237,9 @@ signal_stalled_processes() {
 	if [[ -e "/sys/kernel/livepatch/$module/signal" ]] ; then
 		echo "signaling stalled process(es):"
 		echo 1 > "/sys/kernel/livepatch/$module/signal"
+        else
+            warn "Livepatch process signaling is performed automatically on your system."
+            warn "Skipping manual process signaling."
 	fi
 }
 

--- a/man/kpatch.1
+++ b/man/kpatch.1
@@ -36,7 +36,10 @@ list
        list installed patch modules
 
 signal
-       signal/poke any process stalling the current patch transition
+       signal/poke any process stalling the current patch transition.
+       This is only useful on systems that have the sysfs livepatch signal interface.
+       On other systems, the signaling should be done automatically by the OS and
+       this subcommand is a no-op.
 
 version
        display the kpatch version


### PR DESCRIPTION
From Linux-5.1 onward, the sysfs interface to send signals to
processes stalling livepatch transitions is replace by a peridical
signal sent by the kernel.

On such systems, the kpatch signal subcommand does nothing. Just
let the user know they don't need to worry about it.

Fixes: #1151 
Signed-off-by: Julien Thierry <jthierry@redhat.com>