### PR TITLE
kpatch-build: set EXTRAVERSION and not localversion for RH kernels

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -753,7 +753,7 @@ else
 		rm -rf "$SRCDIR/.git"
 
 		if [[ "$ARCHVERSION" == *-* ]]; then
-			echo "-${ARCHVERSION##*-}" > "$SRCDIR/localversion" || die
+			sed -i "s/^EXTRAVERSION.*/EXTRAVERSION = -${ARCHVERSION##*-}/" "$SRCDIR/Makefile" || die
 		fi
 
 		echo "$ARCHVERSION" > "$VERSIONFILE" || die


### PR DESCRIPTION
```
There are some Red Hat kernel NVR combinations like
"kernel-5.13.0-0.rc4.33.el9.x86_64" that don't work well with our srpm
localversion strategy and end up botching the utsrelease.h file... which
allows for kpatch builds, but the module loader rightly rejects the
vermagic mismatch.

An ordinary rpmbuild sets up the kernel Makefile with:

  # make sure EXTRAVERSION says what we want it to say
  # Trim the release if this is a CI build, since KERNELVERSION is limited to 64 characters
  ShortRel=$(perl -e "print \"%{release}\" =~ s/\.pr\.[0-9A-Fa-f]{32}//r")
  perl -p -i -e "s/^EXTRAVERSION.*/EXTRAVERSION = -${ShortRel}.%{_target_cpu}${Variant:++${Variant}}/" Makefile

The simplest fix is just adding the version string to the kernel
Makefile EXTRAVERSION as rpmbuild would do (minus the perl voodoo).

Fixes: #1196
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>
```