### PR TITLE
github actions: unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,26 @@
+name: build and unit tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        cflags: [ "", "-O2", "-O3" ]
+    runs-on: ubuntu-latest
+    env:
+      CFLAGS: ${{ matrix.cflags }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: sudo apt-get install -y libelf-dev linux-headers-$(uname -r) shellcheck elfutils
+    - name: make
+      run: make
+    - name: submodule update
+      run: git submodule update --init
+    - name: make unit
+      run: make unit
+    - name: make check
+      run: make check
+    - name: install
+      run: sudo make install


### PR DESCRIPTION
Add unit tests through github actions. This is exactly the same as our travis tests but using github actions instead.

I noticed that latest pull requests didn't have a notice from travis also when logging into travis-ci.org there is the following message:

```
 Please be aware travis-ci.org will be shutting down in several weeks, with all accounts migrating to travis-ci.com. Please stay tuned here for more information. 
```

travis-ci.com used to be their commercial offering, so there are some changes going on and I am not exactly sure what those mean for us. This commits enable github "actions" which are the same thing but first party. We can run both in parallel and retire travis at some point since it is third-party and is more likely to have issues.