### PR TITLE
kpatch-build: workaround pahole and CONFIG_DEBUG_INFO_BTF_MODULES

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -151,6 +151,9 @@ cleanup() {
 	# restore original link-vmlinux.sh if we updated it for the build
 	[[ -e "$TEMPDIR/link-vmlinux.sh" ]] && mv -f "$TEMPDIR/link-vmlinux.sh" "$SRCDIR/scripts"
 
+	# restore original Makefile.modfinal if we updated it for the build
+	[[ -e "$TEMPDIR/Makefile.modfinal" ]] && mv -f "$TEMPDIR/Makefile.modfinal" "$SRCDIR/scripts"
+
 	[[ "$DEBUG" -eq 0 ]] && rm -rf "$TEMPDIR"
 	rm -rf "$RPMTOPDIR"
 	unset KCFLAGS
@@ -809,10 +812,14 @@ grep -q "CONFIG_GCC_PLUGIN_RANDSTRUCT=y" "$CONFIGFILE" && die "kernel option 'CO
 
 # CONFIG_DEBUG_INFO_BTF invokes pahole, for which some versions don't
 # support extended ELF sections.  Disable the BTF typeinfo generation in
-# link-vmlinux.sh since kpatch doesn't care about that anyway.
+# link-vmlinux.sh and Makefile.modfinal since kpatch doesn't care about
+# that anyway.
 if grep -q "CONFIG_DEBUG_INFO_BTF=y" "$CONFIGFILE" ; then
 	cp -f "$SRCDIR/scripts/link-vmlinux.sh" "$TEMPDIR/link-vmlinux.sh" || die
 	sed -i 's/CONFIG_DEBUG_INFO_BTF/DISABLED_FOR_KPATCH_BUILD/g' "$SRCDIR"/scripts/link-vmlinux.sh || die
+
+	cp -f "$SRCDIR/scripts/Makefile.modfinal" "$TEMPDIR/Makefile.modfinal" || die
+	sed -i 's/CONFIG_DEBUG_INFO_BTF_MODULES/DISABLED_FOR_KPATCH_BUILD/g' "$SRCDIR"/scripts/Makefile.modfinal || die
 fi
 
 if [[ "$CONFIG_CC_IS_CLANG" -eq 1 ]]; then


### PR DESCRIPTION
With CONFIG_DEBUG_INFO_BTF_MODULES, the kernel build process adds BTF to
each in-tree modules. However, this process is broken with kpatch, with
error message like:

  Failed to parse base BTF 'vmlinux': -4001

Unblock build with CONFIG_DEBUG_INFO_BTF_MODULES with similar workaround
as the one for CONFIG_DEBUG_INFO_BTF.

Signed-off-by: Song Liu <songliubraving@fb.com>