### PR TITLE
github actions: Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+name: close inactive issues
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been open for 30 days with no activity and no assignee.  It will be closed in 7 days unless a comment is added."
+          close-issue-message: "This issue was closed because it was inactive for 7 days after being marked stale."
+          days-before-pr-stale: 60
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR has been open for 60 days with no activity and no assignee.  It will be closed in 7 days unless a comment is added."
+          close-pr-message: "This PR was closed because it was inactive for 7 days after being marked stale."
+          exempt-all-assignees: true
+          ascending: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
kpatch maintainers have limited time.  While we greatly appreciate all of our contributors, unfortunately it's not uncommon for kpatch issues and PRs to get ignored for years.

Add a github workflow which marks issues/PRs stale after 30/60 days, and then closes them after an additional week of inactivity.  Anybody who cares about a particular issue/PR is welcome to help keep it open by stating their case in a comment.

The stale tag gets cleared by adding a comment to the issue/PR, or by manually removing the stale tag.

An assignee can be added to a long-term issue/PR to prevent it from getting marked stale.

The action (which adds/removes stale tags, adds comments, and closes issues/PRs) runs daily at 10:00 UTC.

Suggested-by: Joe Lawrence <joe.lawrence@redhat.com>