### PR TITLE
INSTALL.md: update OpenEuler prereqs formatting

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -203,7 +203,7 @@ Install the dependencies for compiling kpatch and running kpatch-build:
 make dependencies
 ```
 
-Before running kpatch-build, two more things need to be checked:
+#### Before running kpatch-build, two more things need to be checked:
 -------
 1. Ensure current kernel compiled with *CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY* set
 


### PR DESCRIPTION
shrinks the size of the sub-section header below  
the OpenEuler section, reducing confusion as to  
what section that is a part of, as it is only  
necessary for OpenEuler machines  