### PR TITLE
gcc-plugin: update headers for gcc-12

### DIFF
--- a/kpatch-build/gcc-plugins/ppc64le-plugin.c
+++ b/kpatch-build/gcc-plugins/ppc64le-plugin.c
@@ -1,5 +1,5 @@
-#include "gcc-common.h"
 #include <error.h>
+#include "gcc-common.h"
 
 #define PLUGIN_NAME "ppc64le-plugin"
 


### PR DESCRIPTION
Fix build error seen on gcc (GCC) 12.1.1 20220507 (Red Hat 12.1.1-1):

  g++ -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare -Wno-sign-conversion -g -Werror -shared -I/usr/lib/gcc/ppc64le-redhat-linux/12/plugin/include -Igcc-plugins -fPIC -fno-rtti -O2 -Wall gcc-plugins/ppc64le-plugin.c -o gcc-plugins/ppc64le-plugin.so
  In file included from /usr/include/features.h:490,
                   from /usr/include/bits/libc-header-start.h:33,
                   from /usr/include/stdio.h:27,
                   from /usr/lib/gcc/ppc64le-redhat-linux/12/plugin/include/system.h:46,
                   from /usr/lib/gcc/ppc64le-redhat-linux/12/plugin/include/gcc-plugin.h:28,
                   from gcc-plugins/gcc-common.h:6,
                   from gcc-plugins/ppc64le-plugin.c:1:
  /usr/include/bits/error-ldbl.h:23:1: error: type of ‘error’ is unknown
     23 | __LDBL_REDIR_DECL (error)
        | ^~~~~~~~~~~~~~~~~
  /usr/include/bits/error-ldbl.h:23:1: error: ‘int error’ redeclared as different kind of entity
     23 | __LDBL_REDIR_DECL (error)
        | ^~~~~~~~~~~~~~~~~
  In file included from gcc-plugins/ppc64le-plugin.c:2:
  /usr/include/error.h:31:13: note: previous declaration ‘void error(int, int, const char*, ...)’
     31 | extern void error (int __status, int __errnum, const char *__format, ...)
        |             ^~~~~
  make[1]: *** [Makefile:39: gcc-plugins/ppc64le-plugin.so] Error 1

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>