### PR TITLE
create-diff-object: ERROR:couldn't find matching helloDev.c local symbols in helloDev symbol table 

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -102,7 +102,7 @@ static int locals_match(struct lookup_table *table, int idx,
 	for_each_obj_symbol_continue(i, sym, table) {
 		if (sym->type == STT_FILE)
 			break;
-		if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
+		if(strstr(sym->name, ".cold") || strstr(sym->name, ".part"))
 			continue;
 		if (sym->bind != STB_LOCAL)
 			continue;
@@ -135,7 +135,7 @@ static int locals_match(struct lookup_table *table, int idx,
 		for_each_obj_symbol_continue(i, sym, table) {
 			if (sym->type == STT_FILE)
 				break;
-			if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
+			if(strstr(sym->name, ".cold") || strstr(sym->name, ".part"))
 				continue;
 			if (sym->bind != STB_LOCAL)
 				continue;
@@ -169,7 +169,7 @@ static void find_local_syms(struct lookup_table *table, char *hint,
 	for_each_obj_symbol(i, sym, table) {
 		if (sym->type != STT_FILE)
 			continue;
-		if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
+		if(strstr(sym->name, ".cold") || strstr(sym->name, ".part"))
 			continue;
 		if (strcmp(hint, sym->name))
 			continue;

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -102,6 +102,8 @@ static int locals_match(struct lookup_table *table, int idx,
 	for_each_obj_symbol_continue(i, sym, table) {
 		if (sym->type == STT_FILE)
 			break;
+		if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
+			continue;
 		if (sym->bind != STB_LOCAL)
 			continue;
 		if (sym->type != STT_FUNC && sym->type != STT_OBJECT)
@@ -133,6 +135,8 @@ static int locals_match(struct lookup_table *table, int idx,
 		for_each_obj_symbol_continue(i, sym, table) {
 			if (sym->type == STT_FILE)
 				break;
+			if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
+				continue;
 			if (sym->bind != STB_LOCAL)
 				continue;
 			if (sym->type != STT_FUNC && sym->type != STT_OBJECT)
@@ -164,6 +168,8 @@ static void find_local_syms(struct lookup_table *table, char *hint,
 
 	for_each_obj_symbol(i, sym, table) {
 		if (sym->type != STT_FILE)
+			continue;
+		if(strstr(sym->name, ".cold")|| strstr(sym->name, ".part"))
 			continue;
 		if (strcmp(hint, sym->name))
 			continue;


### PR DESCRIPTION
Fixes #1195 

Signed-off-by: jinzhiyu jinzhiyu@macrosan.com