### PR TITLE
create-diff-object: add support for .return_sites section (x86)

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2090,6 +2090,11 @@ static int retpoline_sites_group_size(struct kpatch_elf *kelf, int offset)
 	return 4;
 }
 
+static int return_sites_group_size(struct kpatch_elf *kelf, int offset)
+{
+	return 4;
+}
+
 static int fixup_entry_group_size(struct kpatch_elf *kelf, int offset)
 {
 	static int size = 0;
@@ -2226,6 +2231,11 @@ static struct special_section special_sections[] = {
 		.name		= ".retpoline_sites",
 		.arch		= X86_64,
 		.group_size	= retpoline_sites_group_size,
+	},
+	{
+		.name		= ".return_sites",
+		.arch		= X86_64,
+		.group_size	= return_sites_group_size,
 	},
 	{
 		.name		= "__ftr_fixup",


### PR DESCRIPTION
Fixes https://github.com/dynup/kpatch/issues/1280

Simple test with this change applied:
```
[vagrant@fedora36 linux-5.18.11-200.local.fc36.x86_64]$ cat meminfo-string.diff 
diff --git a/fs/proc/meminfo.c b/fs/proc/meminfo.c
index 6fa761c9..c1a3ab6c 100644
--- a/fs/proc/meminfo.c
+++ b/fs/proc/meminfo.c
@@ -55,6 +55,7 @@ static int meminfo_proc_show(struct seq_file *m, void *v)
        sreclaimable = global_node_page_state_pages(NR_SLAB_RECLAIMABLE_B);
        sunreclaim = global_node_page_state_pages(NR_SLAB_UNRECLAIMABLE_B);
 
+       seq_printf(m, "I can haz kpatch?\n");
        show_val_kb(m, "MemTotal:       ", i.totalram);
        show_val_kb(m, "MemFree:        ", i.freeram);
        show_val_kb(m, "MemAvailable:   ", available);

[vagrant@fedora36 linux-5.18.11-200.local.fc36.x86_64]$ kpatch-build -s . meminfo-string.diff
Using source directory at /home/vagrant/kernel/kernel-5.18.11/linux-5.18.11-200.local.fc36.x86_64
Testing patch file(s)
Reading special section data
Building original source
Building patched source
Extracting new and modified ELF sections
meminfo.o: changed function: meminfo_proc_show
Patched objects: vmlinux
Building patch module: livepatch-meminfo-string.ko
SUCCESS

[vagrant@fedora36 linux-5.18.11-200.local.fc36.x86_64]$ sudo kpatch load livepatch-meminfo-string.ko
loading patch module: livepatch-meminfo-string.ko
waiting (up to 15 seconds) for patch transition to complete...
transition complete (2 seconds)

[vagrant@fedora36 linux-5.18.11-200.local.fc36.x86_64]$ head -1 /proc/meminfo 
I can haz kpatch?
```

/cc @joe-lawrence @jpoimboe
