### PR TITLE
kpatch-build: use err.h instead of error.h for musl support

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <error.h>
+#include <err.h>
 #include <gelf.h>
 #include <argp.h>
 #include <libgen.h>
@@ -56,7 +56,7 @@
 #define DIFF_FATAL(format, ...) \
 ({ \
 	fprintf(stderr, "ERROR: %s: " format "\n", childobj, ##__VA_ARGS__); \
-	error(EXIT_STATUS_DIFF_FATAL, 0, "unreconcilable difference"); \
+	err(EXIT_STATUS_DIFF_FATAL, "unreconcilable difference"); \
 })
 
 char *childobj;

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -27,7 +27,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
-#include <error.h>
+#include <err.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 

--- a/kpatch-build/log.h
+++ b/kpatch-build/log.h
@@ -1,7 +1,7 @@
 #ifndef _LOG_H_
 #define _LOG_H_
 
-#include <error.h>
+#include <err.h>
 #include "kpatch.h"
 
 /* Files that include log.h must define loglevel and childobj */
@@ -9,7 +9,7 @@ extern enum loglevel loglevel;
 extern char *childobj;
 
 #define ERROR(format, ...) \
-	error(EXIT_STATUS_ERROR, 0, "ERROR: %s: %s: %d: " format, childobj, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+	err(EXIT_STATUS_ERROR, "ERROR: %s: %s: %d: " format, childobj, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define log_debug(format, ...) log(DEBUG, format, ##__VA_ARGS__)
 #define log_normal(format, ...) log(NORMAL, "%s: " format, childobj, ##__VA_ARGS__)

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <error.h>
+#include <err.h>
 #include <gelf.h>
 #include <unistd.h>
 #include <libgen.h>


### PR DESCRIPTION
Musl libc doesn't support error.h
Moving to err.h would allow using it on Musl system