### PR TITLE
Fix undefined behavior problem when using list_foreach_entry

### DIFF
--- a/kpatch-build/list.h
+++ b/kpatch-build/list.h
@@ -30,7 +30,7 @@
 /**
  * Get offset of a member
  */
-#define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#define offsetof(TYPE, MEMBER) ((size_t) __builtin_offsetof(TYPE, MEMBER))
 
 /**
  * Casts a member of a structure out to the containing structure


### PR DESCRIPTION
This upstream list.h offsetof implementation rely on undefined behavior implementation. I got SIGILL when building with flag -fsanitize=undefined by clang. Using __builtin_offsetof will fix this problem.