### PR TITLE
test: Add data relocation test

### DIFF
--- a/test/integration/common/multiple.template
+++ b/test/integration/common/multiple.template
@@ -1,6 +1,5 @@
 SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
 ROOTDIR="$(readlink -f $SCRIPTDIR/../../..)"
-KPATCH="sudo $ROOTDIR/kpatch/kpatch"
 
 MODULE_PREFIX="test-"
 MODULE_POSTFIX=".ko"

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -119,6 +119,9 @@ else
 	done
 fi
 
+# export envs for test progs
+export KPATCH
+
 error() {
 	echo "ERROR: $*" |tee -a $LOG >&2
 	ERROR=$((ERROR + 1))

--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -383,7 +383,7 @@ if [ "${DYNDEBUG_ENABLED}" == "1" ]; then
 	sudo sh -c "echo \"func klp_try_switch_task ${prev_dyndebug}\" > ${DYNDEBUG_CONTROL} 2>/dev/null"
 fi
 
-if new_dmesg | grep -q "Call Trace"; then
+if new_dmesg | grep -q -i "Call Trace"; then
 	new_dmesg > dmesg.log
 	error "kernel error detected in printk buffer"
 fi

--- a/test/integration/linux-5.10.11/data-reloc.patch
+++ b/test/integration/linux-5.10.11/data-reloc.patch
@@ -1,0 +1,20 @@
+diff --git a/drivers/usb/serial/ir-usb.c b/drivers/usb/serial/ir-usb.c
+index 172261a908d8..4fdd666cc75a 100644
+--- a/drivers/usb/serial/ir-usb.c
++++ b/drivers/usb/serial/ir-usb.c
+@@ -194,10 +194,15 @@ static u8 ir_xbof_change(u8 xbof)
+ 	return(result);
+ }
+ 
++#include "usb-wwan.h"
+ static int ir_startup(struct usb_serial *serial)
+ {
+ 	struct usb_irda_cs_descriptor *irda_desc;
+ 	int rates;
++	volatile int i = 0;
++	static volatile void *funcs[] = {usb_wwan_open, usb_wwan_close};
++
++	printk("kpatch: usb_wwan_open=%p\n", funcs[i]);
+ 
+ 	irda_desc = irda_usb_find_class_desc(serial, 0);
+ 	if (!irda_desc) {

--- a/test/integration/linux-5.10.11/data-reloc.test
+++ b/test/integration/linux-5.10.11/data-reloc.test
@@ -1,0 +1,5 @@
+sudo modprobe usb_wwan
+sudo modprobe ir-usb
+sleep 5
+
+$KPATCH load test-data-reloc.ko


### PR DESCRIPTION
This patch adds a test case that the klp-module has a
`.klp.rela.<module name>..rodata.<...>` section. This pattern can be
an error if the kernel architecture-specific relocation does not fully
support Livepatch.

Currently, implementation of the Arm64-specific relocation for Livepatch
is in progress [1], but it is pointed out that data relocation is insufficient.
I created this test to confirm that data relocation was implemented correctly. 

[1] https://lore.kernel.org/linux-arm-kernel/20211103210709.31790-1-surajjs@amazon.com/

The prerequisite for this test is that CONFIG_USB_SERIAL_IR=m and
CONFIG_USB_SERIAL_WWAN=m are set. In the patched-modules,
ir-usb.ko's static local variables refers to usb_wwan.ko's symbols,
so `.klp.rela.ir-usb..rodata.<...>` section are generated into
test-data-reloc.ko.

Modifications to drivers/usb/serial/bus.c are not directly related to
the purpose of this test, but are necessary for testing with the
data-reloc-LOADED.test.