### PR TITLE
Declaration and definition are inconsistent

### DIFF
--- a/kpatch-build/insn/asm/inat.h
+++ b/kpatch-build/insn/asm/inat.h
@@ -106,7 +106,7 @@ extern insn_attr_t inat_get_group_attribute(insn_byte_t modrm,
 					    insn_attr_t esc_attr);
 extern insn_attr_t inat_get_avx_attribute(insn_byte_t opcode,
 					  insn_byte_t vex_m,
-					  insn_byte_t vex_pp);
+					  insn_byte_t vex_p);
 
 /* Attribute checking functions */
 static inline int inat_is_legacy_prefix(insn_attr_t attr)


### PR DESCRIPTION
【In English】
Declaration and definition are inconsistent
declaration:
![image](https://github.com/dynup/kpatch/assets/13927736/a65738ba-1053-44d6-a6c9-05e1683e29ee)


definition:
![image](https://github.com/dynup/kpatch/assets/13927736/d3366d18-1f90-418d-acf0-90a970cc09b2)


【中文】
声明和定义不一致