### PR TITLE
Additional rhel 8.4 support

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -188,6 +188,21 @@ kernel_is_rhel() {
 	[[ "$ARCHVERSION" =~ \.el[78]\. ]]
 }
 
+rhel_kernel_version_gte() {
+        [  "${ARCHVERSION}" = "$(echo -e "${ARCHVERSION}\\n$1" | sort -rV | head -n1)" ]
+}
+
+# klp.arch relocations were supported prior to v5.8
+# and prior to 4.18.0-284.el8
+use_klp_arch()
+{
+	if kernel_is_rhel; then
+		! rhel_kernel_version_gte 4.18.0-284.el8
+	else
+		! kernel_version_gte 5.8.0
+	fi
+}
+
 find_dirs() {
 	if [[ -e "$SCRIPTDIR/create-diff-object" ]]; then
 		# git repo
@@ -781,7 +796,7 @@ if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE" && (kernel_is_rhel || kernel_versi
 
 	USE_KLP=1
 
-	if kernel_is_rhel || ! kernel_version_gte 5.8.0; then
+	if use_klp_arch; then
 		USE_KLP_ARCH=1
 		KPATCH_LDFLAGS="--unique=.parainstructions --unique=.altinstructions"
 		CDO_FLAGS="--klp-arch"

--- a/test/integration/rhel-8.4/bug-table-section.patch
+++ b/test/integration/rhel-8.4/bug-table-section.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/proc_sysctl.c	2021-04-20 11:04:27.636102900 -0400
+@@ -338,6 +338,8 @@ static void start_unregistering(struct c
+ 
+ static struct ctl_table_header *sysctl_head_grab(struct ctl_table_header *head)
+ {
++	if (jiffies == 0)
++		printk("kpatch-test: testing __bug_table section changes\n");
+ 	BUG_ON(!head);
+ 	spin_lock(&sysctl_lock);
+ 	if (!use_table(head))

--- a/test/integration/rhel-8.4/cmdline-string-LOADED.test
+++ b/test/integration/rhel-8.4/cmdline-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep kpatch=1 /proc/cmdline

--- a/test/integration/rhel-8.4/cmdline-string.patch
+++ b/test/integration/rhel-8.4/cmdline-string.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/cmdline.c	2021-04-20 11:04:30.118109128 -0400
+@@ -6,8 +6,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_puts(m, saved_command_line);
+-	seq_putc(m, '\n');
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 

--- a/test/integration/rhel-8.4/data-new-LOADED.test
+++ b/test/integration/rhel-8.4/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch:         5" /proc/meminfo

--- a/test/integration/rhel-8.4/data-new.patch
+++ b/test/integration/rhel-8.4/data-new.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/meminfo.c	2021-04-20 11:04:32.584115315 -0400
+@@ -31,6 +31,8 @@ static void show_val_kb(struct seq_file
+ 	seq_write(m, " kB\n", 4);
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -146,6 +148,7 @@ static int meminfo_proc_show(struct seq_
+ 	show_val_kb(m, "CmaFree:        ",
+ 		    global_zone_page_state(NR_FREE_CMA_PAGES));
+ #endif
++	seq_printf(m, "kpatch:         %d\n", foo);
+ 
+ 	hugetlb_report_meminfo(m);
+ 

--- a/test/integration/rhel-8.4/data-read-mostly.patch
+++ b/test/integration/rhel-8.4/data-read-mostly.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/net/core/dev.c src/net/core/dev.c
+--- src.orig/net/core/dev.c	2021-04-20 11:04:27.355102195 -0400
++++ src/net/core/dev.c	2021-04-20 11:04:34.800120875 -0400
+@@ -5058,6 +5058,7 @@ skip_classify:
+ 		case RX_HANDLER_PASS:
+ 			break;
+ 		default:
++			printk("BUG!\n");
+ 			BUG();
+ 		}
+ 	}

--- a/test/integration/rhel-8.4/fixup-section.patch
+++ b/test/integration/rhel-8.4/fixup-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/readdir.c src/fs/readdir.c
+--- src.orig/fs/readdir.c	2021-04-20 11:04:26.675100489 -0400
++++ src/fs/readdir.c	2021-04-20 11:04:36.984126354 -0400
+@@ -189,6 +189,7 @@ static int filldir(struct dir_context *c
+ 			goto efault;
+ 	}
+ 	dirent = buf->current_dir;
++	asm("nop");
+ 	if (__put_user(d_ino, &dirent->d_ino))
+ 		goto efault;
+ 	if (__put_user(reclen, &dirent->d_reclen))

--- a/test/integration/rhel-8.4/gcc-constprop.patch
+++ b/test/integration/rhel-8.4/gcc-constprop.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timekeeping.c src/kernel/time/timekeeping.c
+--- src.orig/kernel/time/timekeeping.c	2021-04-20 11:04:27.325102120 -0400
++++ src/kernel/time/timekeeping.c	2021-04-20 11:04:39.253132047 -0400
+@@ -1231,6 +1231,9 @@ void do_gettimeofday(struct timeval *tv)
+ {
+ 	struct timespec64 now;
+ 
++	if (!tv)
++		return;
++
+ 	getnstimeofday64(&now);
+ 	tv->tv_sec = now.tv_sec;
+ 	tv->tv_usec = now.tv_nsec/1000;

--- a/test/integration/rhel-8.4/gcc-isra.patch
+++ b/test/integration/rhel-8.4/gcc-isra.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/proc_sysctl.c src/fs/proc/proc_sysctl.c
+--- src.orig/fs/proc/proc_sysctl.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/proc_sysctl.c	2021-04-20 11:04:41.824138498 -0400
+@@ -53,6 +53,7 @@ void proc_sys_poll_notify(struct ctl_tab
+ 	if (!poll)
+ 		return;
+ 
++	printk("kpatch-test: testing gcc .isra function name mangling\n");
+ 	atomic_inc(&poll->event);
+ 	wake_up_interruptible(&poll->wait);
+ }

--- a/test/integration/rhel-8.4/gcc-mangled-3.patch
+++ b/test/integration/rhel-8.4/gcc-mangled-3.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/slub.c src/mm/slub.c
+--- src.orig/mm/slub.c	2021-04-20 11:04:27.343102165 -0400
++++ src/mm/slub.c	2021-04-20 11:04:44.205144472 -0400
+@@ -5749,6 +5749,9 @@ void get_slabinfo(struct kmem_cache *s,
+ 	int node;
+ 	struct kmem_cache_node *n;
+ 
++	if (!jiffies)
++		printk("slabinfo\n");
++
+ 	for_each_kmem_cache_node(s, node, n) {
+ 		nr_slabs += node_nr_slabs(n);
+ 		nr_objs += node_nr_objs(n);

--- a/test/integration/rhel-8.4/gcc-static-local-var-2.patch
+++ b/test/integration/rhel-8.4/gcc-static-local-var-2.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/mm/mmap.c src/mm/mmap.c
+--- src.orig/mm/mmap.c	2021-04-20 11:04:27.341102160 -0400
++++ src/mm/mmap.c	2021-04-20 11:04:46.880151184 -0400
+@@ -1690,6 +1690,9 @@ unsigned long mmap_region(struct file *f
+ 	struct rb_node **rb_link, *rb_parent;
+ 	unsigned long charged = 0;
+ 
++	if (!jiffies)
++		printk("kpatch mmap foo\n");
++
+ 	/* Check against address space limit. */
+ 	if (!may_expand_vm(mm, vm_flags, len >> PAGE_SHIFT)) {
+ 		unsigned long nr_pages;

--- a/test/integration/rhel-8.4/gcc-static-local-var-3.patch
+++ b/test/integration/rhel-8.4/gcc-static-local-var-3.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/kernel/reboot.c src/kernel/reboot.c
+--- src.orig/kernel/reboot.c	2021-04-20 11:04:27.316102097 -0400
++++ src/kernel/reboot.c	2021-04-20 11:04:49.155156892 -0400
+@@ -393,8 +393,15 @@ SYSCALL_DEFINE4(reboot, int, magic1, int
+ 	return ret;
+ }
+ 
++void kpatch_bar(void)
++{
++	if (!jiffies)
++		printk("kpatch_foo\n");
++}
++
+ static void deferred_cad(struct work_struct *dummy)
+ {
++	kpatch_bar();
+ 	kernel_restart(NULL);
+ }
+ 

--- a/test/integration/rhel-8.4/gcc-static-local-var-4.patch
+++ b/test/integration/rhel-8.4/gcc-static-local-var-4.patch
@@ -1,0 +1,23 @@
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2021-04-20 11:04:26.671100479 -0400
++++ src/fs/aio.c	2021-04-20 11:04:51.420162575 -0400
+@@ -248,11 +248,18 @@ static int __init aio_setup(void)
+ }
+ __initcall(aio_setup);
+ 
+-static void put_aio_ring_file(struct kioctx *ctx)
++void kpatch_aio_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch aio foo\n");
++}
++
++__always_inline static void put_aio_ring_file(struct kioctx *ctx)
+ {
+ 	struct file *aio_ring_file = ctx->aio_ring_file;
+ 	struct address_space *i_mapping;
+ 
++	kpatch_aio_foo();
+ 	if (aio_ring_file) {
+ 		truncate_setsize(file_inode(aio_ring_file), 0);
+ 

--- a/test/integration/rhel-8.4/gcc-static-local-var-4.test
+++ b/test/integration/rhel-8.4/gcc-static-local-var-4.test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -o pipefail
+if ! $(eu-readelf --wide --symbols test-gcc-static-local-var-4.ko | awk '$NF == "free_ioctx" { exit 1 }'); then
+	exit 1
+else
+	exit 0
+fi

--- a/test/integration/rhel-8.4/gcc-static-local-var-5.patch
+++ b/test/integration/rhel-8.4/gcc-static-local-var-5.patch
@@ -1,0 +1,45 @@
+diff -Nupr src.orig/kernel/audit.c src/kernel/audit.c
+--- src.orig/kernel/audit.c	2021-04-20 11:04:27.312102087 -0400
++++ src/kernel/audit.c	2021-04-20 11:04:53.691168273 -0400
+@@ -327,6 +327,12 @@ void audit_panic(const char *message)
+ 	}
+ }
+ 
++void kpatch_audit_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch audit foo\n");
++}
++
+ static inline int audit_rate_check(void)
+ {
+ 	static unsigned long	last_check = 0;
+@@ -337,6 +343,7 @@ static inline int audit_rate_check(void)
+ 	unsigned long		elapsed;
+ 	int			retval	   = 0;
+ 
++	kpatch_audit_foo();
+ 	if (!audit_rate_limit) return 1;
+ 
+ 	spin_lock_irqsave(&lock, flags);
+@@ -356,6 +363,11 @@ static inline int audit_rate_check(void)
+ 	return retval;
+ }
+ 
++noinline void kpatch_audit_check(void)
++{
++	audit_rate_check();
++}
++
+ /**
+  * audit_log_lost - conditionally log lost audit message event
+  * @message: the message stating reason for lost audit message
+@@ -402,6 +414,8 @@ static int audit_log_config_change(char
+ 	struct audit_buffer *ab;
+ 	int rc = 0;
+ 
++	kpatch_audit_check();
++
+ 	ab = audit_log_start(audit_context(), GFP_KERNEL, AUDIT_CONFIG_CHANGE);
+ 	if (unlikely(!ab))
+ 		return rc;

--- a/test/integration/rhel-8.4/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-8.4/gcc-static-local-var-6.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/net/ipv6/netfilter.c src/net/ipv6/netfilter.c
+--- src.orig/net/ipv6/netfilter.c	2021-04-20 11:04:27.369102230 -0400
++++ src/net/ipv6/netfilter.c	2021-04-20 11:04:56.097174309 -0400
+@@ -86,6 +86,8 @@ static int nf_ip6_reroute(struct sk_buff
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
++
+ int __nf_ip6_route(struct net *net, struct dst_entry **dst,
+ 		   struct flowi *fl, bool strict)
+ {
+@@ -99,6 +101,9 @@ int __nf_ip6_route(struct net *net, stru
+ 	struct dst_entry *result;
+ 	int err;
+ 
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+ 	result = ip6_route_output(net, sk, &fl->u.ip6);
+ 	err = result->error;
+ 	if (err)

--- a/test/integration/rhel-8.4/macro-callbacks.patch
+++ b/test/integration/rhel-8.4/macro-callbacks.patch
@@ -1,0 +1,155 @@
+diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
+--- src.orig/drivers/input/joydev.c	2021-04-20 11:04:26.086099011 -0400
++++ src/drivers/input/joydev.c	2021-04-20 11:04:58.399180085 -0400
+@@ -1084,3 +1084,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
+--- src.orig/drivers/input/misc/pcspkr.c	2021-04-20 11:04:26.090099021 -0400
++++ src/drivers/input/misc/pcspkr.c	2021-04-20 11:04:58.399180085 -0400
+@@ -133,3 +133,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2021-04-20 11:04:26.671100479 -0400
++++ src/fs/aio.c	2021-04-20 11:04:58.399180085 -0400
+@@ -49,6 +49,50 @@
+ 
+ #define KIOCB_KEY		0
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0

--- a/test/integration/rhel-8.4/macro-printk.patch
+++ b/test/integration/rhel-8.4/macro-printk.patch
@@ -1,0 +1,149 @@
+diff -Nupr src.orig/net/ipv4/fib_frontend.c src/net/ipv4/fib_frontend.c
+--- src.orig/net/ipv4/fib_frontend.c	2021-04-20 11:04:27.363102215 -0400
++++ src/net/ipv4/fib_frontend.c	2021-04-20 11:05:00.587185575 -0400
+@@ -790,6 +790,7 @@ errout:
+ 	return err;
+ }
+ 
++#include "kpatch-macros.h"
+ static int inet_rtm_newroute(struct sk_buff *skb, struct nlmsghdr *nlh,
+ 			     struct netlink_ext_ack *extack)
+ {
+@@ -811,6 +812,7 @@ static int inet_rtm_newroute(struct sk_b
+ 	err = fib_table_insert(net, tb, &cfg, extack);
+ 	if (!err && cfg.fc_type == RTN_LOCAL)
+ 		net->ipv4.fib_has_custom_local_routes = true;
++	KPATCH_PRINTK("[inet_rtm_newroute]: err is %d\n", err);
+ errout:
+ 	return err;
+ }
+diff -Nupr src.orig/net/ipv4/fib_semantics.c src/net/ipv4/fib_semantics.c
+--- src.orig/net/ipv4/fib_semantics.c	2021-04-20 11:04:27.363102215 -0400
++++ src/net/ipv4/fib_semantics.c	2021-04-20 11:05:00.588185577 -0400
+@@ -1023,6 +1023,7 @@ static bool fib_valid_prefsrc(struct fib
+ 	return true;
+ }
+ 
++#include "kpatch-macros.h"
+ struct fib_info *fib_create_info(struct fib_config *cfg,
+ 				 struct netlink_ext_ack *extack)
+ {
+@@ -1056,6 +1057,7 @@ struct fib_info *fib_create_info(struct
+ #endif
+ 
+ 	err = -ENOBUFS;
++	KPATCH_PRINTK("[fib_create_info]: create error err is %d\n",err);
+ 	if (fib_info_cnt >= fib_info_hash_size) {
+ 		unsigned int new_size = fib_info_hash_size << 1;
+ 		struct hlist_head *new_info_hash;
+@@ -1076,6 +1078,7 @@ struct fib_info *fib_create_info(struct
+ 		if (!fib_info_hash_size)
+ 			goto failure;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 2 create error err is %d\n",err);
+ 
+ 	fi = kzalloc(sizeof(*fi)+nhs*sizeof(struct fib_nh), GFP_KERNEL);
+ 	if (!fi)
+@@ -1089,6 +1092,8 @@ struct fib_info *fib_create_info(struct
+ 	}
+ 
+ 	fib_info_cnt++;
++	KPATCH_PRINTK("[fib_create_info]: 3 create error err is %d\n",err);
++
+ 	fi->fib_net = net;
+ 	fi->fib_protocol = cfg->fc_protocol;
+ 	fi->fib_scope = cfg->fc_scope;
+@@ -1144,9 +1149,11 @@ struct fib_info *fib_create_info(struct
+ 					       "LWT encap type not specified");
+ 				goto err_inval;
+ 			}
++			KPATCH_PRINTK("[fib_create_info]: 4 create error err is %d\n",err);
+ 			err = lwtunnel_build_state(cfg->fc_encap_type,
+ 						   cfg->fc_encap, AF_INET, cfg,
+ 						   &lwtstate, extack);
++			KPATCH_PRINTK("[fib_create_info]: 5 create error err is %d\n",err);
+ 			if (err)
+ 				goto failure;
+ 
+@@ -1164,6 +1171,7 @@ struct fib_info *fib_create_info(struct
+ 		nh->nh_weight = 1;
+ #endif
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 6 create error err is %d\n",err);
+ 
+ 	if (fib_props[cfg->fc_type].error) {
+ 		if (cfg->fc_gw || cfg->fc_oif || cfg->fc_mp) {
+@@ -1185,6 +1193,7 @@ struct fib_info *fib_create_info(struct
+ 			goto err_inval;
+ 		}
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 7 create error err is %d\n",err);
+ 
+ 	if (cfg->fc_scope > RT_SCOPE_HOST) {
+ 		NL_SET_ERR_MSG(extack, "Invalid scope");
+@@ -1223,6 +1232,7 @@ struct fib_info *fib_create_info(struct
+ 		if (linkdown == fi->fib_nhs)
+ 			fi->fib_flags |= RTNH_F_LINKDOWN;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 8 create error err is %d\n",err);
+ 
+ 	if (fi->fib_prefsrc && !fib_valid_prefsrc(cfg, fi->fib_prefsrc)) {
+ 		NL_SET_ERR_MSG(extack, "Invalid prefsrc address");
+@@ -1232,6 +1242,7 @@ struct fib_info *fib_create_info(struct
+ 	change_nexthops(fi) {
+ 		fib_info_update_nh_saddr(net, nexthop_nh);
+ 	} endfor_nexthops(fi)
++	KPATCH_PRINTK("[fib_create_info]: 9 create error err is %d\n",err);
+ 
+ 	fib_rebalance(fi);
+ 
+@@ -1243,6 +1254,7 @@ link_it:
+ 		ofi->fib_treeref++;
+ 		return ofi;
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 10 create error err is %d\n",err);
+ 
+ 	fi->fib_treeref++;
+ 	refcount_set(&fi->fib_clntref, 1);
+@@ -1266,6 +1278,7 @@ link_it:
+ 		hlist_add_head(&nexthop_nh->nh_hash, head);
+ 	} endfor_nexthops(fi)
+ 	spin_unlock_bh(&fib_info_lock);
++	KPATCH_PRINTK("[fib_create_info]: 11 create error err is %d\n",err);
+ 	return fi;
+ 
+ err_inval:
+@@ -1276,6 +1289,7 @@ failure:
+ 		fi->fib_dead = 1;
+ 		free_fib_info(fi);
+ 	}
++	KPATCH_PRINTK("[fib_create_info]: 12 create error err is %d\n",err);
+ 
+ 	return ERR_PTR(err);
+ }
+diff -Nupr src.orig/net/ipv4/fib_trie.c src/net/ipv4/fib_trie.c
+--- src.orig/net/ipv4/fib_trie.c	2021-04-20 11:04:27.363102215 -0400
++++ src/net/ipv4/fib_trie.c	2021-04-20 11:05:00.588185577 -0400
+@@ -1174,6 +1174,7 @@ static void fib_remove_alias(struct trie
+ 			     struct key_vector *l, struct fib_alias *old);
+ 
+ /* Caller must hold RTNL. */
++#include "kpatch-macros.h"
+ int fib_table_insert(struct net *net, struct fib_table *tb,
+ 		     struct fib_config *cfg, struct netlink_ext_ack *extack)
+ {
+@@ -1195,11 +1196,14 @@ int fib_table_insert(struct net *net, st
+ 
+ 	pr_debug("Insert table=%u %08x/%d\n", tb->tb_id, key, plen);
+ 
++	KPATCH_PRINTK("[fib_table_insert]: start\n");
+ 	fi = fib_create_info(cfg, extack);
+ 	if (IS_ERR(fi)) {
+ 		err = PTR_ERR(fi);
++		KPATCH_PRINTK("[fib_table_insert]: create error err is %d\n",err);
+ 		goto err;
+ 	}
++	KPATCH_PRINTK("[fib_table_insert]: cross\n");
+ 
+ 	l = fib_find_node(t, &tp, key);
+ 	fa = l ? fib_find_alias(&l->leaf, slen, tos, fi->fib_priority,

--- a/test/integration/rhel-8.4/meminfo-init-FAIL.patch
+++ b/test/integration/rhel-8.4/meminfo-init-FAIL.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/meminfo.c	2021-04-20 11:05:05.090196873 -0400
+@@ -156,6 +156,7 @@ static int meminfo_proc_show(struct seq_
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create_single("meminfo", 0, NULL, meminfo_proc_show);
+ 	return 0;
+ }

--- a/test/integration/rhel-8.4/meminfo-init2-FAIL.patch
+++ b/test/integration/rhel-8.4/meminfo-init2-FAIL.patch
@@ -1,0 +1,19 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/meminfo.c	2021-04-20 11:05:02.874191313 -0400
+@@ -41,6 +41,7 @@ static int meminfo_proc_show(struct seq_
+ 	unsigned long sreclaimable, sunreclaim;
+ 	int lru;
+ 
++	printk("a\n");
+ 	si_meminfo(&i);
+ 	si_swapinfo(&i);
+ 	committed = percpu_counter_read_positive(&vm_committed_as);
+@@ -156,6 +157,7 @@ static int meminfo_proc_show(struct seq_
+ 
+ static int __init proc_meminfo_init(void)
+ {
++	printk("a\n");
+ 	proc_create_single("meminfo", 0, NULL, meminfo_proc_show);
+ 	return 0;
+ }

--- a/test/integration/rhel-8.4/meminfo-string-LOADED.test
+++ b/test/integration/rhel-8.4/meminfo-string-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep VMALLOCCHUNK /proc/meminfo

--- a/test/integration/rhel-8.4/meminfo-string.patch
+++ b/test/integration/rhel-8.4/meminfo-string.patch
@@ -1,0 +1,12 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/meminfo.c	2021-04-20 11:05:07.263202325 -0400
+@@ -120,7 +120,7 @@ static int meminfo_proc_show(struct seq_
+ 	seq_printf(m, "VmallocTotal:   %8lu kB\n",
+ 		   (unsigned long)VMALLOC_TOTAL >> 10);
+ 	show_val_kb(m, "VmallocUsed:    ", 0ul);
+-	show_val_kb(m, "VmallocChunk:   ", 0ul);
++	show_val_kb(m, "VMALLOCCHUNK:   ", 0ul);
+ 	show_val_kb(m, "Percpu:         ", pcpu_nr_pages());
+ 
+ #ifdef CONFIG_MEMORY_FAILURE

--- a/test/integration/rhel-8.4/module-LOADED.test
+++ b/test/integration/rhel-8.4/module-LOADED.test
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o errexit
+
+sudo modprobe nfsd
+sleep 5
+grep -q kpatch /proc/fs/nfs/exports
+
+# TODO: This will trigger a printk on newer kernels which have the .klp.arch
+# removal.  Don't actually do the grep until running on a newer kernel.
+echo "file fs/nfsd/export.c +p" > /sys/kernel/debug/dynamic_debug/control
+cat /proc/fs/nfs/exports > /dev/null
+# dmesg | grep -q "kpatch: pr_debug"

--- a/test/integration/rhel-8.4/module.patch
+++ b/test/integration/rhel-8.4/module.patch
@@ -1,0 +1,85 @@
+From 08078d00ab1749a6f84148a00d8d26572af4ec97 Mon Sep 17 00:00:00 2001
+Message-Id: <08078d00ab1749a6f84148a00d8d26572af4ec97.1586900628.git.jpoimboe@redhat.com>
+From: Josh Poimboeuf <jpoimboe@redhat.com>
+Date: Tue, 14 Apr 2020 15:17:51 -0500
+Subject: [PATCH] kpatch module integration test
+
+This tests several things related to the patching of modules:
+
+- 'kpatch_string' tests the referencing of a symbol which is outside the
+  .o, but inside the patch module.
+
+- alternatives patching (.altinstructions)
+
+- paravirt patching (.parainstructions)
+
+- jump labels (5.8+ kernels only) -- including dynamic printk
+
+Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>
+---
+ fs/nfsd/export.c         | 30 ++++++++++++++++++++++++++++++
+ net/netlink/af_netlink.c |  5 +++++
+ 2 files changed, 35 insertions(+)
+
+diff -Nupr src.orig/fs/nfsd/export.c src/fs/nfsd/export.c
+--- src.orig/fs/nfsd/export.c	2021-04-20 11:04:26.703100559 -0400
++++ src/fs/nfsd/export.c	2021-04-20 11:05:09.399207684 -0400
+@@ -1221,15 +1221,45 @@ static void exp_flags(struct seq_file *m
+ 	}
+ }
+ 
++#include <linux/version.h>
++extern char *kpatch_string(void);
++
+ static int e_show(struct seq_file *m, void *p)
+ {
+ 	struct cache_head *cp = p;
+ 	struct svc_export *exp = container_of(cp, struct svc_export, h);
+ 	struct cache_detail *cd = m->private;
++#ifdef CONFIG_X86_64
++	unsigned long long sched_clock;
++
++	alternative("ud2", "call yield", X86_FEATURE_ALWAYS);
++	alternative("call yield", "ud2", X86_FEATURE_IA64);
++
++	sched_clock = paravirt_sched_clock();
++	if (!jiffies)
++		printk("kpatch: sched_clock: %llu\n", sched_clock);
++#endif
++
++	pr_debug("kpatch: pr_debug() test\n");
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 8, 0)
++{
++	static DEFINE_STATIC_KEY_TRUE(kpatch_key);
++
++	if (static_branch_unlikely(&mcsafe_key))
++		printk("kpatch: mcsafe_key\n");
++
++	BUG_ON(!static_branch_likely(&kpatch_key));
++	static_branch_disable(&kpatch_key);
++	BUG_ON(static_branch_likely(&kpatch_key));
++	static_branch_enable(&kpatch_key);
++}
++#endif
+ 
+ 	if (p == SEQ_START_TOKEN) {
+ 		seq_puts(m, "# Version 1.1\n");
+ 		seq_puts(m, "# Path Client(Flags) # IPs\n");
++		seq_puts(m, kpatch_string());
+ 		return 0;
+ 	}
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2021-04-20 11:04:27.385102270 -0400
++++ src/net/netlink/af_netlink.c	2021-04-20 11:05:09.399207684 -0400
+@@ -2879,4 +2879,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "# kpatch\n";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-8.4/multiple.test
+++ b/test/integration/rhel-8.4/multiple.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+source ${SCRIPTDIR}/../common/multiple.template

--- a/test/integration/rhel-8.4/new-function.patch
+++ b/test/integration/rhel-8.4/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2021-04-20 11:04:26.603100308 -0400
++++ src/drivers/tty/n_tty.c	2021-04-20 11:05:11.672213387 -0400
+@@ -2296,7 +2296,7 @@ static ssize_t n_tty_read(struct tty_str
+  *		  lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const unsigned char *buf, size_t nr)
+ {
+ 	const unsigned char *b = buf;
+@@ -2383,6 +2383,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
++			   							     const unsigned char *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  *	n_tty_poll		-	poll method for N_TTY
+  *	@tty: terminal device

--- a/test/integration/rhel-8.4/new-globals.patch
+++ b/test/integration/rhel-8.4/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/cmdline.c	2021-04-20 11:05:13.847218845 -0400
+@@ -17,3 +17,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ fs_initcall(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/meminfo.c	2021-04-20 11:05:13.847218845 -0400
+@@ -21,6 +21,8 @@
+ #include <asm/pgtable.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -57,6 +59,7 @@ static int meminfo_proc_show(struct seq_
+ 	sreclaimable = global_node_page_state_pages(NR_SLAB_RECLAIMABLE_B);
+ 	sunreclaim = global_node_page_state_pages(NR_SLAB_UNRECLAIMABLE_B);
+ 
++	kpatch_print_message();
+ 	show_val_kb(m, "MemTotal:       ", i.totalram);
+ 	show_val_kb(m, "MemFree:        ", i.freeram);
+ 	show_val_kb(m, "MemAvailable:   ", available);

--- a/test/integration/rhel-8.4/parainstructions-section.patch
+++ b/test/integration/rhel-8.4/parainstructions-section.patch
@@ -1,0 +1,11 @@
+diff -Nupr src.orig/fs/proc/generic.c src/fs/proc/generic.c
+--- src.orig/fs/proc/generic.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/generic.c	2021-04-20 11:05:16.189224721 -0400
+@@ -205,6 +205,7 @@ int proc_alloc_inum(unsigned int *inum)
+ {
+ 	int i;
+ 
++	printk("kpatch-test: testing change to .parainstructions section\n");
+ 	i = ida_simple_get(&proc_inum_ida, 0, UINT_MAX - PROC_DYNAMIC_FIRST + 1,
+ 			   GFP_KERNEL);
+ 	if (i < 0)

--- a/test/integration/rhel-8.4/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-8.4/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-8.4/shadow-newpid.patch
+++ b/test/integration/rhel-8.4/shadow-newpid.patch
@@ -1,0 +1,75 @@
+diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
+--- src.orig/fs/proc/array.c	2021-04-20 11:04:26.717100594 -0400
++++ src/fs/proc/array.c	2021-04-20 11:05:18.430230343 -0400
+@@ -370,12 +370,19 @@ static inline void task_seccomp(struct s
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_put_decimal_ull(m, "voluntary_ctxt_switches:\t", p->nvcsw);
+ 	seq_put_decimal_ull(m, "\nnonvoluntary_ctxt_switches:\t", p->nivcsw);
+ 	seq_putc(m, '\n');
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
+--- src.orig/kernel/exit.c	2021-04-20 11:04:27.314102092 -0400
++++ src/kernel/exit.c	2021-04-20 11:05:18.430230343 -0400
+@@ -701,6 +701,7 @@ static void check_stack_usage(void)
+ static inline void check_stack_usage(void) {}
+ #endif
+ 
++#include <linux/livepatch.h>
+ void __noreturn do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -794,6 +795,8 @@ void __noreturn do_exit(long code)
+ 	exit_task_work(tsk);
+ 	exit_thread(tsk);
+ 
++	klp_shadow_free(tsk, 0, NULL);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2021-04-20 11:04:27.315102095 -0400
++++ src/kernel/fork.c	2021-04-20 11:05:18.431230346 -0400
+@@ -2222,6 +2222,7 @@ struct mm_struct *copy_init_mm(void)
+  * It copies the process, and if successful kick-starts
+  * it and waits for it to finish using the VM if required.
+  */
++#include <linux/livepatch.h>
+ long _do_fork(unsigned long clone_flags,
+ 	      unsigned long stack_start,
+ 	      unsigned long stack_size,
+@@ -2234,6 +2235,8 @@ long _do_fork(unsigned long clone_flags,
+ 	struct task_struct *p;
+ 	int trace = 0;
+ 	long nr;
++	int *newpid;
++	static int ctr = 0;
+ 
+ 	/*
+ 	 * Determine whether and which event to report to ptracer.  When
+@@ -2260,6 +2263,11 @@ long _do_fork(unsigned long clone_flags,
+ 	if (IS_ERR(p))
+ 		return PTR_ERR(p);
+ 
++	newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid), GFP_KERNEL,
++					 NULL, NULL);
++	if (newpid)
++		*newpid = ctr++;
++
+ 	/*
+ 	 * Do this prior waking up the new thread - the thread pointer
+ 	 * might get invalid after that point, if the thread exits quickly.

--- a/test/integration/rhel-8.4/smp-locks-section.patch
+++ b/test/integration/rhel-8.4/smp-locks-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/drivers/tty/tty_buffer.c src/drivers/tty/tty_buffer.c
+--- src.orig/drivers/tty/tty_buffer.c	2021-04-20 11:04:26.609100323 -0400
++++ src/drivers/tty/tty_buffer.c	2021-04-20 11:05:20.584235748 -0400
+@@ -256,6 +256,9 @@ static int __tty_buffer_request_room(str
+ 	struct tty_buffer *b, *n;
+ 	int left, change;
+ 
++	if (!size)
++		printk("kpatch-test: testing .smp_locks section changes\n");
++
+ 	b = buf->tail;
+ 	if (b->flags & TTYB_NORMAL)
+ 		left = 2 * b->size - b->used;

--- a/test/integration/rhel-8.4/special-static.patch
+++ b/test/integration/rhel-8.4/special-static.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2021-04-20 11:04:27.315102095 -0400
++++ src/kernel/fork.c	2021-04-20 11:05:23.010241835 -0400
+@@ -1554,10 +1554,18 @@ static void posix_cpu_timers_init_group(
+ 	posix_cputimers_group_init(pct, cpu_limit);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-8.4/symvers-disagreement-FAIL.patch
+++ b/test/integration/rhel-8.4/symvers-disagreement-FAIL.patch
@@ -1,0 +1,46 @@
+From 2d6b7bce089e52563bd9c67df62f48e90b48047d Mon Sep 17 00:00:00 2001
+From: Julien Thierry <jthierry@redhat.com>
+Date: Wed, 6 May 2020 14:30:57 +0100
+Subject: [PATCH] Symbol version change
+
+This change causes:
+1) Some exported symbols in drivers/base/core.c to see their CRCs
+   change.
+2) Changes usb_get_dev() referencing a get_device() whose CRC has
+   changed, causing the symbol and the new CRC to be included in the
+   __version section of the final module.
+
+This makes the final module unloadable for the target kernel.
+
+See "Exported symbol versioning" of the patch author guide for more
+detail.
+
+---
+ drivers/base/core.c    | 2 ++
+ drivers/usb/core/usb.c | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff -Nupr src.orig/drivers/base/core.c src/drivers/base/core.c
+--- src.orig/drivers/base/core.c	2021-04-20 11:04:25.703098050 -0400
++++ src/drivers/base/core.c	2021-04-20 11:05:25.287247548 -0400
+@@ -31,6 +31,8 @@
+ #include "base.h"
+ #include "power/power.h"
+ 
++#include <linux/blktrace_api.h>
++
+ #ifdef CONFIG_SYSFS_DEPRECATED
+ #ifdef CONFIG_SYSFS_DEPRECATED_V2
+ long sysfs_deprecated = 1;
+diff -Nupr src.orig/drivers/usb/core/usb.c src/drivers/usb/core/usb.c
+--- src.orig/drivers/usb/core/usb.c	2021-04-20 11:04:26.613100333 -0400
++++ src/drivers/usb/core/usb.c	2021-04-20 11:05:25.287247548 -0400
+@@ -693,6 +693,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
+  */
+ struct usb_device *usb_get_dev(struct usb_device *dev)
+ {
++	barrier();
++
+ 	if (dev)
+ 		get_device(&dev->dev);
+ 	return dev;

--- a/test/integration/rhel-8.4/tracepoints-section.patch
+++ b/test/integration/rhel-8.4/tracepoints-section.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/kernel/time/timer.c src/kernel/time/timer.c
+--- src.orig/kernel/time/timer.c	2021-04-20 11:04:27.325102120 -0400
++++ src/kernel/time/timer.c	2021-04-20 11:05:27.596253341 -0400
+@@ -1751,6 +1751,9 @@ static __latent_entropy void run_timer_s
+ {
+ 	struct timer_base *base = this_cpu_ptr(&timer_bases[BASE_STD]);
+ 
++	if (!base)
++		printk("kpatch-test: testing __tracepoints section changes\n");
++
+ 	__run_timers(base);
+ 	if (IS_ENABLED(CONFIG_NO_HZ_COMMON))
+ 		__run_timers(this_cpu_ptr(&timer_bases[BASE_DEF]));

--- a/test/integration/rhel-8.4/warn-detect-FAIL.patch
+++ b/test/integration/rhel-8.4/warn-detect-FAIL.patch
@@ -1,0 +1,9 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2021-04-20 11:04:27.273101989 -0400
++++ src/arch/x86/kvm/x86.c	2021-04-20 11:05:29.870259047 -0400
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: GPL-2.0-only
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *


### PR DESCRIPTION
- `pahole` and large ELF sections already merged (4cc2f062794c184c31bc90f5688a8b7479f3f90e and e25450f5a80349b88607634a80a3fa4e02823caa) 
- Drop `klp.arch relocations` support for rhel-8.4
- Add rebased and now enabled integration tests for rhel-8.4 `kernel-4.18.0-304.el8`