### PR TITLE
Fix shellcheck error

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -909,7 +909,7 @@ else
 		echo "Unpacking kernel source"
 
 		rpm -D "_topdir $RPMTOPDIR" -ivh "$SRCRPM" 2>&1 | logger || die
-		rpmbuild -D "_topdir $RPMTOPDIR" -bp --nodeps "--target=$(uname -m)" "$RPMTOPDIR"/SPECS/kernel$ALT.spec 2>&1 | logger ||
+		rpmbuild -D "_topdir $RPMTOPDIR" -bp --nodeps "--target=$(uname -m)" "$RPMTOPDIR/SPECS/kernel$ALT.spec" 2>&1 | logger ||
 			die "rpmbuild -bp failed.  you may need to run 'yum-builddep kernel' first."
 
 		if [[ "$DISTRO" = openEuler ]]; then
@@ -1271,7 +1271,7 @@ for i in $FILES; do
 
 		# create-diff-object orig.o patched.o parent-name parent-symtab
 		#		     Module.symvers patch-mod-name output.o
-		"$TOOLSDIR"/create-diff-object $CDO_FLAGS "orig/$i" "patched/$i" "$KOBJFILE_NAME" \
+		"$TOOLSDIR"/create-diff-object "$CDO_FLAGS" "orig/$i" "patched/$i" "$KOBJFILE_NAME" \
 			"$SYMTAB" "$SYMVERS_FILE" "${MODNAME//-/_}" \
 			"output/$i" 2>&1 | logger 1
 		check_pipe_status create-diff-object
@@ -1341,7 +1341,7 @@ cd "$TEMPDIR/patch" || die
 
 # We no longer need kpatch-cc
 for ((idx=0; idx<${#MAKEVARS[@]}; idx++)); do
-    MAKEVARS[$idx]=${MAKEVARS[$idx]/${KPATCH_CC_PREFIX}/}
+    MAKEVARS[idx]=${MAKEVARS[$idx]/${KPATCH_CC_PREFIX}/}
 done
 
 export KPATCH_BUILD="$KERNEL_SRCDIR" KPATCH_NAME="$MODNAME" \
@@ -1357,7 +1357,7 @@ if [[ "$USE_KLP" -eq 1 ]]; then
 		extra_flags="--no-klp-arch-sections"
 	fi
 	cp -f "$TEMPDIR/patch/$MODNAME.ko" "$TEMPDIR/patch/tmp.ko" || die
-	"$TOOLSDIR"/create-klp-module $extra_flags "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
+	"$TOOLSDIR"/create-klp-module "$extra_flags" "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
 	check_pipe_status create-klp-module
 	[[ "$rc" -ne 0 ]] && die "create-klp-module: exited with return code: $rc"
 fi

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -355,7 +355,6 @@ load_module () {
 			i=$((i+1))
 			if [[ $i -eq $MAX_LOAD_ATTEMPTS ]]; then
 				die "failed to load module $module"
-				break
 			else
 				warn "retrying..."
 				sleep $RETRY_INTERVAL


### PR DESCRIPTION
  Fix the following ShellCheck error.
  
      - SC2317 (info): Command appears to be unreachable. Check usage (or ignore if
        invoked indirectly).
      - SC2086 (info): Double quote to prevent globbing and word splitting.
      - SC2004 (style): $/${} is unnecessary on arithmetic variables.
