### PR TITLE
kpatch-build: fix KBUILD_MODNAME for OOT modules

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1100,6 +1100,7 @@ for i in $FILES; do
 			SYMVERS_FILE="$BUILDDIR/Module.symvers"
 		elif [[ "$(basename "$KOBJFILE")" = "$(basename "$OOT_MODULE")" ]]; then
 			KOBJFILE_NAME="$(basename --suffix=.ko "$OOT_MODULE")"
+			KOBJFILE_NAME="${KOBJFILE_NAME//-/_}"
 			KOBJFILE_PATH="$OOT_MODULE"
 			SYMTAB="${TEMPDIR}/module/${KOBJFILE_NAME}.symtab"
 			SYMVERS_FILE="$TEMPDIR/Module.symvers"


### PR DESCRIPTION
For consistency with what the kernel does (and what we already do for
in-tree modules), if the file has any dashes ('-'), replace them with
underscores in the objname (aka KBUILD_MODNAME).

Fixes #1286.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>