### PR TITLE
kpatch-build: skip mangling for powerpc cpu feature relocations

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1575,7 +1575,8 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 			    !strcmp(rela->sym->name, ".fixup") ||
 			    !strcmp(rela->sym->name, ".altinstr_replacement") ||
 			    !strcmp(rela->sym->name, ".altinstr_aux") ||
-			    !strcmp(rela->sym->name, ".text..refcount"))
+			    !strcmp(rela->sym->name, ".text..refcount") ||
+			    !strncmp(rela->sym->name, "__ftr_alt_", 10))
 				continue;
 
 			/*


### PR DESCRIPTION
PowerPC implements alternative instructions with __ftr_fixup and __ftr_alt_* sections, for example net/core/dev.o:

  Disassembly of section __ftr_alt_97:

  0000000000000000 <__ftr_alt_97>:
     0: 3c 00 40 7c pause_short
     4: 3c 00 40 7c pause_short
     8: 3c 00 40 7c pause_short
     c: 3c 00 40 7c pause_short

  Disassembly of section __ftr_fixup:

  0000000000000000 <__ftr_fixup>:
     0: 00 00 00 00 .long 0x0
     4: 00 00 04 00 .long 0x40000
    ...
    10: R_PPC64_REL64 .text.napi_busy_loop+0x1cc
    18: R_PPC64_REL64 .text.napi_busy_loop+0x1dc
    20: R_PPC64_REL64 __ftr_alt_97+0x20
    28: R_PPC64_REL64 __ftr_alt_97+0x2c
    34: 00 00 04 00 .long 0x40000
    ...
    40: R_PPC64_REL64 .text.napi_busy_loop+0x3c0
    48: R_PPC64_REL64 .text.napi_busy_loop+0x3d0
    50: R_PPC64_REL64 __ftr_alt_97+0x24
    58: R_PPC64_REL64 __ftr_alt_97+0x30
    64: 00 00 04 00 .long 0x40000
    ...
    70: R_PPC64_REL64 .text.napi_threaded_poll+0x170
    78: R_PPC64_REL64 .text.napi_threaded_poll+0x180
    80: R_PPC64_REL64 __ftr_alt_97+0x28
    88: R_PPC64_REL64 __ftr_alt_97+0x34
    94: 00 00 04 00 .long 0x40000
    ...
    a0: R_PPC64_REL64 .text.net_rx_action+0x1a0
    a8: R_PPC64_REL64 .text.net_rx_action+0x1b0
    b0: R_PPC64_REL64 __ftr_alt_97+0x2c
    b8: R_PPC64_REL64 __ftr_alt_97+0x38

Like .altinstr_{aux,replacement}, __ftr_alt sections don't have symbols associated with them and may skip kpatch_replace_sections_syms()'s rela mangling.  As __ftr_fixup references __ftr_alt_* directly, kpatch_process_special_sections() will already include __ftr_alt_* as part of the "group" handling in kpatch_regenerate_special_section().

Reported-by: Zhijun Wang <zhijwang@redhat.com>