### PR TITLE
Makefile tweaks for handling non-replace kpatch building

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -2,14 +2,6 @@ KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
 KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD) CFLAGS_MODULE='$(CFLAGS_MODULE)'
 LDFLAGS += $(KPATCH_LDFLAGS)
 
-# ppc64le kernel modules are expected to compile with the
-# -mcmodel=large flag.  This enables 64-bit relocations
-# instead of a 32-bit offset from the TOC pointer.
-PROCESSOR = $(shell uname -m)
-ifeq ($(PROCESSOR), ppc64le)
-CFLAGS_MODULE += -mcmodel=large
-endif
-
 obj-m += $(KPATCH_NAME).o
 ldflags-y += -T $(src)/kpatch.lds
 targets += kpatch.lds

--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -1,5 +1,5 @@
 KPATCH_BUILD ?= /lib/modules/$(shell uname -r)/build
-KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD)
+KPATCH_MAKE = $(MAKE) -C $(KPATCH_BUILD) M=$(PWD) CFLAGS_MODULE='$(CFLAGS_MODULE)'
 LDFLAGS += $(KPATCH_LDFLAGS)
 
 # ppc64le kernel modules are expected to compile with the
@@ -7,7 +7,7 @@ LDFLAGS += $(KPATCH_LDFLAGS)
 # instead of a 32-bit offset from the TOC pointer.
 PROCESSOR = $(shell uname -m)
 ifeq ($(PROCESSOR), ppc64le)
-KBUILD_CFLAGS_MODULE += -mcmodel=large
+CFLAGS_MODULE += -mcmodel=large
 endif
 
 obj-m += $(KPATCH_NAME).o

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -839,7 +839,7 @@ if grep -q "CONFIG_LIVEPATCH=y" "$CONFIGFILE" && (kernel_is_rhel || kernel_versi
 	if [[  "$KLP_REPLACE" -eq 1 ]] ; then
 		support_klp_replace || die "The kernel doesn't support klp replace"
 	else
-		export KBUILD_CFLAGS_MODULE="$KBUILD_CFLAGS_MODULE -DKLP_REPLACE_ENABLE=false"
+		export CFLAGS_MODULE="$CFLAGS_MODULE -DKLP_REPLACE_ENABLE=false"
 	fi
 else
 	# No support for livepatch in the kernel. Kpatch core module is needed.

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -10,13 +10,13 @@ local: slow
 remote: remote_slow
 
 slow: clean
-	./kpatch-test -d $(PATCH_DIR) $(PATCHES)
+	./kpatch-test --kpatch-build-opts="$(KPATCH_BUILD_OPTS)" -d $(PATCH_DIR) $(PATCHES)
 
 quick: clean
-	./kpatch-test -d $(PATCH_DIR) --quick $(PATCHES)
+	./kpatch-test --kpatch-build-opts="$(KPATCH_BUILD_OPTS)" -d $(PATCH_DIR) --quick $(PATCHES)
 
 cached:
-	./kpatch-test -d $(PATCH_DIR) --cached $(PATCHES)
+	./kpatch-test --kpatch-build-opts="$(KPATCH_BUILD_OPTS)" -d $(PATCH_DIR) --cached $(PATCHES)
 
 vagrant: vagrant-quick
 


### PR DESCRIPTION
These two commits fix and extend the ability to build non atomic replace kpatches:

1. Fixes the --no-replace kpatch-build flag so that the kpatch module build honors the setting.

2. Requested by Red Hat QE, who reuse the integration test .ko modules for their own tests -- they were not prepared for atomic-replace style patches when loading multiple kpatches.  Provide a general facility to set the integration test kpatch-build options through the makefile.