### PR TITLE
kpatch: also unload a loaded, but no longer enabled kernel live patch

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -378,8 +378,12 @@ disable_patch () {
 
 	local enabled="$SYSFS/$modname/enabled"
 	if ! [[ -e "$enabled" ]]; then
-	    warn "patch module $modname is not loaded"
-	    return 1
+		if [[ -d "/sys/module/$modname" ]] ; then
+			# Module is loaded, but already disabled
+			return 0
+		fi
+		warn "patch module $modname is not loaded"
+		return 1
 	fi
 
 	if [[ "$(cat "$enabled")" -eq 1 ]]; then


### PR DESCRIPTION
Currently "kpatch force unload <klp_some_version>" will fail to unload
an old kernel live patch module that is no longer seeing any use, when
the "enabled" file for that module is no longer present.

Check for the presence of such modules by checking /sys/module, and
return success from disable_patch() for a module that is already
disabled.

This allows "kpatch force unload <klp_some_version>" to succeed for
already disabled modules.

Signed-off-by: Rik van Riel <riel@surriel.com>