### PR TITLE
kpatch:use vmlinux from first build

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -271,14 +271,29 @@ find_core_symvers() {
 }
 
 gcc_version_from_file() {
-	"$READELF" -p .comment "$1" | grep -m 1 -o 'GCC:.*'| awk '{$1=$2=""; print $0}'|awk '{gsub(/^\s+|\s+$/, "");print}'
+	"$READELF" -p .comment "$1" | grep -m 1 -o 'GCC:.*'| cut -d ' ' -f 3-
 }
 
 gcc_version_from_config() {
-    if [[ -n "$CONFIGFILE" ]]; then
-        cat "$CONFIGFILE" | grep -w "Compiler: gcc" | awk '{$1=$2=$3=$4=""; print $0}' | awk '{gsub(/^\s+|\s+$/, "");print}'
+    local gccver
+    if [[ -f "$CONFIGFILE" ]]; then
+	    # Compiler: gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-4)
+	    gccver="$(sed -n '/Compiler:/p' "$CONFIGFILE" | cut -d ' ' -f 5-)"
+	    if [[ -z "$gccver" ]];then
+		    #CONFIG_CC_VERSION_TEXT="gcc (GCC) 6.5.1 20190307 (Red Hat 6.5.1-1 2.17)"
+		    gccver="$(sed -n '/CONFIG_CC_VERSION_TEXT/p' "$CONFIGFILE" | cut -d ' ' -f 3-)"
+		    gccver=${gccver%\"*}
+	    fi
+    fi
+    echo "$gccver"
+}
+
+kernel_version_from_config() {
+    if [[ -f "$CONFIGFILE" ]]; then
+       sed -n '/Kernel Configuration/p' "$CONFIGFILE" | cut -d ' ' -f 3
     fi
 }
+
 gcc_version_check() {
 	local target="$1"
 	local c="$TEMPDIR/test.c" o="$TEMPDIR/test.o"
@@ -813,7 +828,9 @@ if [[ -n "$USERSRCDIR" ]]; then
 
 	[[ -z "$VMLINUX" ]] && VMLINUX="$KERNEL_SRCDIR"/vmlinux
 	# Extract the target kernel version from vmlinux in this case.
-	VMLINUX_VER="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
+	if [[ -f "$VMLINUX" ]]; then
+		VMLINUX_VER="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
+	fi
 	if [[ -n "$ARCHVERSION" ]]; then
 		if [[ -n "$VMLINUX_VER" ]] && [[ "$ARCHVERSION" != "$VMLINUX_VER" ]]; then
 			die "Kernel version mismatch: $ARCHVERSION was specified but vmlinux was built for $VMLINUX_VER"
@@ -823,6 +840,9 @@ if [[ -n "$USERSRCDIR" ]]; then
 			die "Unable to determine the kernel version from vmlinux"
 		fi
 		ARCHVERSION="$VMLINUX_VER"
+        if [[ -z "$ARCHVERSION" ]] && [[ -f "$CONFIGFILE" ]]; then
+            ARCHVERSION="$(kernel_version_from_config)"
+        fi
 	fi
 fi
 

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -271,9 +271,14 @@ find_core_symvers() {
 }
 
 gcc_version_from_file() {
-	"$READELF" -p .comment "$1" | grep -m 1 -o 'GCC:.*'
+	"$READELF" -p .comment "$1" | grep -m 1 -o 'GCC:.*'| awk '{$1=$2=""; print $0}'|awk '{gsub(/^\s+|\s+$/, "");print}'
 }
 
+gcc_version_from_config() {
+    if [[ -n "$CONFIGFILE" ]]; then
+        cat "$CONFIGFILE" | grep -w "Compiler: gcc" | awk '{$1=$2=$3=$4=""; print $0}' | awk '{gsub(/^\s+|\s+$/, "");print}'
+    fi
+}
 gcc_version_check() {
 	local target="$1"
 	local c="$TEMPDIR/test.c" o="$TEMPDIR/test.o"
@@ -284,7 +289,11 @@ gcc_version_check() {
 	echo 'void main(void) {}' > "$c"
 	out="$("$GCC" -c -pg -ffunction-sections -o "$o" "$c" 2>&1)"
 	gccver="$(gcc_version_from_file "$o")"
+    if [[ -f "$target" ]]; then
 	kgccver="$(gcc_version_from_file "$target")"
+    else
+        kgccver="$(gcc_version_from_config)"
+    fi
 
 	if [[ -n "$out" ]]; then
 		warn "gcc >= 4.8 required for -pg -ffunction-settings"
@@ -803,8 +812,6 @@ if [[ -n "$USERSRCDIR" ]]; then
 	KERNEL_SRCDIR="$USERSRCDIR"
 
 	[[ -z "$VMLINUX" ]] && VMLINUX="$KERNEL_SRCDIR"/vmlinux
-	[[ ! -e "$VMLINUX" ]] && die "can't find vmlinux"
-
 	# Extract the target kernel version from vmlinux in this case.
 	VMLINUX_VER="$(strings "$VMLINUX" | grep -m 1 -e "^Linux version" | awk '{ print($3); }')"
 	if [[ -n "$ARCHVERSION" ]]; then
@@ -812,7 +819,7 @@ if [[ -n "$USERSRCDIR" ]]; then
 			die "Kernel version mismatch: $ARCHVERSION was specified but vmlinux was built for $VMLINUX_VER"
 		fi
 	else
-		if [[ -z "$VMLINUX_VER" ]]; then
+		if [[ -z "$VMLINUX_VER" ]] && [[ -f "$VMLINUX" ]]; then
 			die "Unable to determine the kernel version from vmlinux"
 		fi
 		ARCHVERSION="$VMLINUX_VER"
@@ -1090,8 +1097,6 @@ fi
 export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections \
 		$ARCH_KCFLAGS $DEBUG_KCFLAGS"
 
-echo "Reading special section data"
-find_special_section_data
 
 if [[ $DEBUG -ge 4 ]]; then
 	export KPATCH_GCC_DEBUG=1
@@ -1122,6 +1127,9 @@ fi
 # $TARGETS used as list, no quotes.
 # shellcheck disable=SC2086
 make "${MAKEVARS[@]}" "-j$CPUS" $TARGETS 2>&1 | logger || die
+
+echo "Reading special section data"
+find_special_section_data
 
 # Save original module symvers
 cp -f "$BUILDDIR/Module.symvers" "$TEMPDIR/Module.symvers" || die


### PR DESCRIPTION
We can use the first compiled vmlinux file from origin source code, and  get the gcc version from the config file ，so we don't have to download kernel debuginfo(it's too big),and use kpatch-build command without '-v'

Signed-off-by: yinbinbin <yinbinbin001@linux.alibaba.com>