### PR TITLE
kpatch-build: Do not check KLP_REPLACE for kpatch.ko-based patches

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -858,9 +858,6 @@ else
 	# sections.  Use with caution!
 	echo "WARNING: Use of kpatch core module (kpatch.ko) is deprecated!  There may be bugs!" >&2
 
-	if [[ "$KLP_REPLACE" -eq 1 ]] ; then
-		die "kpatch core module (kpatch.ko) does not support replace, please add -R|--non-replace"
-	fi
 	find_core_symvers || die "unable to find Module.symvers for kpatch core module"
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi


### PR DESCRIPTION
After commit 17dcebf077d69 ("kpatch-build: enable klp with replace option by default"),
building the old-style (kpatch.ko-based) patches fails with the following
error:

> "kpatch core module (kpatch.ko) does not support replace, please add -R|--non-replace"

kpatch.ko actually supports atomic replacement of patches but KLP_REPLACE
has nothing to do with that. Let us not break such builds and remove that check.
