### PR TITLE
three fix of elf file creation

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1558,9 +1558,9 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 				start = sym->sym.st_value;
 				end = sym->sym.st_value + sym->sym.st_size;
 
-				if (is_text_section(relasec->base) &&
+				if (rela->type == R_X86_64_32S &&
+				    is_text_section(relasec->base) &&
 				    !is_text_section(sym->sec) &&
-				    rela->type == R_X86_64_32S &&
 				    rela->addend == (long)sym->sec->sh.sh_size &&
 				    end == (long)sym->sec->sh.sh_size) {
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2705,8 +2705,9 @@ static void kpatch_include_debug_sections(struct kpatch_elf *kelf)
 		if (!is_rela_section(sec) || !is_debug_section(sec))
 			continue;
 		list_for_each_entry_safe(rela, saferela, &sec->relas, list)
-			if (!rela->sym->sec->include)
+			if (!rela->sym->include || !rela->sym->sec->include) {
 				list_del(&rela->list);
+			}
 	}
 }
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1544,6 +1544,10 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 
 			target_off = rela_target_offset(kelf, relasec, rela);
 
+			if (target_off >= (long)rela->sym->sec->sh.sh_size)
+				continue;
+
+			found = false;
 			/*
 			 * Attempt to replace references to unbundled sections
 			 * with their symbols.

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -946,6 +946,7 @@ void kpatch_write_output_elf(struct kpatch_elf *kelf, Elf *elf, char *outfile,
 	memset(&ehout, 0, sizeof(ehout));
 	ehout.e_ident[EI_DATA] = eh.e_ident[EI_DATA];
 	ehout.e_machine = eh.e_machine;
+	ehout.e_flags = eh.e_flags;
 	ehout.e_type = eh.e_type;
 	ehout.e_version = EV_CURRENT;
 


### PR DESCRIPTION
Hi Josh,
 We are preparing to support a new architecture:LoongArch . But we find some common problems of this tool,So I think we can submit the common patches firstly,Then the fllowing LoongArch support.
These three patches solve the following problem:
1. e_flags is not written in the end file,we should save it,beause it holds processor-specific flags.
2. clean up the symbol replacement algorithm. When we want add LoongArch support,we find out we should add
  !strcmp(rela->sym->name, ".orc_unwind_ip"). IMO, too many compares in the code is not a good idea, so I clean the code and
  make it easy to read.
3. when one symbol is not included in the output elf file,the related rela of debug info section should also not be included. If we
  don't follow it,then the rela would refer to an not included symbol which contains random data.

Thanks
Hongchen Zhang
