### PR TITLE
kpatch-build: fix "make check"

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -452,12 +452,12 @@ relpath() {
 		return
 	fi
 
-	while [[ "${filedir#$common/}" = "$filedir" ]]; do
+	while [[ "${filedir#"$common"/}" = "$filedir" ]]; do
 		common="$(dirname "$common")"
 		result="../$result"
 	done
 
-	result="${result}${filedir#$common/}"
+	result="${result}${filedir#"$common"/}"
 	echo "${result}/$(basename "$file")"
 }
 

--- a/kpatch-build/kpatch-cc
+++ b/kpatch-build/kpatch-cc
@@ -23,7 +23,7 @@ if [[ "$TOOLCHAINCMD" =~ ^(.*-)?gcc$ || "$TOOLCHAINCMD" =~ ^(.*-)?clang$ ]] ; th
 			[[ "$obj" = */.tmp_mc_*.o ]] && break;
 
 			[[ "$obj" = */.tmp_*.o ]] && obj="${obj/.tmp_/}"
-			relobj=${obj##$KPATCH_GCC_SRCDIR/}
+			relobj=${obj##"$KPATCH_GCC_SRCDIR"/}
 			case "$relobj" in
 				*.mod.o|\
 				*built-in.o|\


### PR DESCRIPTION
For some reason the github version of 'make check' just started complaining about these:
```
shellcheck kpatch/kpatch kpatch-build/kpatch-build kpatch-build/kpatch-cc

In kpatch-build/kpatch-build line 455:
	while [[ "${filedir#$common/}" = "$filedir" ]]; do
                            ^-----^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean:
	while [[ "${filedir#"$common"/}" = "$filedir" ]]; do

In kpatch-build/kpatch-build line 460:
	result="${result}${filedir#$common/}"
                                   ^-----^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean:
	result="${result}${filedir#"$common"/}"

In kpatch-build/kpatch-cc line 26:
			relobj=${obj##$KPATCH_GCC_SRCDIR/}
                                      ^----------------^ SC2295 (info): Expansions inside ${..} need to be quoted separately, otherwise they match as patterns.

Did you mean:
			relobj=${obj##"$KPATCH_GCC_SRCDIR"/}

For more information:
  https://www.shellcheck.net/wiki/SC2295 -- Expansions inside ${..} need to b...
make: *** [Makefile:70: check] Error 1
Error: Process completed with exit code 2.
```
Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>