### PR TITLE
kpatch-build: strengthen conditions for changed sections

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -579,7 +579,9 @@ static void kpatch_compare_correlated_section(struct section *sec)
 	}
 
 	if (sec1->sh.sh_size != sec2->sh.sh_size ||
-	    sec1->data->d_size != sec2->data->d_size) {
+	    sec1->data->d_size != sec2->data->d_size ||
+		(sec1->rela && !sec2->rela) ||
+		(sec2->rela && !sec1->rela)) {
 		sec->status = CHANGED;
 		goto out;
 	}


### PR DESCRIPTION
Based on this [kpatch-build: rela section could disappear after patched](https://github.com/dynup/kpatch/pull/1301).

I found another problem, considering the following example in X86.

original code:
```
__noreturn noinline int kpatch_func(void)
{
	while(1) { };
}
EXPORT_SYMBOL(kpatch_func);
```

patched code:
```
__noreturn notrace noinline int kpatch_func(void)
{
	asm(".byte 0xe8, 0x00, 0x00, 0x00, 0x00");
	while(1) { };
}
EXPORT_SYMBOL(kpatch_func);
```

These two functions are different, but the output of Kpatch is
`
ERROR: no functional changes found.
`

The problem is explained in the log:

------------------------------

If two sections want to be the same, they need to satisfy
two conditions:

1) the result of memcpy is zero, which means they have the same content.

2) they have the same relocation entries.

In one specific situation, two sections have the same content.
But one section has relocation entries while the other one has
no relocation entries. For example, in X86, consider the
following code:

original code
```
__noreturn noinline int kpatch_func(void)
{
	while(1) {};
}
```

patched code
```
__noreturn notrace noinline int kpatch_func(void)
{
	asm(".byte 0xe8, 0x00, 0x00, 0x00, 0x00");
	while(1){};
}
```

Since the original code has a fentry call, these two functions have
the same compile result. But obviously, they are different functions.
Currently, Kpatch would not find their differences since the patched
code has no relocation entries.

For the situation that one section has relocation entries while the
other one doesn't have, it should be set to be changed directly.

------------------------------

I am not sure if it is useful for Kpatch, so I open another PR.
