### PR TITLE
kpatch-gcc: powerpc - skip vdso files

### DIFF
--- a/kpatch-build/kpatch-gcc
+++ b/kpatch-build/kpatch-gcc
@@ -42,6 +42,7 @@ if [[ "$TOOLCHAINCMD" =~ "gcc" ]] ; then
 				arch/x86/entry/vdso/*|\
 				drivers/firmware/efi/libstub/*|\
 				arch/powerpc/kernel/prom_init.o|\
+				arch/powerpc/kernel/vdso64/*|\
 				lib/*|\
 				.*.o|\
 				*/.lib_exports.o)


### PR DESCRIPTION
Starting v5.11-rc, kpatch-build fails on powerpc with the error:

ERROR: invalid ancestor arch/powerpc/kernel/vdso64/vdso64.so.dbg for arch/powerpc/kernel/vdso64/vgettimeofday.o

the upstream commit ab037dd87a2f(powerpc/vdso: Switch VDSO to generic
implementation) introduced this breakage, lets skip vdso files. They are
not compatible with kpatch.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.vnet.ibm.com>