### PR TITLE
livepatch-patch-hook: remove redundant loop condition in patch_free_livepatch

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -232,7 +232,7 @@ static void patch_free_livepatch(struct klp_patch *patch)
 	struct klp_object *object;
 
 	if (patch) {
-		for (object = patch->objs; object && object->funcs; object++) {
+		for (object = patch->objs; object; object++) {
 			if (object->funcs)
 				kfree(object->funcs);
 #ifndef HAVE_ELF_RELOCS


### PR DESCRIPTION
Inside the for loop of releasing patch->objs, each object->funcs is checked
null, thus there is no need to check it twice.

See issue: https://github.com/dynup/kpatch/issues/1210

Signed-off-by: Hu Bin <im.bin.hu@gmail.com>