### PR TITLE
kpatch-test: add dmesg entry at start of test

### DIFF
--- a/test/integration/kpatch-test
+++ b/test/integration/kpatch-test
@@ -299,12 +299,13 @@ run_combined_test() {
 
 # save existing dmesg so we can detect new content
 save_dmesg() {
-	SAVED_DMESG="$(dmesg | tail -n1)"
+	SAVED_DMESG="kpatch-test timestamp: $(date --rfc-3339=ns)"
+	echo "$SAVED_DMESG" > /dev/kmsg
 }
 
 # new dmesg entries since our saved entry
 new_dmesg() {
-	if ! dmesg | awk -v last="$SAVED_DMESG" 'p; $0 == last{p=1} END {exit !p}'; then
+	if ! dmesg --notime | awk -v last="$SAVED_DMESG" 'p; $0 == last{p=1} END {exit !p}'; then
 		error "dmesg overflow, try increasing kernel log buffer size"
 	fi
 }


### PR DESCRIPTION
If the kernel log is empty prior to running the integration tests, the following confusing status may be reported:

  ...
  ERROR: dmesg overflow, try increasing kernel log buffer size
  SUCCESS

This occurs because the script can't find an empty dmesg entry when the tests are complete.  Copy the upstream kernel livepatching kselftests to fix this by logging a canary message at the beginning of the integration tests.  This will ensure a "real" message than can be found at the end.

Fixes: de1d0c6e08e6 ("kpatch-test: don't clear dmesg during test")