### PR TITLE
examples: add cmdline-string.patch as a compatible example

### DIFF
--- a/examples/cmdline-string.patch
+++ b/examples/cmdline-string.patch
@@ -1,0 +1,13 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2022-10-24 15:41:08.858760066 -0400
++++ src/fs/proc/cmdline.c	2022-10-24 15:41:11.698715352 -0400
+@@ -6,8 +6,7 @@
+ 
+ static int cmdline_proc_show(struct seq_file *m, void *v)
+ {
+-	seq_puts(m, saved_command_line);
+-	seq_putc(m, '\n');
++	seq_printf(m, "%s kpatch=1\n", saved_command_line);
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
This is a test example currently preferable to [proc-version.patch](https://github.com/dynup/kpatch/blob/master/examples/proc-version.patch) as crash utility has difficulty parsing /proc/version content after being altered.

Signed-off-by: Linqing Lu <lilu@redhat.com>