### PR TITLE
create-diff-object: support R_PPC64_REL64 relocations on ppc64le

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3002,7 +3002,9 @@ static bool need_dynrela(struct lookup_table *table, const struct rela *rela)
 	 * should never be converted to dynrelas.
 	 */
 	if (rela->type == R_PPC64_REL16_HA || rela->type == R_PPC64_REL16_LO ||
-	    rela->type == R_PPC64_REL64 || rela->type == R_PPC64_ENTRY)
+	    rela->type == R_PPC64_ENTRY)
+		return false;
+	if (rela->type == R_PPC64_REL64 && !strcmp(rela->sym->name, ".TOC."))
 		return false;
 
 	/*


### PR DESCRIPTION
Integration tests built on RHEL-9 revealed that the kernel now makes use
of R_PPC64_REL64 relocations in the jump table:

  Relocation section '.rela__jump_table' at offset 0x14c6f0 contains 21 entries:
      Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
  ...
  0000000000000018  000000830000002c R_PPC64_REL64          0000000000000000 __tracepoint_netif_receive_skb + 8
  ...

but need_dynrela() contains code to specifically skip any R_PPC64_REL64
type when determining if a relocation should be turned into dynrela.

Kamalesh Babulal explains:

  I tried digging a little deeper and the upstream Kernel commit
  b0b3b2c78ec (powerpc: Switch to relative jump labels) in v5.13,
  introduced the change of generating relocation entries of type
  R_PPC64_REL64, instead of absolute relocation type R_PPC64_ADDR64:

  Relocation section '.rela__jump_table' at offset 0x1a87d8 contains 303 entries:
      Offset             Info             Type               Symbol's Value  Symbol's Name + Addend
  ...
  00000000000003c8  000007910000002c R_PPC64_REL64          0000000000000000 __tracepoint_netif_receive_skb + 8
  ...

Relax the existing check to only skip R_PPC64_REL64 relocations for
.TOC. entries, since their relocation doesn't refer to any symbol.

Fixes: #1212
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>