### PR TITLE
github actions: fix warning with node 16

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       CFLAGS: ${{ matrix.cflags }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: dependencies
       run: sudo apt-get install -y libelf-dev linux-headers-$(uname -r) shellcheck elfutils
     - name: make


### PR DESCRIPTION
Attempt to fix the following warning:

  Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>