### PR TITLE
kpatch build dependency cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ UNITTEST_DIR = test/unit
 INTEGRATION_DIR = test/integration
 CLEAN_DIRS  += clean-$(UNITTEST_DIR)
 
-.PHONY: all install uninstall clean check unit
+.PHONY: all dependencies install uninstall clean check unit
 .PHONY: $(SUBDIRS) $(BUILD_DIRS) $(INSTALL_DIRS) $(CLEAN_DIRS)
 .PHONY: integration integration-slow integration-quick
 .PHONY: vagrant-integration-slow vagrant-integration-quick vagrant-integration
@@ -20,6 +20,10 @@ CLEAN_DIRS  += clean-$(UNITTEST_DIR)
 all: $(BUILD_DIRS)
 $(BUILD_DIRS):
 	$(MAKE) -C $(@:build-%=%)
+
+dependencies: SHELL:=/bin/bash
+dependencies:
+	source test/integration/lib.sh && kpatch_dependencies
 
 install: $(INSTALL_DIRS)
 $(INSTALL_DIRS):

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ CLEAN_DIRS  += clean-$(UNITTEST_DIR)
 .PHONY: integration integration-slow integration-quick
 .PHONY: vagrant-integration-slow vagrant-integration-quick vagrant-integration
 .PHONY: vagrant-install
+.PHONY: help
 
 
 all: $(BUILD_DIRS)
@@ -71,3 +72,24 @@ check:
 		   test/integration/lib.sh test/integration/rebase-patches	\
 		   test/integration/test-vagrant				\
 		   test/integration/vm-integration-run
+
+help:
+	@echo "kpatch Makefile"
+	@echo
+	@echo "Targets:"
+	@echo "    make dependencies                 install build dependencies [1]"
+	@echo "    make all                          build entire project"
+	@echo "    make install                      install programs to system [1]"
+	@echo "    make uninstall                    remove programs from system [1]"
+	@echo "    make clean                        clean build files"
+	@echo
+	@echo "Test targets:"
+	@echo "    make check                        run static code analyzers"
+	@echo "    make integration                  build and run integration tests [2]"
+	@echo "    make integration-slow             build and run integration tests [2]"
+	@echo "    make integration-quick            build and run integration tests [2]"
+	@echo "    make unit                         run unit tests"
+	@echo
+	@echo "[1] requires admin privileges"
+	@echo "[2] installs test kpatch kernel modules, run at your own risk"
+	@echo

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -32,9 +32,8 @@ architecture is supported.
 Install the dependencies for compiling kpatch and running kpatch-build:
 
 ```bash
-source test/integration/lib.sh
 # Will request root privileges
-kpatch_dependencies
+make dependencies
 ```
 
 ### Oracle Linux 7
@@ -78,12 +77,12 @@ ccache --max-size=5G
 Install the dependencies for compiling kpatch and running kpatch-build
 
 ```bash
-source test/integration/lib.sh
 # required on ppc64le
 # e.g., on Ubuntu 18.04 for gcc-7.3
 apt-get install gcc-7-plugin-dev
+
 # Will request root privileges
-kpatch_dependencies
+make dependencies
 ```
 
 ### Debian 9 (Stretch)
@@ -200,9 +199,8 @@ to see its documents. This document describes how to run mainline kpatch in open
 Install the dependencies for compiling kpatch and running kpatch-build:
 
 ```bash
-source test/integration/lib.sh
 # Will request root privileges
-kpatch_dependencies
+make dependencies
 ```
 
 Before running kpatch-build, two more things need to be checked:

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -7,23 +7,6 @@ kpatch_set_ccache_max_size()
 	ccache --max-size="${ccache_max_size}"
 }
 
-kpatch_fedora_dependencies()
-{
-	local kernel_version
-	kernel_version=$(uname -r)
-
-	sudo dnf install -y gcc "kernel-devel-${kernel_version%.*}" elfutils elfutils-devel
-	sudo dnf install -y pesign yum-utils openssl wget numactl-devel
-	sudo dnf builddep -y "kernel-${kernel_version%.*}"
-	sudo dnf debuginfo-install -y "kernel-${kernel_version%.*}"
-
-	sudo dnf install -y ccache
-
-	if [[ "$(uname -m)" == "ppc64le" ]]; then
-		sudo yum install -y gcc-plugin-devel
-	fi
-}
-
 kpatch_ubuntu_dependencies()
 {
 	sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list
@@ -98,29 +81,12 @@ kpatch_rhel_dependencies()
 
 kpatch_centos_dependencies()
 {
-	local kernel_version
-	local arch
-	local rhel_major
-	kernel_version=$(uname -r)
-	arch=$(uname -m)
-	rhel_major=${VERSION_ID%%.*}
+	kpatch_rhel_dependencies
+}
 
-	sudo yum install -y gcc gcc-c++ "kernel-devel-${kernel_version%.*}" elfutils elfutils-devel
-	sudo yum install -y yum-utils zlib-devel binutils-devel newt-devel \
-		python-devel perl-ExtUtils-Embed audit-libs-devel numactl-devel \
-		pciutils-devel bison ncurses-devel rpm-build java-devel pesign
-	sudo yum-config-manager --enable debug
-	sudo yum-builddep -y "kernel-${kernel_version%.*}"
-	sudo debuginfo-install -y "kernel-${kernel_version%.*}"
-
-	# ccache
-	if ! command -v ccache &> /dev/null; then
-		if ! sudo yum install -y ccache; then
-			sudo yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${rhel_major}.noarch.rpm" && \
-			sudo yum install -y ccache && \
-			sudo yum remove -y epel-release
-		fi
-	fi
+kpatch_fedora_dependencies()
+{
+	kpatch_rhel_dependencies
 }
 
 kpatch_openEuler_dependencies()

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -91,17 +91,24 @@ kpatch_rhel_dependencies()
 			;;
 	esac
 
-	sudo yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-	sudo yum install -y ccache
-	sudo yum remove -y epel-release
+	# ccache
+	if ! command -v ccache &> /dev/null; then
+		if ! sudo yum install -y ccache; then
+			sudo yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${rhel_major}.noarch.rpm" && \
+			sudo yum install -y ccache && \
+			sudo yum remove -y epel-release
+		fi
+	fi
 }
 
 kpatch_centos_dependencies()
 {
 	local kernel_version
 	local arch
+	local rhel_major
 	kernel_version=$(uname -r)
 	arch=$(uname -m)
+	rhel_major=${VERSION_ID%%.*}
 
 	sudo yum install -y gcc gcc-c++ "kernel-devel-${kernel_version%.*}" elfutils elfutils-devel
 	sudo yum install -y yum-utils zlib-devel binutils-devel newt-devel \
@@ -111,9 +118,14 @@ kpatch_centos_dependencies()
 	sudo yum-builddep -y "kernel-${kernel_version%.*}"
 	sudo debuginfo-install -y "kernel-${kernel_version%.*}"
 
-	sudo yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
-	sudo yum install -y ccache
-	sudo yum remove -y epel-release
+	# ccache
+	if ! command -v ccache &> /dev/null; then
+		if ! sudo yum install -y ccache; then
+			sudo yum install -y "https://dl.fedoraproject.org/pub/epel/epel-release-latest-${rhel_major}.noarch.rpm" && \
+			sudo yum install -y ccache && \
+			sudo yum remove -y epel-release
+		fi
+	fi
 }
 
 kpatch_openEuler_dependencies()


### PR DESCRIPTION
`yum-builddep kernel` has been bugging me for a _long_ time.  Sometimes it installs all kernel build dependencies, other times it leaves out obvious packages like bison, flex, bc, etc.  The RHEL kernel.spec file is not the most straightforward specfile and I think effort has gone into paring down a minimal dependency set (think about skipping debug builds, kABI, all the other things that the specfile can do).  Whether specfile complexity is the root cause or not, the result is that I have to often install additional packages after running test/integration/lib.sh's **kpatch_dependencies()** function.

This patchset modifies **kpatch_dependencies()**'s `yum-builddep` invocation to add `--skip-unavailable`, which in my limited tests, seems to render a more complete dependency install.  My theory is that without the flag, yum bails out early once it encounters a package it can't install (perhaps a dep for another architecture).  With the flag, many more packages do get installed, at least the ones that kpatch-build's kernel build actually requires.

A few cleanups were added along the way, including a few top-level Makefile flourishes that I thought would be helpful.