### PR TITLE
rewrite the is_bundleable function

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3817,7 +3817,8 @@ int main(int argc, char *argv[])
 	if (arguments.klp_arch)
 		KLP_ARCH = true;
 
-	elf_version(EV_CURRENT);
+	if (elf_version(EV_CURRENT) == EV_NONE)
+		ERROR("ELF library initialisation failed \n");
 
 	orig_obj      = arguments.args[0];
 	patched_obj   = arguments.args[1];


### PR DESCRIPTION
The implementation of "is_bundleable" function has too many cases.
I summarize these cases and provide a new implementation.