### PR TITLE
kpatch-build: check if gawk exist

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -674,6 +674,10 @@ usage() {
 	echo "		                        (not recommended)" >&2
 }
 
+if ! command -v gawk &> /dev/null; then
+	die "gawk not installed"
+fi
+
 options="$(getopt -o ha:r:s:c:v:j:t:n:o:dR -l "help,archversion:,sourcerpm:,sourcedir:,config:,vmlinux:,jobs:,target:,name:,output:,oot-module:,oot-module-src:,debug,skip-gcc-check,skip-compiler-check,skip-cleanup,non-replace" -- "$@")" || die "getopt failed"
 
 eval set -- "$options"


### PR DESCRIPTION
kpatch-build uses gawk to find special section's struct size, but gawk is not always installed. So check if gawk is installed.