### PR TITLE
kpatch-build: Fix setlocalversion issue with 6.3 kernel

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -166,18 +166,13 @@ remove_patches() {
 }
 
 cleanup() {
-	rm -f "$BUILDDIR/.scmversion"
-
 	remove_patches
 
-	# restore original vmlinux if it was overwritten by sourcedir build
+	# restore any files that were modified for the build
 	[[ -e "$TEMPDIR/vmlinux" ]] && mv -f "$TEMPDIR/vmlinux" "$KERNEL_SRCDIR/"
-
-	# restore original link-vmlinux.sh if we updated it for the build
 	[[ -e "$TEMPDIR/link-vmlinux.sh" ]] && mv -f "$TEMPDIR/link-vmlinux.sh" "$KERNEL_SRCDIR/scripts"
-
-	# restore original Makefile.modfinal if we updated it for the build
 	[[ -e "$TEMPDIR/Makefile.modfinal" ]] && mv -f "$TEMPDIR/Makefile.modfinal" "$KERNEL_SRCDIR/scripts"
+	[[ -e "$TEMPDIR/setlocalversion" ]] && mv -f "$TEMPDIR/setlocalversion" "$KERNEL_SRCDIR/scripts"
 
 	[[ "$DEBUG" -eq 0 ]] && rm -rf "$TEMPDIR"
 	rm -rf "$RPMTOPDIR"
@@ -989,6 +984,25 @@ if [[ -z "$OOT_MODULE" && ! "$CONFIGFILE" -ef "$KERNEL_SRCDIR"/.config ]] ; then
 	cp -f "$CONFIGFILE" "$KERNEL_SRCDIR/.config" || die
 fi
 
+# When the kernel source is in a git repo, applying the patch (plus the
+# Makefile sed hacks we do) can cause it to be built with "+" or "dirty"
+# appended to the kernel version string (VERMAGIC_STRING), even if the original
+# kernel was not dirty.  That can complicate both the build (create-diff-object
+# false positive changes) and the patch module link (module version mismatch
+# load failures).
+#
+# Prevent that by replacing the original setlocalversion with a friendlier one
+# which just echo's the original version.  This should be done before any
+# changes to the source.
+if [[ -n "$USERSRCDIR" && -e "$KERNEL_SRCDIR/.git" ]]; then
+	cd "$KERNEL_SRCDIR" || die
+	cp -f scripts/setlocalversion "$TEMPDIR" || die
+	LOCALVERSION="$(make kernelversion)"
+	LOCALVERSION="$(KERNELVERSION="$LOCALVERSION" ./scripts/setlocalversion)"
+	[[ -n "$LOCALVERSION" ]] || die "setlocalversion failed"
+	echo "echo $LOCALVERSION" > scripts/setlocalversion
+fi
+
 # kernel option checking
 
 trace_off "reading .config"
@@ -1099,7 +1113,6 @@ fi
 save_env
 
 echo "Building original source"
-[[ -n "$OOT_MODULE" ]] || ./scripts/setlocalversion --save-scmversion || die
 unset KPATCH_GCC_TEMPDIR
 
 KPATCH_CC_PREFIX="$TOOLSDIR/kpatch-cc "


### PR DESCRIPTION
kpatch-build: Fix setlocalversion issue with 6.3 kernel
    
The kernel has a VERMAGIC_STRING, e.g. "6.2.0".  The module loader uses that string to ensure that all loaded modules' version strings match the kernel's.

If the kernel source is in a git tree, and if there are uncommitted changes, the version string will have a '+' or "-dirty" appended to it, like "6.1.0+" or "6.2.0-dirty".  This dirty tree detection is done by the setlocalversion script.

This affects kpatch-build in a few ways.  When it builds the original kernel, in some cases there are uncommitted changes to the makefiles.  When it builds the patched kernel, there are additional uncommitted changes due to the .patch file being applied.

We want to avoid the VERMAGIC_STRING changing between builds.  Otherwise it would cause problems:

- object code which uses that string would change unnecessarily, causing a false positive change detected by create-diff-object

- the linked patch module would report the wrong version, resulting in the module failing to load due to version mismatch.
    
Up until now, the version was prevented from changing by running `setlocalversion --save-scmversion` before the build.  That command hard-codes the version by saving it to a file which is then automatically read later during future invocations of the kernel build.

Unfortunately that feature was removed in the 6.3 merge window with commit f6e09b07cc12 ("kbuild: do not put .scmversion into the source tarball").  So we need to come up with a new approach.

Fix it by temporarily replacing the setlocalversion script with a one-liner which just echo's the original version.  I think this is unfortunately the best we can do, as we really can't handle VERMAGIC_STRING changing, either during/between kernel builds or during the module link.

Fixes #1335.

Signed-off-by: Josh Poimboeuf <jpoimboe@redhat.com>