### PR TITLE
kpatch-build: rela section could disappear after patched

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -974,7 +974,7 @@ static void kpatch_correlate_section(struct section *sec_orig,
 		__kpatch_correlate_section(sec_orig->base, sec_patched->base);
 		sec_orig = sec_orig->base;
 		sec_patched = sec_patched->base;
-	} else if (sec_orig->rela) {
+	} else if (sec_orig->rela && sec_patched->rela) {
 		__kpatch_correlate_section(sec_orig->rela, sec_patched->rela);
 	}
 


### PR DESCRIPTION
Hi, guys. I meet a segment fault when I use the Kpatch.

My patch is

```
From d4238410bab5b907ee514c15ab4d9109d6da2796 Mon Sep 17 00:00:00 2001
From: Luo Longjun <luolongjuna@gmail.com>
Date: Wed, 14 Sep 2022 16:38:28 +0800
Subject: [PATCH] kpatch test

---
 fs/proc/version.c | 6 +-----
 1 file changed, 1 insertion(+), 5 deletions(-)

diff --git a/fs/proc/version.c b/fs/proc/version.c
index b449f186577f..734ddfc7d316 100644
--- a/fs/proc/version.c
+++ b/fs/proc/version.c
@@ -6,12 +6,8 @@
 #include <linux/seq_file.h>
 #include <linux/utsname.h>
 
-static int version_proc_show(struct seq_file *m, void *v)
+notrace noinline static int version_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, linux_proc_banner,
-		utsname()->sysname,
-		utsname()->release,
-		utsname()->version);
 	return 0;
 }
 
-- 
2.37.3
```


My test environment:

```
NAME="Fedora Linux"
VERSION="36 (Server Edition)"
ID=fedora
VERSION_ID=36
VERSION_CODENAME=""
PLATFORM_ID="platform:f36"
PRETTY_NAME="Fedora Linux 36 (Server Edition)"
ANSI_COLOR="0;38;2;60;110;180"
LOGO=fedora-logo-icon
CPE_NAME="cpe:/o:fedoraproject:fedora:36"
HOME_URL="https://fedoraproject.org/"
DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f36/system-administrators-guide/"
SUPPORT_URL="https://ask.fedoraproject.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="Fedora"
REDHAT_BUGZILLA_PRODUCT_VERSION=36
REDHAT_SUPPORT_PRODUCT="Fedora"
REDHAT_SUPPORT_PRODUCT_VERSION=36
PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
VARIANT="Server Edition"
VARIANT_ID=server
```


The output of the Kpatch:

```
WARNING: Skipping compiler version matching check (not recommended)
Using cache at /home/anatasluo/.kpatch/src
Testing patch file(s)
Reading special section data
Building original source
Building patched source
Extracting new and modified ELF sections
/home/anatasluo/Git/kpatch/kpatch-build/kpatch-build: line 1082: 2901326 Segmentation fault      (core dumped) "$TOOLSDIR"/create-diff-object $CDO_FLAGS "orig/$i" "patched/$i" "$KOBJFILE_NAME" "$SYMTAB" "$SYMVERS_FILE" "${MODNAME//-/_}" "output/$i" 2>&1
     2901327 Done                    | logger 1
ERROR: create-diff-object SIGSEGV
ERROR: There was a SIGSEGV, but no core dump was found in the current directory.  Depending on your distro you might find it in /var/lib/systemd/coredump or /var/crash.. Check /home/anatasluo/.kpatch/build.log for more details.
```


After patched, the function of 'version_proc_show' has no rela entries. So it has no corresponding rela section.
In common cases, each function will have at least two rela entries in X86. One is from trace mechanism, this rela entry can be removed by the 'notrace' macro. Another is from the return thunk mechanism, make 'CONFIG_RETHUNK=n' can remove it. Fedora 36 disables this config. So this problem mainly can appear in fedora36.
