### PR TITLE
create-diff-object: fix use after free in kpatch-check-relocations()

### DIFF
--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -67,6 +67,12 @@ struct section {
 	};
 };
 
+enum symbol_strip {
+	SYMBOL_DEFAULT,
+	SYMBOL_USED,
+	SYMBOL_STRIP,
+};
+
 struct symbol {
 	struct list_head list;
 	struct symbol *twin;
@@ -82,7 +88,7 @@ struct symbol {
 	enum status status;
 	union {
 		int include; /* used in the patched elf */
-		int strip; /* used in the output elf */
+		enum symbol_strip strip; /* used in the output elf */
 	};
 	int has_func_profiling;
 };


### PR DESCRIPTION
Building data-read-mostly.patch on rhel-9.0-beta for ppc64le leads to a
segmentation fault:

    Program received signal SIGSEGV, Segmentation fault.
    kpatch_check_relocations (kelf=0x10040490) at create-diff-object.c:2571
    2571                                    sdata = rela->sym->sec->data;
    (gdb) bt
    (gdb) p rela->sym->sec->data
    Cannot access memory at address 0x160000007e

Valgrind narrows the problem down to invalid reads through rela->sym in
kpatch-check-relocations().

The culprits are kpatch_create_intermediate_sections(), which marks
symbols referenced by rela sections that are now dynrelas to be
stripped, and kpatch_strip_unneeded_syms(), which removes and frees
them.

The problem with the symbol stripping is that multiple relas may
reference the same ELF symbol.  If any remaining relocation references a
shared symbol, we must keep it.

Replace the symbol->strip boolean with an enumeration:

  SYMBOL_DEFAULT - initial value, symbol usage unknown
  SYMBOL_USED    - symbol is definitely used by a rela
  SYMBOL_STRIP   - symbol was only referenced by dynrela(s)

Allow transitions from SYMBOL_DEFAULT to SYMBOL_* and SYMBOL_STRIP to
SYMBOL_USED, but _not_ SYMBOL_USED to SYMBOL_*.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>