### PR TITLE
Collection of small llvm fixes

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2718,7 +2718,8 @@ static void kpatch_mark_ignored_sections(struct kpatch_elf *kelf)
 	list_for_each_entry(sec, &kelf->sections, list) {
 		if (!strncmp(sec->name, ".discard", 8) ||
 		    !strncmp(sec->name, ".rela.discard", 13) ||
-		    !strncmp(sec->name, ".llvm_addrsig", 13))
+		    !strncmp(sec->name, ".llvm_addrsig", 13) ||
+		    !strncmp(sec->name, ".llvm.", 6))
 			sec->ignore = 1;
 	}
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2717,7 +2717,8 @@ static void kpatch_mark_ignored_sections(struct kpatch_elf *kelf)
 	/* Ignore any discarded sections */
 	list_for_each_entry(sec, &kelf->sections, list) {
 		if (!strncmp(sec->name, ".discard", 8) ||
-		    !strncmp(sec->name, ".rela.discard", 13))
+		    !strncmp(sec->name, ".rela.discard", 13) ||
+		    !strncmp(sec->name, ".llvm_addrsig", 13))
 			sec->ignore = 1;
 	}
 


### PR DESCRIPTION
These are spun out of @swine's patchset #1302 in the interest of upstreaming sooner than the arm64 changes.  This set pulls out the non-arm64 specific llvm fixes.  I made minor changes along the way to align a little closer to the project commit/code conventions.  Internal x86 clang integration tests passed.