### PR TITLE
Bump to version v0.9.9

### DIFF
--- a/contrib/kpatch.spec
+++ b/contrib/kpatch.spec
@@ -6,7 +6,7 @@
 
 Name: kpatch
 Summary: Dynamic kernel patching
-Version: 0.9.8
+Version: 0.9.9
 License: GPLv2
 Group: System Environment/Kernel
 URL: http://github.com/dynup/kpatch
@@ -104,6 +104,13 @@ rm -rf %{buildroot}
 %{_mandir}/man1/kpatch-build.1*
 
 %changelog
+* Thu Jul 27 2023 Joe Lawrence <joe.lawrence@redhat.com> - 0.9.9
+- Support for gcc-13
+- Support for Linux 6.2
+- Support for UBSAN kernels
+- Fix handling of PowerPC cpu features
+- Added RHEL-8.8 and 9.2 integration tests
+
 * Wed Mar 8 2023 Joe Lawrence <joe.lawrence@redhat.com> - 0.9.8
 * Clang fix ups from Pete Swain
 * Support for gcc-12

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -25,7 +25,7 @@
 
 INSTALLDIR=/var/lib/kpatch
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
-VERSION="0.9.8"
+VERSION="0.9.9"
 POST_ENABLE_WAIT=15	# seconds
 POST_SIGNAL_WAIT=60	# seconds
 MODULE_REF_WAIT=15	# seconds


### PR DESCRIPTION
Updates of interest:
v0.9.9:
- Support for gcc-13
- Support for Linux 6.2
- Support for UBSAN kernels
- Fix handling of PowerPC cpu features
- Added RHEL-8.8 and 9.2 integration tests