### PR TITLE
Basic Clang PGO support

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -455,6 +455,14 @@ static bool rela_equal(struct rela *rela1, struct rela *rela2)
 		return true;
 
 	/*
+	 * __llvm_prf_cnts is used by clang PGO to store counters. Ignore
+	 * these to void unnecessary "changed function".
+	 */
+	if (!strcmp(rela1->sym->name, "__llvm_prf_cnts") &&
+	    !strcmp(rela2->sym->name, "__llvm_prf_cnts"))
+		return true;
+
+	/*
 	 * With -mcmodel=large on ppc64le, GCC might generate entries in the .toc
 	 * section for relocation symbol references.   The .toc offsets may change
 	 * between the original and patched .o, so comparing ".toc + offset" isn't

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -986,6 +986,8 @@ static void kpatch_correlate_section(struct section *sec_orig,
 		kpatch_correlate_symbol(sec_orig->sym, sec_patched->sym);
 }
 
+static char *kpatch_section_function_name(struct section *sec);
+
 static void kpatch_correlate_sections(struct list_head *seclist_orig,
 		struct list_head *seclist_patched)
 {
@@ -995,8 +997,9 @@ static void kpatch_correlate_sections(struct list_head *seclist_orig,
 		if (sec_orig->twin)
 			continue;
 		list_for_each_entry(sec_patched, seclist_patched, list) {
-			if (kpatch_mangled_strcmp(sec_orig->name, sec_patched->name) ||
-			    sec_patched->twin)
+			if (sec_patched->twin ||
+			    kpatch_mangled_strcmp(kpatch_section_function_name(sec_orig),
+						  kpatch_section_function_name(sec_patched)))
 				continue;
 
 			if (is_special_static(is_rela_section(sec_orig) ?

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -677,9 +677,10 @@ usage() {
 	echo "		--skip-cleanup          Skip post-build cleanup" >&2
 	echo "		--skip-compiler-check   Skip compiler version matching check" >&2
 	echo "		                        (not recommended)" >&2
+	echo "		-p, --profile-data      specify profile data for PGO (clang only)" >&2
 }
 
-options="$(getopt -o ha:r:s:c:v:j:t:n:o:dR -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,oot-module:,oot-module-src:,debug,skip-gcc-check,skip-compiler-check,skip-cleanup,non-replace" -- "$@")" || die "getopt failed"
+options="$(getopt -o ha:r:s:c:v:j:t:n:o:dRp: -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,oot-module:,oot-module-src:,debug,skip-gcc-check,skip-compiler-check,skip-cleanup,non-replace,profile-data" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"
 
@@ -760,6 +761,10 @@ while [[ $# -gt 0 ]]; do
 	--skip-compiler-check)
 		echo "WARNING: Skipping compiler version matching check (not recommended)"
 		SKIPCOMPILERCHECK=1
+		;;
+	-p|--profile-data)
+		PROFILE_DATA="$(readlink -f "$2")"
+		shift
 		;;
 	*)
 		[[ "$1" = "--" ]] && shift && continue
@@ -1056,6 +1061,16 @@ fi
 
 if [[ -n "$CONFIG_CC_IS_CLANG" ]]; then
 	echo "WARNING: Clang support is experimental"
+	if [[ -z "$PROFILE_DATA" ]] && [[ -n "$CONFIG_PGO_CLANG" ]]; then
+		die "Please specify profile-data for CONFIG_PGO_CLANG"
+	fi
+	if [[ -n "$PROFILE_DATA" ]] && [[ -z "$CONFIG_PGO_CLANG" ]]; then
+		echo "WARNING profile-data specified w/o CONFIG_PGO_CLANG, ignore it"
+	fi
+else
+	if [[ -n "$PROFILE_DATA" ]]; then
+		die "Only supports profile-data with Clang"
+	fi
 fi
 
 if [[ "$SKIPCOMPILERCHECK" -eq 0 ]]; then
@@ -1107,6 +1122,9 @@ declare -a MAKEVARS
 if [[ -n "$CONFIG_CC_IS_CLANG" ]]; then
 	MAKEVARS+=("CC=${KPATCH_CC_PREFIX}${CLANG}")
 	MAKEVARS+=("HOSTCC=clang")
+	if [[ -n "$CONFIG_PGO_CLANG" ]]; then
+		MAKEVARS+=("LLVM=1 CFLAGS_PGO_CLANG=-fprofile-use=$PROFILE_DATA")
+	fi
 else
 	MAKEVARS+=("CC=${KPATCH_CC_PREFIX}${GCC}")
 fi


### PR DESCRIPTION
This series adds basic Clang PGO support. 
The first commit fixes issue that function section name in original and patched kernel has different prefixes (e.g., .text vs. .text.unlikely). Such behavior is expected with PGO. 
The secondd commit adds -p|--profile-data option to kpatch-build. 