### PR TITLE
Add Arm64 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Supported Architectures
 
 - [x] x86-64
 - [x] ppc64le
-- [ ] arm64
+- [x] arm64
 - [ ] s390
 
 Installation

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -22,6 +22,7 @@ GCC_PLUGINS_DIR := $(shell gcc -print-file-name=plugin)
 PLUGIN_CFLAGS := $(filter-out -Wconversion, $(CFLAGS))
 PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
+else ifeq ($(ARCH),aarch64)
 else
 $(error Unsupported architecture ${ARCH}, check https://github.com/dynup/kpatch/#supported-architectures)
 endif

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3401,6 +3401,21 @@ static void kpatch_create_callbacks_objname_rela(struct kpatch_elf *kelf, char *
 	}
 }
 
+static void kpatch_alloc_mcount_sections(struct kpatch_elf *kelf, struct kpatch_elf *kelfout)
+{
+	int nr;
+	struct symbol *sym;
+
+	nr = 0;
+	list_for_each_entry(sym, &kelfout->symbols, list)
+		if (sym->type == STT_FUNC && sym->status != SAME &&
+		    sym->has_func_profiling)
+			nr++;
+
+	/* create text/rela section pair */
+	create_section_pair(kelfout, "__mcount_loc", sizeof(void*), nr);
+}
+
 /*
  * This function basically reimplements the functionality of the Linux
  * recordmcount script, so that patched functions can be recognized by ftrace.
@@ -3408,7 +3423,7 @@ static void kpatch_create_callbacks_objname_rela(struct kpatch_elf *kelf, char *
  * TODO: Eventually we can modify recordmount so that it recognizes our bundled
  * sections as valid and does this work for us.
  */
-static void kpatch_create_mcount_sections(struct kpatch_elf *kelf)
+static void kpatch_populate_mcount_sections(struct kpatch_elf *kelf)
 {
 	int nr, index;
 	struct section *sec, *relasec;
@@ -3417,15 +3432,10 @@ static void kpatch_create_mcount_sections(struct kpatch_elf *kelf)
 	void **funcs;
 	unsigned long insn_offset;
 
-	nr = 0;
-	list_for_each_entry(sym, &kelf->symbols, list)
-		if (sym->type == STT_FUNC && sym->status != SAME &&
-		    sym->has_func_profiling)
-			nr++;
 
-	/* create text/rela section pair */
-	sec = create_section_pair(kelf, "__mcount_loc", sizeof(void*), nr);
+	sec = find_section_by_name(&kelf->sections, "__mcount_loc");
 	relasec = sec->rela;
+	nr = (int) (sec->data->d_size / sizeof(void *));
 
 	/* populate sections */
 	index = 0;
@@ -3788,6 +3798,9 @@ int main(int argc, char *argv[])
 	/* this is destructive to kelf_patched */
 	kpatch_migrate_included_elements(kelf_patched, &kelf_out);
 
+	/* this must be done before kelf_patched is torn down */
+	kpatch_alloc_mcount_sections(kelf_patched, kelf_out);
+
 	/*
 	 * Teardown kelf_patched since we shouldn't access sections or symbols
 	 * through it anymore.  Don't free however, since our section and symbol
@@ -3806,7 +3819,7 @@ int main(int argc, char *argv[])
 	kpatch_create_callbacks_objname_rela(kelf_out, parent_name);
 	kpatch_build_strings_section_data(kelf_out);
 
-	kpatch_create_mcount_sections(kelf_out);
+	kpatch_populate_mcount_sections(kelf_out);
 
 	/*
 	 *  At this point, the set of output sections and symbols is

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1635,7 +1635,7 @@ static void kpatch_check_func_profiling_calls(struct kpatch_elf *kelf)
 		    (sym->parent && sym->parent->status == CHANGED))
 			continue;
 		if (!sym->twin->has_func_profiling) {
-			log_normal("function %s has no fentry/mcount call, unable to patch\n",
+			log_normal("function %s doesn't have patchable function entry, unable to patch\n",
 				   sym->name);
 			errs++;
 		}

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -375,9 +375,57 @@ find_special_section_data_ppc64le() {
 	return
 }
 
+find_special_section_data_aarch64() {
+	[[ "$CONFIG_JUMP_LABEL" -eq 0 ]] && AWK_OPTIONS="-vskip_j=1"
+	[[ "$CONFIG_PRINTK_INDEX" -eq 0 ]] && AWK_OPTIONS="$AWK_OPTIONS -vskip_i=1"
+
+	# shellcheck disable=SC2086
+	SPECIAL_VARS="$(readelf -wi "$VMLINUX" |
+		gawk --non-decimal-data $AWK_OPTIONS '
+		BEGIN { a = b = p = e = o = j = s = i = 0 }
+
+		# Set state if name matches
+		a == 0 && /DW_AT_name.* alt_instr[[:space:]]*$/ {a = 1; next}
+		b == 0 && /DW_AT_name.* bug_entry[[:space:]]*$/ {b = 1; next}
+		e == 0 && /DW_AT_name.* exception_table_entry[[:space:]]*$/ {e = 1; next}
+		j == 0 && /DW_AT_name.* jump_entry[[:space:]]*$/ {j = 1; next}
+		i == 0 && /DW_AT_name.* pi_entry[[:space:]]*$/ {i = 1; next}
+
+		# Reset state unless this abbrev describes the struct size
+		a == 1 && !/DW_AT_byte_size/ { a = 0; next }
+		b == 1 && !/DW_AT_byte_size/ { b = 0; next }
+		e == 1 && !/DW_AT_byte_size/ { e = 0; next }
+		j == 1 && !/DW_AT_byte_size/ { j = 0; next }
+		i == 1 && !/DW_AT_byte_size/ { i = 0; next }
+
+		# Now that we know the size, stop parsing for it
+		a == 1 {printf("export ALT_STRUCT_SIZE=%d\n", $4); a = 2}
+		b == 1 {printf("export BUG_STRUCT_SIZE=%d\n", $4); b = 2}
+		e == 1 {printf("export EX_STRUCT_SIZE=%d\n", $4); e = 2}
+		j == 1 {printf("export JUMP_STRUCT_SIZE=%d\n", $4); j = 2}
+		i == 1 {printf("export PRINTK_INDEX_STRUCT_SIZE=%d\n", $4); i = 2}
+
+		# Bail out once we have everything
+		a == 2 && b == 2 && e == 2 && (j == 2 || skip_j) && (i == 2 || skip_i) {exit}')"
+
+	[[ -n "$SPECIAL_VARS" ]] && eval "$SPECIAL_VARS"
+
+	[[ -z "$ALT_STRUCT_SIZE" ]] && die "can't find special struct alt_instr size"
+	[[ -z "$BUG_STRUCT_SIZE" ]] && die "can't find special struct bug_entry size"
+	[[ -z "$EX_STRUCT_SIZE" ]]  && die "can't find special struct paravirt_patch_site size"
+	[[ -z "$JUMP_STRUCT_SIZE" && "$CONFIG_JUMP_LABEL" -ne 0 ]] && die "can't find special struct jump_entry size"
+	[[ -z "$PRINTK_INDEX_STRUCT_SIZE" && "$CONFIG_PRINTK_INDEX" -ne 0 ]] && die "can't find special struct pi_entry size"
+
+	return
+
+}
+
 find_special_section_data() {
 	if [[ "$ARCH" = "ppc64le" ]]; then
 		find_special_section_data_ppc64le
+		return
+	elif [[ "$ARCH" = "aarch64" ]]; then
+		find_special_section_data_aarch64
 		return
 	fi
 

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -332,7 +332,24 @@ static void kpatch_find_func_profiling_calls(struct kpatch_elf *kelf)
 				break;
 			}
 		}
-#else
+#elif defined(__aarch64__)
+{
+		struct section *sec = find_section_by_name(&kelf->sections,
+				      "__patchable_function_entries");
+		/*
+		 * If we can't find the __patchable_function_entries section or
+		 * there are no relocations in it then not patchable.
+		 */
+		if (!sec || !sec->rela)
+			return;
+		list_for_each_entry(rela, &sec->rela->relas, list) {
+			if (rela->sym->sec && sym->sec == rela->sym->sec) {
+				sym->has_func_profiling = 1;
+				break;
+			}
+		}
+}
+#else /* x86_64 */
 		rela = list_first_entry(&sym->sec->rela->relas, struct rela,
 					list);
 		if ((rela->type != R_X86_64_NONE &&


### PR DESCRIPTION
Implement support for building livepatches for arm64

Kernel Support:
- Currently being worked on upstream
- My tree here: https://github.com/amazonlinux/linux/tree/amazon-arm-livepatch-v5.10

With the above kernel tree and the changes in this pull request I have been able to build and apply patches using kpatch.