### PR TITLE
create-diff-object: add support for .retpoline_sites section

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2083,6 +2083,11 @@ static int static_call_sites_group_size(struct kpatch_elf *kelf, int offset)
 
 	return size;
 }
+
+static int retpoline_sites_group_size(struct kpatch_elf *kelf, int offset)
+{
+	return 4;
+}
 #endif
 #ifdef __powerpc64__
 static int fixup_entry_group_size(struct kpatch_elf *kelf, int offset)
@@ -2198,6 +2203,10 @@ static struct special_section special_sections[] = {
 	{
 		.name		= ".static_call_sites",
 		.group_size	= static_call_sites_group_size,
+	},
+	{
+		.name		= ".retpoline_sites",
+		.group_size	= retpoline_sites_group_size,
 	},
 #endif
 #ifdef __powerpc64__


### PR DESCRIPTION
Linux 5.16's objtool gathers retpoline thunk call sites in its own special section on x86_64 with `CONFIG_RETPOLINE=y`. This PR allows building live patches for this config.

I tested the change with kernels 5.15 and 5.16, each of them with a patch touching no code with indirect calls (and thus without the new `.retpoline_sites` section) and with a patch touching code with indirect calls (and thus with the new `.retpoline_sites` section). Without the change in this PR, building a live patch touching code with indirect calls for kernel 5.16 results in the following error:

```
ERROR: stacktrace.o: 1 unsupported section change(s)
stacktrace.o: changed function: arch_stack_walk_reliable
stacktrace.o: changed section .rela.retpoline_sites not selected for inclusion
/home/ubuntu/kpatch/kpatch-build/create-diff-object: unreconcilable difference
ERROR: 1 error(s) encountered. Check /home/ubuntu/.kpatch/build.log for more details.
```

The build succeeds with the change in this PR. The resulting relocations look sane and the patched code can be loaded and executed.