### PR TITLE
kpatch-build: Add missing malloc failure check

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -911,6 +911,8 @@ do {								\
 		log_debug("renaming %s %s to %s\n",		\
 			  kindstr, e2->name, e1->name);		\
 		e2->name = strdup(e1->name);			\
+		if (!e2->name)				        \
+			ERROR("strdup");			\
 	}							\
 } while (0)
 
@@ -3461,6 +3463,8 @@ static void kpatch_create_mcount_sections(struct kpatch_elf *kelf)
 
 			/* Make a writable copy of the text section data */
 			newdata = malloc(sym->sec->data->d_size);
+			if (!newdata)
+				ERROR("malloc");
 			memcpy(newdata, sym->sec->data->d_buf, sym->sec->data->d_size);
 			sym->sec->data->d_buf = newdata;
 			insn = newdata;

--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -326,6 +326,8 @@ static void create_klp_arch_sections(struct kpatch_elf *kelf, char *strings)
 
 		new_size = old_size + base->data->d_size;
 		sec->data->d_buf = realloc(sec->data->d_buf, new_size);
+		if (!sec->data->d_buf)
+			ERROR("realloc");
 		sec->data->d_size = new_size;
 		sec->sh.sh_size = sec->data->d_size;
 		memcpy(sec->data->d_buf + old_size,


### PR DESCRIPTION
In kpatch_create_mcount_sections(), there is a section of code wherein
on x86-64 builds, if the rela type for a symbol is R_X86_64_NONE, a
buffer into which a writeable copy of the symbol's .text is allocated.
This is done so that the .text section may be copied into the buffer,
and the NOP call that is generated for the function entry (by older
versions of the kernel/gcc) can be updated to be a call to fentry.

In all other calls in kpatch-build, any allocation is checked for
failures, and gracefully failed with a call to ERROR(). This diff
corrects the one aforementioned spot where this was missed.

Signed-off-by: David Vernet <void@manifault.com>