### PR TITLE
support ubsan for kpatch

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1036,6 +1036,9 @@ static void kpatch_correlate_sections(struct list_head *seclist_orig,
 			    sec_patched->twin)
 				continue;
 
+			if (is_ubsan_sec(sec_orig->name))
+				continue;
+
 			if (is_special_static(is_rela_section(sec_orig) ?
 					      sec_orig->base->secsym :
 					      sec_orig->secsym))
@@ -1070,6 +1073,9 @@ static void kpatch_correlate_symbols(struct list_head *symlist_orig,
 		list_for_each_entry(sym_patched, symlist_patched, list) {
 			if (kpatch_mangled_strcmp(sym_orig->name, sym_patched->name) ||
 			    sym_orig->type != sym_patched->type || sym_patched->twin)
+				continue;
+
+			if (is_ubsan_sec(sym_orig->name))
 				continue;
 
 			if (is_special_static(sym_orig))
@@ -1545,6 +1551,13 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 		list_for_each_entry(rela, &relasec->relas, list) {
 
 			if (rela->sym->type != STT_SECTION || !rela->sym->sec)
+				continue;
+
+			/*
+			 * UBSAN data will be taken wholesale, no need to
+			 * replace section symbols.
+			 */
+			if (is_ubsan_sec(rela->sym->name))
 				continue;
 
 			/*

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -587,6 +587,18 @@ bool is_local_sym(struct symbol *sym)
 	return sym->bind == STB_LOCAL;
 }
 
+bool is_ubsan_sec(const char *name) {
+	if (!strncmp(name, ".data.rel.local..Lubsan_data", 28) ||
+		!strncmp(name, ".data..Lubsan_type", 18) ||
+		!strncmp(name, ".Lubsan_data", 12) ||
+		!strncmp(name, ".data..Lubsan_data", 18) ||
+		!strncmp(name, ".rela.data..Lubsan_data", 23) ||
+		!strncmp(name, ".rela.data.rel.local..Lubsan_data", 33))
+		return true;
+	else
+		return false;
+}
+
 void print_strtab(char *buf, size_t size)
 {
 	size_t i;

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -170,6 +170,7 @@ bool is_null_sym(struct symbol *sym);
 bool is_file_sym(struct symbol *sym);
 bool is_local_func_sym(struct symbol *sym);
 bool is_local_sym(struct symbol *sym);
+bool is_ubsan_sec(const char *name);
 
 void print_strtab(char *buf, size_t size);
 void kpatch_create_shstrtab(struct kpatch_elf *kelf);

--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -84,7 +84,8 @@ static bool maybe_discarded_sym(const char *name)
 	    !strncmp(name, "__func_stack_frame_non_standard_", 32) ||
 	    strstr(name, "__addressable_") ||
 	    strstr(name, "__UNIQUE_ID_") ||
-	    !strncmp(name, ".L.str", 6))
+	    !strncmp(name, ".L.str", 6) ||
+	    is_ubsan_sec(name))
 		return true;
 
 	return false;


### PR DESCRIPTION
ubsan generates .data..Lubsan_data* sections as follows:

```
1. int main(int argc, char **argv) {
    int arr[100]; 
    arr[101] = 1; 
    printf("arr[101] = %d", arr[101]); 
    return 0; 
}
```
reloc:
```
2. 1a:   50 10 b0 ac          st      %r1,172(%r11)
      int arr[100];
      arr[101] = 1;
1e:   a7 39 00 65             lghi    %r3,101
22:   c0 20 00 00 00 00       larl    %r2,22 <main+0x22>
            24: R_390_PC32DBL       .data..Lubsan_data1+0x2
28:   c0 e5 00 00 00 00       brasl   %r14,28 <main+0x28>
            2a: R_390_PLT32DBL      __ubsan_handle_out_of_bounds+0x2
```

3. ubsan data section info:
``` 
0000000000000000 <.data..Lubsan_data1>:
0: R_390_64     .rodata              <=== source_location.location->file_name
8: 00 00 00 04  .long   0x00000004   <=== source_location.location->line
c: 00 00 00 05  .long   0x00000005   <=== source_location.location->column

10: R_390_64    .data..Lubsan_type0   <== source_location->array_type
18: R_390_64    .data..Lubsan_type1   <=== source_location->index_type```
```

4. Avoid correlating the *.data.Lubsan* sections. This means included function points to new *.data.Lubsan* sections.
 
5. Misc:
 * .data..Lubsan_type section does not have symbol, hence skip this case in kpatch_replace_sections_syms()
 * skip data.ubsan* from lookup table, as this in not present in vmlinux.symtab. 

6. Fixes the issue reported in https://github.com/dynup/kpatch/issues/1328