### PR TITLE
doc: fix internal link to supported arches

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -20,7 +20,7 @@ Prerequisites
 -------------
 
 Before starting, see [Supported
-Architectures](README.md#supported-architectures) and check if your device's
+Architectures](../README.md#supported-architectures) and check if your device's
 architecture is supported.
 
 ### Fedora, RHEL, CentOS


### PR DESCRIPTION
This seems to fix the doc linking problem.

Fixes #1267