### PR TITLE
kpatch-build: Allow setting kernel version if --sourcedir and --vmlinux are used

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -638,10 +638,6 @@ if [[ $DEBUG -eq 1 ]] || [[ $DEBUG -ge 3 ]]; then
 	set -o xtrace
 fi
 
-if [[ -n "$ARCHVERSION" ]] && [[ -n "$VMLINUX" ]]; then
-	die "--archversion is incompatible with --vmlinux"
-fi
-
 if [[ -n "$SRCRPM" ]]; then
 	if  [[ -n "$ARCHVERSION" ]]; then
 		warn "--archversion is incompatible with --sourcerpm"
@@ -664,17 +660,23 @@ rm -rf "${TEMPDIR:?}"/*
 rm -f "$LOGFILE"
 
 if [[ -n "$USERSRCDIR" ]]; then
-	if [[ -n "$ARCHVERSION" ]]; then
-		warn "--archversion is incompatible with --sourcedir"
-		exit 1
-	fi
 	KERNEL_SRCDIR="$USERSRCDIR"
 
 	[[ -z "$VMLINUX" ]] && VMLINUX="$KERNEL_SRCDIR"/vmlinux
 	[[ ! -e "$VMLINUX" ]] && die "can't find vmlinux"
 
 	# Extract the target kernel version from vmlinux in this case.
-	ARCHVERSION="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
+	VMLINUX_VER="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
+	if [[ -n "$ARCHVERSION" ]]; then
+		if [[ -n "$VMLINUX_VER" ]] && [[ "$ARCHVERSION" != "$VMLINUX_VER" ]]; then
+			die "Kernel version mismatch: $ARCHVERSION was specified but vmlinux was built for $VMLINUX_VER"
+		fi
+	else
+		if [[ -z "$VMLINUX_VER" ]]; then
+			die "Unable to determine the kernel version from vmlinux"
+		fi
+		ARCHVERSION="$VMLINUX_VER"
+	fi
 fi
 
 if [[ -n "$OOT_MODULE" ]]; then


### PR DESCRIPTION
Using -a/--archversion to explicitly set target kernel version was not
allowed if the kernel source directory and/or path to vmlinux with debug
info were set. This seems too strict, however.

vmlinux with debug info is used during the build to get symbol data, the
size of special structures, GCC version used to build the kernel, and the
target kernel version. As it turned out, some kernels, e.g. the ones from
OpenSUSE and derivatives, contain all that data except the Linux version
string in the file with debug info for vmlinux. Instead, that string is
present in vmlinux itself but that file does not contain debug info.

A simple workaround is to allow specifying the target kernel version
explicitly using -a/--archversion even if --sourcedir and/or --vmlinux are
set. If vmlinux with debug info does contain the Linux version string and
the version is different, kpatch-build will report an error.

I tested this on the kernel based on 5.3.18-150300.59.54-default from OpenSUSE Leap 15.3. If I set the correct version explicitly, as well as --sourcedir and --vmlinux, the binary patch is built OK by kpatch-build and seems to work.