### PR TITLE
kpatch-build: handle paravirt absence in Linux v6.8+

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -358,7 +358,7 @@ find_special_section_data() {
 		"x86_64")
 			check[a]=true					# alt_instr
 			kernel_version_gte 5.10.0 && check[s]=true	# static_call_site
-			[[ -n "$CONFIG_PARAVIRT" ]] && check[p]=true	# paravirt_patch_site
+			[[ -n "$CONFIG_PARAVIRT" ]] && ! kernel_version_gte 6.8.0 && check[p]=true	# paravirt_patch_site
 			;;
 		"ppc64le")
 			check[f]=true					# fixup_entry


### PR DESCRIPTION
Adds linux kernel version checks to all functions pertaining to struct paravirt_patch_site as it is removed in Linux v6.8+

Fixes: https://github.com/dynup/kpatch/issues/1380