### PR TITLE
kpatch-build: account for __pfx_-less NOP padding

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -399,7 +399,7 @@ static void kpatch_create_section_list(struct kpatch_elf *kelf)
 
 /*
  * Some x86 kernels have NOP function padding [1] for which objtool [2]
- * adds ELF function symbols with prefix "__pfx_" to indicate the start
+ * may add ELF function symbols with prefix "__pfx_" to indicate the start
  * of a function, inclusive of NOP-padding.  Find the prefix symbols and
  * link them to their corresponding function symbols at an expected
  * offset.
@@ -438,7 +438,7 @@ static void kpatch_create_section_list(struct kpatch_elf *kelf)
  * 0000000000000000     0 SECTION LOCAL  DEFAULT   99 .text.unlikely.__mmdrop
  * 0000000000000000    48 FUNC    LOCAL  DEFAULT   99 __mmdrop.cold
  *
- * (kpatch-build generated tmp.ko, multple functions in one section, no __pfx_ symbols)
+ * (kpatch-build generated tmp.ko, multiple functions in one section, no __pfx_ symbols)
  * 0000000000000000     0 SECTION LOCAL  DEFAULT   10 .text.unlikely.callback_info.isra.0
  * 0000000000000010    65 FUNC    LOCAL  DEFAULT   10 callback_info.isra.0
  * 0000000000000061    54 FUNC    LOCAL  DEFAULT   10 callback_info.isra.0


### PR DESCRIPTION
Some kernel configurations generate function NOP padding, but without associated __pfx_<function> symbols.  For example:
```
  $ git describe HEAD
  v6.4-rc7-72-gdad9774deaf1

  # Initial default config turns on Indirect Branch Tracking and 16-NOP padding bytes
  $ make defconfig
  $ grep -e CONFIG_X86_KERNEL_IBT -e CONFIG_FUNCTION_PADDING_BYTES .config
  CONFIG_X86_KERNEL_IBT=y
  CONFIG_FUNCTION_PADDING_BYTES=16

  # Test .o build generates 16 bytes of NOPs but no "__pfx_" symbol
  $ make -j$(nproc) fs/proc/cmdline.o
  $ objdump -Dr -j .text fs/proc/cmdline.o  | grep -e '<.*>:' -e 'Disassembly'
  Disassembly of section .text:
  0000000000000000 <cmdline_proc_show-0x10>:
  0000000000000010 <cmdline_proc_show>:
```
This is because objtool operation on the object code may be delayed under certain configurations.  As such, create-diff-object should be prepared to encounter NOP padded functions in object files before any __pfx_ symbols are created.

Fixes: 3e54c63b175b ("create-diff-object: support x86 NOP-padded functions")
Closes: #1347 ("x86 NOP padded functions without __pfx_ symbol")