### PR TITLE
S390x kpatch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported Architectures
 - [x] x86-64
 - [x] ppc64le
 - [ ] arm64
-- [ ] s390
+- [x] s390 [upstream prerequisites](doc/s390-upstream-prerequisites.md)
 
 Installation
 ------------

--- a/doc/s390-upstream-prerequisites.md
+++ b/doc/s390-upstream-prerequisites.md
@@ -1,0 +1,33 @@
+### s390 backporting
+
+**Prerequisite gcc patches (all backported to releases/gcc-11 branch):**
+- gcc-mirror/gcc@a1c1b7a IBM Z: Define NO_PROFILE_COUNTERS
+- gcc-mirror/gcc@0990d93 IBM Z: Use @PLT symbols for local functions in 64-bit mode
+- gcc-mirror/gcc@935b522 S/390: New option -mpic-data-is-text-relative
+- gcc-mirror/gcc@8753b13 IBM Z: fix section type conflict with -mindirect-branch-table
+
+**Prerequisite kernel patches:**
+**v5.19:**
+- 69505e3d9a39 bug: Use normal relative pointers in 'struct bug_entry'
+
+**v5.18:**
+- 602bf1687e6f s390/nospec: align and size extern thunks
+- 1d2ad084800e s390/nospec: add an option to use thunk-extern
+- eed38cd2f46f s390/nospec: generate single register thunks if possible
+- 2268169c14e5 s390: remove unused expoline to BC instructions
+- f0003a9e4c18 s390/entry: remove unused expoline thunk
+
+**v5.16:**
+- torvalds/linux@f6ac18f sched: Improve try_invoke_on_locked_down_task()
+- torvalds/linux@9b3c4ab sched,rcu: Rework try_invoke_on_locked_down_task()
+- torvalds/linux@00619f7 sched,livepatch: Use task_call_func()
+- torvalds/linux@8850cb6 sched: Simplify wake_up_*idle*()
+- torvalds/linux@5de62ea sched,livepatch: Use wake_up_if_idle()
+- torvalds/linux@96611c2 sched: Improve wake_up_all_idle_cpus() take #2
+
+**v5.15**
+- torvalds/linux@de5012b s390/ftrace: implement hotpatching
+- torvalds/linux@67ccddf ftrace: Introduce ftrace_need_init_nop()
+
+**v5.14:**
+- torvalds/linux@7561c14 s390/vdso: add .got.plt in vdso linker script

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -21,7 +21,8 @@ GCC_PLUGINS_DIR := $(shell $(CROSS_COMPILE)gcc -print-file-name=plugin)
 PLUGIN_CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
-else ifneq ($(ARCH),x86_64)
+endif
+ifeq ($(filter $(ARCH),s390x x86_64 ppc64le),)
 $(error Unsupported architecture ${ARCH}, check https://github.com/dynup/kpatch/#supported-architectures)
 endif
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -119,6 +119,16 @@ static bool is_bundleable(struct symbol *sym)
 		return true;
 
 	if (sym->type == STT_OBJECT &&
+	    !strncmp(sym->sec->name, ".data.rel.ro.local.", 19) &&
+	    !strcmp(sym->sec->name + 19, sym->name))
+		return 1;
+
+	if (sym->type == STT_OBJECT &&
+	    !strncmp(sym->sec->name, ".data.rel.local.", 16) &&
+	    !strcmp(sym->sec->name + 16, sym->name))
+		return 1;
+
+	if (sym->type == STT_OBJECT &&
 	   !strncmp(sym->sec->name, ".rodata.",8) &&
 	   !strcmp(sym->sec->name + 8, sym->name))
 		return true;

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -937,6 +937,10 @@ if [[ "$ARCH" = "ppc64le" ]]; then
 	ARCH_KCFLAGS="-mcmodel=large -fplugin=$PLUGINDIR/ppc64le-plugin.so"
 fi
 
+if [[ "$ARCH" = "s390x" ]]; then
+	ARCH_KCFLAGS="-mno-pic-data-is-text-relative -fno-section-anchors"
+fi
+
 export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections \
 		$ARCH_KCFLAGS $DEBUG_KCFLAGS"
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -343,12 +343,18 @@ find_special_section_data() {
 	check[e]=true						# exception_table_entry
 
 	# Arch-specific features, without kernel CONFIG_ toggle
-	if [[ "$ARCH" = "x86_64" ]]; then
-		check[a]=true					# alt_instr
-		kernel_version_gte 5.10.0 && check[s]=true	# static_call_site
-	elif [[ "$ARCH" = "ppc64le" ]]; then
-		check[f]=true					# fixup_entry
-	fi
+	case "$ARCH" in
+		"x86_64")
+			check[a]=true					# alt_instr
+			kernel_version_gte 5.10.0 && check[s]=true	# static_call_site
+			;;
+		"ppc64le")
+			check[f]=true					# fixup_entry
+			;;
+		"s390x")
+			check[a]=true					# alt_instr
+			;;
+	esac
 
 	# Kernel CONFIG_ features
 	[[ -n "$CONFIG_PRINTK_INDEX" ]] && check[i]=true	# pi_entry
@@ -856,6 +862,7 @@ trace_on
 	die "openEuler kernel doesn't have 'CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY' enabled"
 
 [[ -z "$CONFIG_DEBUG_INFO" ]] && die "kernel doesn't have 'CONFIG_DEBUG_INFO' enabled"
+[[ "$ARCH" = "s390x" ]] && [[ -z "$CONFIG_EXPOLINE_EXTERN" ]] && [[ -n "$CONFIG_EXPOLINE" ]] && die "kernel doesn't have 'CONFIG_EXPOLINE_EXTERN' enabled"
 
 # Build variables - Set some defaults, then adjust features
 # according to .config and kernel version

--- a/kpatch-build/kpatch-cc
+++ b/kpatch-build/kpatch-cc
@@ -43,6 +43,9 @@ if [[ "$TOOLCHAINCMD" =~ ^(.*-)?gcc$ || "$TOOLCHAINCMD" =~ ^(.*-)?clang$ ]] ; th
 				drivers/firmware/efi/libstub/*|\
 				arch/powerpc/kernel/prom_init.o|\
 				arch/powerpc/kernel/vdso64/*|\
+				arch/s390/boot/*|\
+				arch/s390/purgatory/*|\
+				arch/s390/kernel/vdso64/*|\
 				lib/*|\
 				.*.o|\
 				*/.lib_exports.o)

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -272,12 +272,14 @@ static void symtab_read(struct lookup_table *table, char *path)
 		 * tables.  .dynsym is just a subset of .symtab, so skip it to
 		 * avoid duplicates.
 		 */
-		if (strstr(line, ".dynsym")) {
-			skip = true;
-			continue;
-		} else if (strstr(line, ".symtab")) {
-			skip = false;
-			continue;
+		if (!strncmp(line, "Symbol table ", 13)) {
+			if (strstr(line, ".dynsym")) {
+				skip = true;
+				continue;
+			} else if (strstr(line, ".symtab")) {
+				skip = false;
+				continue;
+			}
 		}
 		if (skip)
 			continue;


### PR DESCRIPTION
Hi All,

Add s390x support for kpatch

Prerequisite gcc patches:
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=a1c1b7a888ade6f21bc7c7f05a2cbff290273fcc
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=0990d93dd8a4268bff5bbe48aa26748cf63201c7
https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=935b5226c385e34088c314374cbbe9e4995b9e44

Prerequisite kernel patches:
https://lore.kernel.org/live-patching/YObPhPkzRSqnzgK3@alley/T/#me6c2fcdbd4f582d5cc5c594bafb083ba814acdf9 - Yet to be upstream.
https://git.kernel.org/pub/scm/linux/kernel/git/s390/linux.git/commit/?h=for-next&id=7561c14d8a4d1a24a40b1839d927d488e2d6345a
Recommended Patches:
torvalds/linux@de5012b
torvalds/linux@67ccddf

 
Tested on kernel 5.14:
KPATCHBUILD_OPTS="-v /home/extend/vmlinux -s /home/extend/linux-devel/linux/  -d" ./kpatch-test  -d linux-5.14.0/ -q
build: combined module
load test: combined module
SUCCESS

Let me know your suggestions. 
Thank you. 

--
Sumanth