### PR TITLE
kpatch-build: fix missed parameter of verify_patch_files

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -119,7 +119,7 @@ verify_patch_files() {
 	local ret=0
 
 	for patch in "${PATCH_LIST[@]}"; do
-		for path in $(lsdiff "$patch" 2>/dev/null); do
+		for path in $(lsdiff --strip=1 "$patch" 2>/dev/null); do
 
 			dir=$(dirname "$path")
 			ext="${path##*.}"


### PR DESCRIPTION
Verify_patch_files() use `lsdiff` to get patches' path and verify they are supported. To be consistent with apply_patches() which using `patch -p1`, `lsdiff` should use '--strip=1' paremeter.

Close: #1357