### PR TITLE
add R_X86_64_GOTPCREL for has_func_profiling check

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3970,7 +3970,8 @@ static void kpatch_find_func_profiling_calls(struct kpatch_elf *kelf)
 						list);
 			if ((rela->type != R_X86_64_NONE &&
 			     rela->type != R_X86_64_PC32 &&
-			     rela->type != R_X86_64_PLT32) ||
+			     rela->type != R_X86_64_PLT32 &&
+				 rela->type != R_X86_64_GOTPCREL) ||
 			    strcmp(rela->sym->name, "__fentry__"))
 				continue;
 


### PR DESCRIPTION
I found for the relocation type of R_X86_64_GOTPCREL, even though the function have __fentry__ in X86_64, create-diff-object will still judge it into no fentry and reject to patch this function.

The patch used for test is as follow:
diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c --- src.orig/fs/proc/cmdline.c  2021-01-28 04:47:10.915473099 -0500
+++ src/fs/proc/cmdline.c       2021-01-28 05:04:23.106898578 -0500
@@ -17,3 +17,10 @@ static int __init proc_cmdline_init(void
        return 0;
 }
 fs_initcall(proc_cmdline_init);
+
+#include <linux/printk.h>
+void kpatch_print_message(void)
+{
+       if (!jiffies)
+               printk("hello there!\n");
+}
diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
--- src.orig/fs/proc/meminfo.c  2021-01-28 04:47:10.916473090 -0500
+++ src/fs/proc/meminfo.c       2021-01-28 05:04:23.141898268 -0500
@@ -19,6 +19,8 @@
 #include <asm/page.h>
 #include "internal.h"

+void kpatch_print_message(void);
+
 void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
 {
 }
@@ -55,6 +57,7 @@ static int meminfo_proc_show(struct seq_
        sreclaimable = global_node_page_state_pages(NR_SLAB_RECLAIMABLE_B);
        sunreclaim = global_node_page_state_pages(NR_SLAB_UNRECLAIMABLE_B);

+       kpatch_print_message();
        show_val_kb(m, "MemTotal:       ", i.totalram);
        show_val_kb(m, "MemFree:        ", i.freeram);
        show_val_kb(m, "MemAvailable:   ", available);

And I copy the object of meminfo and use objdump to see the function meminfo_proc_show:

0000000000000000 <meminfo_proc_show>:
   0:   ff 15 00 00 00 00       callq  *0x0(%rip)        # 6 <meminfo_proc_show+0x6>
            2: R_X86_64_GOTPCREL    __fentry__-0x4
   6:   55                      push   %rbp
   7:   31 c0                   xor    %eax,%eax
   9:   b9 28 00 00 00          mov    $0x28,%ecx
   e:   48 89 e5                mov    %rsp,%rbp
  11:   41 57                   push   %r15
  13:   41 56                   push   %r14
  15:   41 55                   push   %r13
  17:   41 54                   push   %r12
  19:   4c 8d a5 90 fe ff ff    lea    -0x170(%rbp),%r12
  20:   53                      push   %rbx
  21:   48 89 fb                mov    %rdi,%rbx
  24:   4c 89 e7                mov    %r12,%rdi
  27:   48 81 ec 48 02 00 00    sub    $0x248,%rsp
  2e:   f3 48 ab                rep stos %rax,%es:(%rdi)
  31:   8b 05 00 00 00 00       mov    0x0(%rip),%eax        # 37 <meminfo_proc_show+0x37>
            33: R_X86_64_PC32   sysctl_rich_container_enable-0x4
  37:   65 4c 8b 2d 00 00 00    mov    %gs:0x0(%rip),%r13        # 3f <meminfo_proc_show+0x3f>
  3e:   00
            3b: R_X86_64_PC32   current_task-0x4
  3f:   85 c0                   test   %eax,%eax
  41:   0f 85 73 05 00 00       jne    5ba <meminfo_proc_show+0x5ba>
  47:   45 31 ed                xor    %r13d,%r13d
  4a:   e8 00 00 00 00          callq  4f <meminfo_proc_show+0x4f>
            4b: R_X86_64_PC32   rcu_read_unlock_strict-0x4
  4f:   4d 85 ed                test   %r13,%r13
  52:   0f 84 ad 05 00 00       je     605 <meminfo_proc_show+0x605>
  58:   4c 8d b5 00 fe ff ff    lea    -0x200(%rbp),%r14
  5f:   48 8d b5 90 fd ff ff    lea    -0x270(%rbp),%rsi
  66:   4c 89 ef                mov    %r13,%rdi
  69:   4c 89 f2                mov    %r14,%rdx
  6c:   e8 00 00 00 00          callq  71 <meminfo_proc_show+0x71>

This function should be patched. However, create-diff-object not allow the relocation type of R_X86_64_GOTPCREL. So, I add it.