### PR TITLE
kpatch-build: add support for OpenCloudOS

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -71,6 +71,7 @@ declare -rA SUPPORTED_DEB_DISTROS=(
 	["ubuntu"]="Ubuntu OS")
 
 declare -rA SUPPORTED_RPM_DISTROS=(
+	["opencloudos"]="OpenCloudOS"
 	["anolis"]="Anolis OS"
 	["centos"]="CentOS"
 	["fedora"]="Fedora"
@@ -994,6 +995,8 @@ else
 			# openEuler has two directories with the same content after 'rpm -D'
 			# openEuler 21.09 has linux-* and linux-*-source while openEuler 20.03 has linux-* and linux-*-Source
 			mv "$RPMTOPDIR"/BUILD/kernel-*/linux-*[sS]ource "$KERNEL_SRCDIR" 2>&1 | logger || die
+		elif [[ "$DISTRO" = opencloudos ]]; then
+			mv "$RPMTOPDIR"/BUILD/kernel-*/kernel-* "$KERNEL_SRCDIR" 2>&1 | logger || die
 		elif [[ "$DISTRO" = photon ]]; then
 			# Photon has some files that are copied over during the build section of the spec file (instead of prep)
 			# These change occasionally, so check they exist before copying
@@ -1022,7 +1025,7 @@ else
 
 		echo "$ARCHVERSION" > "$VERSIONFILE" || die
 
-		if [[ "$DISTRO" = openEuler ]]; then
+		if [[ "$DISTRO" = openEuler ]] || [[ "$DISTRO" = opencloudos ]]; then
 			[[ -z "$CONFIGFILE" ]] && CONFIGFILE="/boot/config-${ARCHVERSION}"
 		elif [[ "$DISTRO" = photon ]]; then
 			[[ -z "$CONFIGFILE" ]] && CONFIGFILE="$KERNEL_SRCDIR/$SRC_CFG"

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -120,6 +120,19 @@ kpatch_photon_dependencies()
 	fi
 }
 
+kpatch_opencloudos_dependencies()
+{
+	local kernel_version
+	local arch
+	kernel_version=$(uname -r)
+	arch=$(uname -m)
+	sudo yum install -y make gcc patch bison flex openssl-devel dwarves dnf-utils \
+		rpm-build dnf-plugins-core python3-devel openssl-devel ncurses-devel elfutils-libelf-devel
+	sudo yum install -y "kernel-debuginfo-${kernel_version%.*}"\
+		"kernel-devel-${kernel_version%.*}"
+	sudo yum-builddep -y "kernel-${kernel_version}*"
+}
+
 kpatch_anolis_dependencies()
 {
 	local kernel_version


### PR DESCRIPTION
OpenCloudOS is a centos-like Linux distribution.
I test kpatch in OpenCloudOS V8 and V9.
It works well in V9. But v8 itself has two problems:
1. no available epol repo, so kpatch can't install ccache.
2. executing 'uname -r' can't get an accurate kernel version.

Both problems have been notified to the OpenCloudOS community. After they fix these problems, kpatch will work well in all versions.