### PR TITLE
kpatch-build: add KERNELRELEASE to MAKEVARS

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1117,7 +1117,8 @@ if [[ -n "$CONFIG_LD_IS_LLD" ]]; then
 else
 	MAKEVARS+=("LD=${KPATCH_CC_PREFIX}${LD}")
 fi
-
+#Force the kpatch module version to be consistent with ${ARCHVERSION}
+MAKEVARS+=("KERNELRELEASE=${ARCHVERSION}")
 
 # $TARGETS used as list, no quotes.
 # shellcheck disable=SC2086


### PR DESCRIPTION
If the ${KERNEL_SRCDIR} is a git repository, `scripts/setlocalversion` will append a plus sign to the kpatch module version. This will cause a version mismatch when installing this patch module:

    invalid module version ${kernel-release} for kernel ${kernel-release}+

Use $ARCHVERSION instead.