### PR TITLE
lookup.c: maybe_discarded_sym() add __pfx_ pattern

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -83,6 +83,7 @@ static bool maybe_discarded_sym(const char *name)
 	    !strncmp(name, "__brk_reservation_fn_", 21) ||
 	    !strncmp(name, "__func_stack_frame_non_standard_", 32) ||
 	    strstr(name, "__addressable_") ||
+	    strstr(name, "__pfx_") ||
 	    strstr(name, "__UNIQUE_ID_") ||
 	    !strncmp(name, ".L.str", 6) ||
 	    is_ubsan_sec(name))


### PR DESCRIPTION
Linux-6.4 may generate `__pfx_{func}` symbols for function symbol `{func}`, however, vmlinux symtab will not contain these symbols, which will cause error when matching local symbols for changed objects.

fix part of https://github.com/dynup/kpatch/issues/1360