### PR TITLE
kpatch-build: drop klp.arch support in RHEL-8.4

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -188,6 +188,21 @@ kernel_is_rhel() {
 	[[ "$ARCHVERSION" =~ \.el[789] ]]
 }
 
+rhel_kernel_version_gte() {
+        [  "${ARCHVERSION}" = "$(echo -e "${ARCHVERSION}\\n$1" | sort -rV | head -n1)" ]
+}
+
+# klp.arch relocations were supported prior to v5.8
+# and prior to 4.18.0-240.el8
+use_klp_arch()
+{
+	if kernel_is_rhel; then
+		! rhel_kernel_version_gte 4.18.0-240.el8
+	else
+		! kernel_version_gte 5.8.0
+	fi
+}
+
 find_dirs() {
 	if [[ -e "$SCRIPTDIR/create-diff-object" ]]; then
 		# git repo
@@ -781,7 +796,7 @@ if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE" && (kernel_is_rhel || kernel_versi
 
 	USE_KLP=1
 
-	if kernel_is_rhel || ! kernel_version_gte 5.8.0; then
+	if use_klp_arch; then
 		USE_KLP_ARCH=1
 		KPATCH_LDFLAGS="--unique=.parainstructions --unique=.altinstructions"
 		CDO_FLAGS="--klp-arch"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -185,7 +185,7 @@ kernel_version_gte() {
 }
 
 kernel_is_rhel() {
-	[[ "$ARCHVERSION" =~ \.el[78]\. ]]
+	[[ "$ARCHVERSION" =~ \.el[789] ]]
 }
 
 find_dirs() {


### PR DESCRIPTION
RHEL-8.4 backported the "livepatch,module: Remove .klp.arch and
module_disable_ro()" patchset [1], so update kpatch-build accordingly.

[1] https://lore.kernel.org/live-patching/nycvar.YFH.7.76.2005080016330.25812@cbobk.fhfr.pm/T/#t

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>