### PR TITLE
kpatch-build: add support for openEuler

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -750,9 +750,13 @@ elif [[ -e "$KERNEL_SRCDIR"/.config ]] && [[ -e "$VERSIONFILE" ]] && [[ "$(cat "
 	echo "Using cache at $KERNEL_SRCDIR"
 
 else
-	if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]]; then
+	if [[ "$DISTRO" = fedora ]] || [[ "$DISTRO" = rhel ]] || [[ "$DISTRO" = ol ]] || [[ "$DISTRO" = centos ]] || [[ "$DISTRO" = openEuler ]]; then
 
-		echo "Fedora/Red Hat distribution detected"
+		[[ "$DISTRO" = fedora ]] && echo "Fedora distribution detected"
+		[[ "$DISTRO" = rhel ]] && echo "RHEL distribution detected"
+		[[ "$DISTRO" = ol ]] && echo "Oracle Linux distribution detected"
+		[[ "$DISTRO" = centos ]] && echo "CentOS distribution detected"
+		[[ "$DISTRO" = openEuler ]] && echo "OpenEuler distribution detected"
 
 		clean_cache
 
@@ -773,7 +777,13 @@ else
 		rpmbuild -D "_topdir $RPMTOPDIR" -bp --nodeps "--target=$(uname -m)" "$RPMTOPDIR"/SPECS/kernel$ALT.spec 2>&1 | logger ||
 			die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
 
-		mv "$RPMTOPDIR"/BUILD/kernel-*/linux-* "$KERNEL_SRCDIR" 2>&1 | logger || die
+		if [[ "$DISTRO" = openEuler ]]; then
+			# openEuler has two directories with the same content after 'rpm -D'
+			# openEuler 21.09 has linux-* and linux-*-source while openEuler 20.03 has linux-* and linux-*-Source
+			mv "$RPMTOPDIR"/BUILD/kernel-*/linux-*[sS]ource "$KERNEL_SRCDIR" 2>&1 | logger || die
+		else
+			mv "$RPMTOPDIR"/BUILD/kernel-*/linux-* "$KERNEL_SRCDIR" 2>&1 | logger || die
+		fi
 		rm -rf "$RPMTOPDIR"
 		rm -rf "$KERNEL_SRCDIR/.git"
 
@@ -783,7 +793,11 @@ else
 
 		echo "$ARCHVERSION" > "$VERSIONFILE" || die
 
-		[[ -z "$CONFIGFILE" ]] && CONFIGFILE="$KERNEL_SRCDIR/configs/kernel$ALT-$KVER-$ARCH.config"
+		if [[ "$DISTRO" = openEuler ]]; then
+			[[ -z "$CONFIGFILE" ]] && CONFIGFILE="/boot/config-${ARCHVERSION}"
+		else
+			[[ -z "$CONFIGFILE" ]] && CONFIGFILE="$KERNEL_SRCDIR/configs/kernel$ALT-$KVER-$ARCH.config"
+		fi
 
 		(cd "$KERNEL_SRCDIR" && make mrproper 2>&1 | logger) || die
 
@@ -840,6 +854,9 @@ fi
 # Don't check external file.
 # shellcheck disable=SC1090
 source "$CONFIGFILE"
+
+[[ "$DISTRO" = openEuler ]] && [[ -z "$CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY" ]] && \
+	die "openEuler kernel doesn't have 'CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY' enabled"
 
 [[ -z "$CONFIG_DEBUG_INFO" ]] && die "kernel doesn't have 'CONFIG_DEBUG_INFO' enabled"
 

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -116,6 +116,19 @@ kpatch_centos_dependencies()
 	sudo yum remove -y epel-release
 }
 
+kpatch_openEuler_dependencies()
+{
+	local kernel_version
+	local arch
+	kernel_version=$(uname -r)
+	arch=$(uname -m)
+
+	sudo yum install -y make gcc patch bison flex openssl-devel dwarves \
+		rpm-build dnf-plugins-core python3-devel openssl-devel ncurses-devel elfutils-libelf-devel
+	sudo yum install -y "kernel-source-${kernel_version%.*}" \
+		"kernel-debuginfo-${kernel_version%.*}" "kernel-devel-${kernel_version%.*}"
+}
+
 kpatch_dependencies()
 {
 	# shellcheck disable=SC1091


### PR DESCRIPTION
As I noticed, commit eaaced191 has added
partial support for openEuler.

This patch enables usage in openEuler like:
kaptch-build xxxx.patch

I test it in openEuler 21.09, for people who
want to use kpatch in openEuler, two more steps
are needed.

1) add repo source
source rpm package of openEuler kernel are put in
two places. One is
https://repo.openeuler.org/openEuler-21.09/source/
Another one is
https://repo.openeuler.org/openEuler-21.09/update/source/
The latter one is not included in rpm repo lists by default.

2) compile kernel with CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY enabled
openEuler has its own strategy when trying to apply patches.
We can only use klp_enable_patch function when
CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY enabled.

Signed-off-by: anatasluo <luolongjuna@gmail.com>