### PR TITLE
Draft: gcc-plugin: update gcc-common.h for gcc-13

### DIFF
--- a/kpatch-build/gcc-plugins/gcc-common.h
+++ b/kpatch-build/gcc-plugins/gcc-common.h
@@ -107,7 +107,9 @@
 #include "varasm.h"
 #include "stor-layout.h"
 #include "internal-fn.h"
+#include "gimple.h"
 #include "gimple-expr.h"
+#include "gimple-iterator.h"
 #include "gimple-fold.h"
 #include "context.h"
 #include "tree-ssa-alias.h"
@@ -129,7 +131,6 @@
 #include "tree-ssa-operands.h"
 #include "tree-phinodes.h"
 #include "tree-cfg.h"
-#include "gimple-iterator.h"
 #include "gimple-ssa.h"
 #include "ssa-iterators.h"
 #endif


### PR DESCRIPTION
Backport this kernel commit to kpatch's version of gcc-common.h:

commit e6a71160cc145e18ab45195abf89884112e02dfb
Author: Kees Cook <keescook@chromium.org>
Date:   Wed Jan 18 12:21:35 2023 -0800

    gcc-plugins: Reorganize gimple includes for GCC 13

    The gimple-iterator.h header must be included before gimple-fold.h
    starting with GCC 13. Reorganize gimple headers to work for all GCC
    versions.

    Reported-by: Palmer Dabbelt <palmer@rivosinc.com>
    Acked-by: Palmer Dabbelt <palmer@rivosinc.com>
    Link: https://lore.kernel.org/all/20230113173033.4380-1-palmer@rivosinc.com/
    Cc: linux-hardening@vger.kernel.org
    Signed-off-by: Kees Cook <keescook@chromium.org>

Note that we can't directly copy the gcc-plugin headers from the kernel as has it has dropped gcc-4.9 and older support since v5.16.  Distros like rhel-7 still use gcc-4.8, so manually cherry pick changes into the kpatch tree.