### PR TITLE
kpatch-build: workaround pahole and CONFIG_DEBUG_INFO_BTF

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -148,6 +148,9 @@ cleanup() {
 	# restore original vmlinux if it was overwritten by sourcedir build
 	[[ -e "$TEMPDIR/vmlinux" ]] && mv -f "$TEMPDIR/vmlinux" "$SRCDIR/"
 
+	# restore original link-vmlinux.sh if we updated it for the build
+	[[ -e "$TEMPDIR/link-vmlinux.sh" ]] && mv -f "$TEMPDIR/link-vmlinux.sh" "$SRCDIR/scripts"
+
 	[[ "$DEBUG" -eq 0 ]] && rm -rf "$TEMPDIR"
 	rm -rf "$RPMTOPDIR"
 	unset KCFLAGS
@@ -777,6 +780,14 @@ grep -q "CONFIG_MODVERSIONS=y"  "$CONFIGFILE" && CONFIG_MODVERSIONS=1
 grep -q "CONFIG_DEBUG_INFO_SPLIT=y" "$CONFIGFILE" && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
 grep -q "CONFIG_GCC_PLUGIN_LATENT_ENTROPY=y" "$CONFIGFILE" && die "kernel option 'CONFIG_GCC_PLUGIN_LATENT_ENTROPY' not supported"
 grep -q "CONFIG_GCC_PLUGIN_RANDSTRUCT=y" "$CONFIGFILE" && die "kernel option 'CONFIG_GCC_PLUGIN_RANDSTRUCT' not supported"
+
+# CONFIG_DEBUG_INFO_BTF invokes pahole, for which some versions don't
+# support extended ELF sections.  Disable the BTF typeinfo generation in
+# link-vmlinux.sh since kpatch doesn't care about that anyway.
+if grep -q "CONFIG_DEBUG_INFO_BTF=y" "$CONFIGFILE" ; then
+	cp "$SRCDIR/scripts/link-vmlinux.sh" "$TEMPDIR/"
+	sed -i 's/CONFIG_DEBUG_INFO_BTF/DISABLED_FOR_KPATCH_BUILD/g' "$SRCDIR"/scripts/link-vmlinux.sh || die
+fi
 
 echo "Testing patch file(s)"
 cd "$SRCDIR" || die

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -640,7 +640,7 @@ if [[ -n "$USERSRCDIR" ]]; then
 
 	# save original vmlinux before it gets overwritten by sourcedir build
 	if [[ -z "$OOT_MODULE" ]] && [[ "$VMLINUX" -ef "$SRCDIR"/vmlinux ]]; then
-		cp -f "$VMLINUX" "$TEMPDIR/vmlinux"
+		cp -f "$VMLINUX" "$TEMPDIR/vmlinux" || die
 		VMLINUX="$TEMPDIR/vmlinux"
 	fi
 
@@ -734,7 +734,9 @@ fi
 
 [[ -z "$CONFIGFILE" ]] && CONFIGFILE="$SRCDIR"/.config
 [[ ! -e "$CONFIGFILE" ]] && die "can't find config file"
-[[ ! "$CONFIGFILE" -ef "$SRCDIR"/.config ]] && cp -f "$CONFIGFILE" "$SRCDIR/.config"
+if [[ ! "$CONFIGFILE" -ef "$SRCDIR"/.config ]] ; then
+	cp -f "$CONFIGFILE" "$SRCDIR/.config" || die
+fi
 
 # kernel option checking
 grep -q "CONFIG_DEBUG_INFO=y" "$CONFIGFILE" || die "kernel doesn't have 'CONFIG_DEBUG_INFO' enabled"
@@ -785,7 +787,7 @@ grep -q "CONFIG_GCC_PLUGIN_RANDSTRUCT=y" "$CONFIGFILE" && die "kernel option 'CO
 # support extended ELF sections.  Disable the BTF typeinfo generation in
 # link-vmlinux.sh since kpatch doesn't care about that anyway.
 if grep -q "CONFIG_DEBUG_INFO_BTF=y" "$CONFIGFILE" ; then
-	cp "$SRCDIR/scripts/link-vmlinux.sh" "$TEMPDIR/"
+	cp -f "$SRCDIR/scripts/link-vmlinux.sh" "$TEMPDIR/link-vmlinux.sh" || die
 	sed -i 's/CONFIG_DEBUG_INFO_BTF/DISABLED_FOR_KPATCH_BUILD/g' "$SRCDIR"/scripts/link-vmlinux.sh || die
 fi
 
@@ -819,7 +821,7 @@ unset KPATCH_GCC_TEMPDIR
 CROSS_COMPILE="$TOOLSDIR/kpatch-gcc " make "-j$CPUS" $TARGETS 2>&1 | logger || die
 
 # Save original module symvers
-cp "$SRCDIR/Module.symvers" "$TEMPDIR/Module.symvers"
+cp -f "$SRCDIR/Module.symvers" "$TEMPDIR/Module.symvers" || die
 
 echo "Building patched source"
 apply_patches
@@ -911,7 +913,7 @@ ERROR=0
 # Prepare OOT module symvers file
 if [[ -n "$OOT_MODULE" ]]; then
     BUILDDIR="/lib/modules/$ARCHVERSION/build/"
-    cp "$SRCDIR/Module.symvers" "$TEMPDIR/Module.symvers"
+    cp -f "$SRCDIR/Module.symvers" "$TEMPDIR/Module.symvers" || die
     awk '{ print $1 "\t" $2 "\t" $3 "\t" $4}' "${BUILDDIR}/Module.symvers" >> "$TEMPDIR/Module.symvers"
 fi
 
@@ -966,7 +968,7 @@ for i in $FILES; do
 			objnames[${#objnames[@]}]="$KOBJFILE"
 		fi
 	else
-		cp -f "patched/$i" "output/$i"
+		cp -f "patched/$i" "output/$i" || die
 		objnames[${#objnames[@]}]="$KOBJFILE"
 	fi
 done
@@ -1006,7 +1008,7 @@ cd "$TEMPDIR/output" || die
 ld -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") 2>&1 | logger || die
 
 if [[ "$USE_KLP" -eq 1 ]]; then
-	cp "$TEMPDIR"/patch/tmp_output.o "$TEMPDIR"/patch/output.o || die
+	cp -f "$TEMPDIR"/patch/tmp_output.o "$TEMPDIR"/patch/output.o || die
 	# Avoid MODPOST warning (pre-v5.8) and error (v5.8+) with an empty .cmd file
 	touch "$TEMPDIR"/patch/.output.o.cmd || die
 else
@@ -1033,7 +1035,7 @@ if [[ "$USE_KLP" -eq 1 ]]; then
 	if [[ "$USE_KLP_ARCH" -eq 0 ]]; then
 		extra_flags="--no-klp-arch-sections"
 	fi
-	cp "$TEMPDIR/patch/$MODNAME.ko" "$TEMPDIR/patch/tmp.ko" || die
+	cp -f "$TEMPDIR/patch/$MODNAME.ko" "$TEMPDIR/patch/tmp.ko" || die
 	"$TOOLSDIR"/create-klp-module $extra_flags "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
 	check_pipe_status create-klp-module
 fi


### PR DESCRIPTION
kpatch-build requires gcc flags -f[function|data]-sections when building
original and patched targets.  These flags result in an ELF binary with
many sections, potentially requiring special extended ELF header
processing to parse correctly.

CONFIG_DEBUG_INFO_BTF invokes pahole as part of the kernel build and
unfortunately pahole cannot iterate through more than 65535 section
headers.  As result, the pahole program segfaults and fails the build
like so:

  ...
    BTF     .btf.vmlinux.bin.o
  scripts/link-vmlinux.sh: line 127: 718345 Segmentation fault      (core dumped) LLVM_OBJCOPY=${OBJCOPY} ${PAHOLE} -J ${1}
  objcopy: --change-section-vma .BTF=0x0000000000000000 never used
  objcopy: --change-section-lma .BTF=0x0000000000000000 never used
  objcopy: error: the input file '.btf.vmlinux.bin' is empty
  Failed to generate BTF for vmlinux
  Try to disable CONFIG_DEBUG_INFO_BTF
  make: *** [Makefile:1050: vmlinux] Error 1

Workaround this limitation by disabling CONFIG_DEBUG_INFO_BTF code in
scripts/vmlinux-link.sh during kpatch-build.  This leaves
CONFIG_DEBUG_INFO_BTF contingent kernel code in place, but skips the
problematic pahole .BTF typeinfo generation step (for which kpatch
doesn't care about anyway).

Fixes: #1153
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>
Suggested-by: Josh Poimboeuf <jpoimboe@redhat.com>