### PR TITLE
kpatch: use /sys/kernel/kpatch/ to check whether core module is loaded

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -127,11 +127,11 @@ find_core_module() {
 }
 
 kpatch_core_loaded() {
-	grep -q -e "T kpatch_register" /proc/kallsyms
+	[[ -d "/sys/kernel/kpatch" ]]
 }
 
 core_loaded () {
-	grep -q -e "T klp_enable_patch" -e "T kpatch_register" /proc/kallsyms
+	[[ -d "/sys/kernel/kpatch" ]] || [[ -d "/sys/kernel/livepatch" ]]
 }
 
 get_module_name () {


### PR DESCRIPTION
Fixes #1187

Signed-off-by: xiejingfeng <xiejingfeng@linux.alibaba.com>