### PR TITLE
kpatch-cc: fix stripping of source tree prefix

### DIFF
--- a/kpatch-build/kpatch-cc
+++ b/kpatch-build/kpatch-cc
@@ -23,7 +23,7 @@ if [[ "$TOOLCHAINCMD" =~ ^(.*-)?gcc$ || "$TOOLCHAINCMD" =~ ^(.*-)?clang$ ]] ; th
 			[[ "$obj" = */.tmp_mc_*.o ]] && break;
 
 			[[ "$obj" = */.tmp_*.o ]] && obj="${obj/.tmp_/}"
-			relobj=${obj//$KPATCH_GCC_SRCDIR\//}
+			relobj=${obj##$KPATCH_GCC_SRCDIR/}
 			case "$relobj" in
 				*.mod.o|\
 				*built-in.o|\


### PR DESCRIPTION
To support building out-of-tree kernel modules, the source tree prefix
is attempted to be stripped from change object file paths to make them
relative. However, if the path is already relative, the change can
strip a substring instead, resulting in build errors.

Ensure just the prefix is stripped instead of any substring.

Fixes: #1282
Fixes: 51a8fad34ff3 ("Add support for building out-of-tree modules")