### PR TITLE
Fix sym->type condition in locals_match()

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -131,7 +131,7 @@ static bool locals_match(struct lookup_table *table, int idx,
 			break;
 		if (sym->bind != STB_LOCAL)
 			continue;
-		if (sym->type != STT_FUNC && table_sym->type != STT_OBJECT)
+		if (sym->type != STT_FUNC && sym->type != STT_OBJECT)
 			continue;
 		/*
 		 * Symbols which get discarded at link time are missing from


### PR DESCRIPTION
Second loop in locals_match() checks table_sym->type instead of
sym->type.

Fixes: 7207687 Switch to per-file lookup table pointers.
Signed-off-by: Artem Savkov <asavkov@redhat.com>