### PR TITLE
kpatch-build: enable option -R|--replace to build replace klp

### DIFF
--- a/doc/patch-author-guide.md
+++ b/doc/patch-author-guide.md
@@ -39,6 +39,13 @@ recommended that when patching a system which has already been patched, the
 second patch should be a cumulative upgrade which is a superset of the first
 patch.
 
+Since upstream kernel 5.1, livepatch supports a "replace" flag to help the
+management of cumulative patches. With the flag set, the kernel will load
+the cumulative patch and unload all existing patches in one transition.
+kpatch-build enables the replace flag by default. If replace behavior is
+not desired, the user can disable it with -R|--non-replace.
+
+
 Data structure changes
 ----------------------
 

--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -74,6 +74,18 @@
 # define HAVE_SIMPLE_ENABLE
 #endif
 
+#ifdef RHEL_RELEASE_CODE
+# if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 2)
+#  define HAVE_KLP_REPLACE
+# endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+# define HAVE_KLP_REPLACE
+#endif
+
+#ifndef KLP_REPLACE_ENABLE
+#define KLP_REPLACE_ENABLE true
+#endif
+
 /*
  * There are quite a few similar structures at play in this file:
  * - livepatch.h structs prefixed with klp_*
@@ -385,6 +397,9 @@ static int __init patch_init(void)
 		goto out;
 	lpatch->mod = THIS_MODULE;
 	lpatch->objs = lobjects;
+#ifdef HAVE_KLP_REPLACE
+	lpatch->replace = KLP_REPLACE_ENABLE;
+#endif
 #if defined(__powerpc64__) && defined(HAVE_IMMEDIATE)
 	lpatch->immediate = true;
 #endif

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -55,6 +55,7 @@ DEBUG_KCFLAGS=""
 declare -a PATCH_LIST
 APPLIED_PATCHES=0
 OOT_MODULE=
+KLP_REPLACE=1
 
 warn() {
 	echo "ERROR: $1" >&2
@@ -215,6 +216,15 @@ use_klp_arch()
 		! rhel_kernel_version_gte 4.18.0-284.el8
 	else
 		! kernel_version_gte 5.8.0
+	fi
+}
+
+support_klp_replace()
+{
+	if kernel_is_rhel; then
+		rhel_kernel_version_gte 4.18.0-193.el8
+	else
+		kernel_version_gte 5.1.0
 	fi
 }
 
@@ -514,12 +524,13 @@ usage() {
 	echo "		                        (can be specified multiple times)" >&2
 	echo "		-e, --oot-module        Enable patching out-of-tree module," >&2
 	echo "		                        specify current version of module" >&2
+	echo "		-R, --non-replace       Disable replace patch (replace is on by default)" >&2
 	echo "		--skip-cleanup          Skip post-build cleanup" >&2
 	echo "		--skip-compiler-check   Skip compiler version matching check" >&2
 	echo "		                        (not recommended)" >&2
 }
 
-options="$(getopt -o ha:r:s:c:v:j:t:n:o:de: -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,oot-module:,debug,skip-gcc-check,skip-compiler-check,skip-cleanup" -- "$@")" || die "getopt failed"
+options="$(getopt -o ha:r:s:c:v:j:t:n:o:de:R -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,oot-module:,debug,skip-gcc-check,skip-compiler-check,skip-cleanup,non-replace" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"
 
@@ -581,6 +592,9 @@ while [[ $# -gt 0 ]]; do
 		[[ ! -f "$2" ]] && die "out-of-tree module '$2' not found"
 		OOT_MODULE="$(readlink -f "$2")"
 		shift
+		;;
+	-R|--non-replace)
+		KLP_REPLACE=0
 		;;
 	--skip-cleanup)
 		echo "Skipping cleanup"
@@ -821,6 +835,12 @@ if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE" && (kernel_is_rhel || kernel_versi
 		KPATCH_LDFLAGS="--unique=.parainstructions --unique=.altinstructions"
 		CDO_FLAGS="--klp-arch"
 	fi
+
+	if [[  "$KLP_REPLACE" -eq 1 ]] ; then
+		support_klp_replace || die "The kernel doesn't support klp replace"
+	else
+		export KBUILD_CFLAGS_MODULE="$KBUILD_CFLAGS_MODULE -DKLP_REPLACE_ENABLE=false"
+	fi
 else
 	# No support for livepatch in the kernel. Kpatch core module is needed.
 
@@ -828,6 +848,9 @@ else
 	# sections.  Use with caution!
 	echo "WARNING: Use of kpatch core module (kpatch.ko) is deprecated!  There may be bugs!" >&2
 
+	if [[ "$KLP_REPLACE" -eq 1 ]] ; then
+		die "kpatch core module (kpatch.ko) does not support replace, please add -R|--non-replace"
+	fi
 	find_core_symvers || die "unable to find Module.symvers for kpatch core module"
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi

--- a/man/kpatch-build.1
+++ b/man/kpatch-build.1
@@ -51,6 +51,10 @@ effect.
    Enable patching out-of-tree module,
    specify current version of module
 
+-R|--non-replace
+   Disable replace flag of KLP
+   (replace is on by default)
+
 --skip-cleanup
    Skip post-build cleanup
 

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -50,6 +50,7 @@ ERROR=0
 LOG=test.log
 DYNDEBUG_CONTROL=/sys/kernel/debug/dynamic_debug/control
 DYNDEBUG_ENABLED=1
+ARCHVERSION="$(uname -r)"
 rm -f ./*.log
 
 PATCHDIR="${PATCHDIR:-$PWD}"
@@ -308,11 +309,37 @@ new_dmesg() {
 	fi
 }
 
+kernel_version_gte() {
+	[  "${ARCHVERSION//-*/}" = "$(echo -e "${ARCHVERSION//-*}\\n$1" | sort -rV | head -n1)" ]
+}
+
+support_klp_replace()
+{
+	if kernel_is_rhel; then
+		rhel_kernel_version_gte 4.18.0-193.el8
+	else
+		kernel_version_gte 5.1.0
+	fi
+}
+
+kernel_is_rhel() {
+	[[ "$ARCHVERSION" =~ \.el[789] ]]
+}
+
+rhel_kernel_version_gte() {
+        [  "${ARCHVERSION}" = "$(echo -e "${ARCHVERSION}\\n$1" | sort -rV | head -n1)" ]
+}
+
 # shellcheck disable=SC1091
 source /etc/os-release
 if [[ "${ID}" == "rhel" && "${VERSION_ID%%.*}" == "7" && "${VERSION_ID##*.}" -le "6" ]]; then
 	DYNDEBUG_ENABLED=0
 	echo "Dynamic debug is not supported on '${PRETTY_NAME}', disabling."
+fi
+
+if ! support_klp_replace ; then
+    	KPATCHBUILD_OPTS="$KPATCHBUILD_OPTS -R"
+	echo "KLP replace is not supported on '${PRETTY_NAME}', disabling."
 fi
 
 for file in "${PATCH_LIST[@]}"; do


### PR DESCRIPTION
Since 5.1 kernel, klp_patch supports a "replace" option, which does atomic
replace of cumulative patches. Enable building such patch with an option.

Signed-off-by: Song Liu <song@kernel.org>