### PR TITLE
Always set CONFIG_DEBUG_SECTION_MISMATCH for Ubuntu/Debian

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -713,6 +713,7 @@ elif [[ "$DISTRO" = ubuntu ]] || [[ "$DISTRO" = debian ]]; then
 	fi
 
 	export PATH="/usr/lib/ccache:$PATH"
+	export CONFIG_DEBUG_SECTION_MISMATCH=y
 fi
 
 find_dirs || die "can't find supporting tools"


### PR DESCRIPTION
I think I have concluded that stock Ubuntu kernels are built with CONFIG_DEBUG_SECTION_MISMATCH=y.

This CONFIG controls whether or not '-fno-inline-functions-called-once' is set during compilation.
For 'kpatch' this is naturally important; I see instances where there is a long c file with a lot of 'static' functions in it called only once from a public function.
And if it's not too complex, the compiler will inline the function, UNLESS the above flag is on.
As anyone knows, this could pose problems for the kpatch tool

However, the perhaps strange thing is that it's not on in the .config file provided in the 'modules' package.
Instead look in the following files, using Ubuntu 21.04 as an example:

linux-5.11.0/debian/rules.d/0-common-vars.mk:255
...
kmake = make ARCH=$(build_arch)
CROSS_COMPILE=$(CROSS_COMPILE)
KERNELVERSION=$(abi_release)-$(target_flavour)
CONFIG_DEBUG_SECTION_MISMATCH=y
KBUILD_BUILD_VERSION="$(uploadnum)"
LOCALVERSION= localver-extra=
CFLAGS_MODULE="-DPKG_ABI=$(abinum)"
PYTHON=$(PYTHON)
ifneq ($(LOCAL_ENV_CC),)
kmake += CC="$(LOCAL_ENV_CC)" DISTCC_HOSTS="$(LOCAL_ENV_DISTCC_HOSTS)"
endif

linux-5.11.0/Makefile:914
...
ifdef CONFIG_DEBUG_SECTION_MISMATCH
KBUILD_CFLAGS += $(call cc-option, -fno-inline-functions-called-once)
endif

If one only uses linux-5.11.0/Makefile to build as kpatch does it, then this is not set.
However, the debian-style scripts used during official builds, see https://wiki.ubuntu.com/Kernel/BuildYourOwnKernel for a good reference, the build is kicked off with:
$ LANG=C fakeroot debian/rules binary
This is debian's way of building the kernel + a boatload of DKMS modules and debian packaging (This takes forever to build....thus not desired for kpatch)