### PR TITLE
test/unit: update for .eh_frame removal

### DIFF
--- a/test/unit/Makefile.include
+++ b/test/unit/Makefile.include
@@ -28,7 +28,7 @@ SYMVERS_FILE = $(if $(wildcard $(TNAME).$(EXT_SYMVERS)),$(TNAME).$(EXT_SYMVERS),
 
 define check_stripped =
 	$(if $(shell readelf --debug-dump $(1)),
-		$(error $(1) is not properly stripped, use 'strip --strip-debug --keep-file-symbols $(1)' to fix this),
+		$(error $(1) is not properly stripped, use 'strip --strip-debug --keep-file-symbols --remove-section=.eh_frame $(1)' to fix this),
 	)
 endef
 


### PR DESCRIPTION
Update the unit test submodule reference to include ppc64le files w/o .eh_frame.  At the same time, give additional guidance on stripping these sections going forward.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>