### PR TITLE
lookup: local_match can be empty

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -165,6 +165,24 @@ static bool locals_match(struct lookup_table *table, int idx,
 	return true;
 }
 
+static bool file_has_locals(struct symbol *file_sym, struct list_head *sym_list)
+{
+	struct symbol *sym = file_sym;
+
+	list_for_each_entry_continue(sym, sym_list, list) {
+		if (sym->type == STT_FILE)
+			break;
+		if (sym->bind != STB_LOCAL)
+			continue;
+		if (maybe_discarded_sym(sym->name))
+			continue;
+		if (sym->type == STT_FUNC || sym->type == STT_OBJECT)
+			return true;
+	}
+
+	return false;
+}
+
 static void find_local_syms(struct lookup_table *table, struct symbol *file_sym,
 		struct list_head *sym_list)
 {
@@ -184,6 +202,13 @@ static void find_local_syms(struct lookup_table *table, struct symbol *file_sym,
 			      file_sym->name, table->objname);
 
 		lookup_table_file_sym = sym;
+
+		/*
+		 * If the file doesn't have local symbols, any empty
+		 * match will do.  Skip the duplicate check.
+		 */
+		if (!file_has_locals(file_sym, sym_list))
+			break;
 	}
 
 	if (!lookup_table_file_sym)


### PR DESCRIPTION
symtab may have two STT_FILE symbols with the same name, but neither of them has a local symbol.
we can choose either one,
because the lookup_table_file_sym is used to match the local symbol.

for example:
in x86:
arch/x86/mm/kaslr.c have two local symbols (can modify the code to have no local symbols)
arch/x86/lib/kaslr.c have no local symbols

if we make the patch for arch/x86/lib/kaslr.c  or arch/x86/mm/kaslr.c, it will be error.