### PR TITLE
kpatch-build: skip system_certificates.o

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1059,6 +1059,7 @@ for i in $FILES; do
 		[[ "$i" = arch/x86/lib/copy_user_64.o ]] && continue
 
 	[[ "$i" = usr/initramfs_data.o ]] && continue
+	[[ "$i" = certs/system_certificates.o ]] && continue
 
 	mkdir -p "output/$(dirname "$i")"
 	cd "$SRCDIR" || die


### PR DESCRIPTION
system_certificates.o: WARNING: FILE symbol not found in base. Stripped object file or assembly source?
since kpatch does not support patch assembly file cert/system_certificates.S, we can simply skip it and
avoid the warning.

Signed-off-by: xiejingfeng <xiejingfeng@linux.alibaba.com>