### PR TITLE
kpatch: cleanup install directory

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -575,10 +575,12 @@ case "$1" in
 	fi
 
 	[[ ! -e "$MODULE" ]] && die "$PATCH is not installed for kernel $KVER"
-	
 
 	echo "uninstalling $PATCH ($KVER)"
 	rm -f "$MODULE" || die "failed to uninstall module $PATCH"
+	rmdir --ignore-fail-on-non-empty "$INSTALLDIR/$KVER" || die "failed to remove directory $INSTALLDIR/$KVER"
+	rmdir --ignore-fail-on-non-empty "$INSTALLDIR" || die "failed to remove directory $INSTALLDIR"
+
 	;;
 
 "list")


### PR DESCRIPTION
On module installation kpatch utility creates a directory with kernel version as a name in /var/lib/kpatch which is never removed. To address this check if any files are left in this directory after each 'uninstall' call and if not - remove it.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1930108