### PR TITLE
kpatch-build: relax vmlinux "Linux version" grep

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -806,7 +806,7 @@ if [[ -n "$USERSRCDIR" ]]; then
 	[[ ! -e "$VMLINUX" ]] && die "can't find vmlinux"
 
 	# Extract the target kernel version from vmlinux in this case.
-	VMLINUX_VER="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
+	VMLINUX_VER="$(strings "$VMLINUX" | grep -m1 -o -e 'Linux version \S*' | awk '{print $3}')"
 	if [[ -n "$ARCHVERSION" ]]; then
 		if [[ -n "$VMLINUX_VER" ]] && [[ "$ARCHVERSION" != "$VMLINUX_VER" ]]; then
 			die "Kernel version mismatch: $ARCHVERSION was specified but vmlinux was built for $VMLINUX_VER"


### PR DESCRIPTION
When determining the linux version from a vmlinux file, we assume that `strings` output will show "Linux version <version>" at the beginning of the line.

This assumption was observed to not hold true for clang on s390x:

  $ strings ./build/linux-5.18/vmlinux | grep -m1 -e "Linux version"
  mY*Linux version 5.18.0 (root@xyz.com) (clang version 14.0.5 (Fedora 14.0.5-1.fc36), GNU ld version 2.37-36.fc36) #7 SMP Wed Oct 19 12:47:00 EDT 2022

Relax the regular expression to look for "Linux version <word>", but not anchored at the beginning of the line.

Reported-by: Yulia Kopkova <ykopkova@redhat.com>
Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>