### PR TITLE
Recognize Amazon Linux ID in kpatch-build

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -78,7 +78,8 @@ declare -rA SUPPORTED_RPM_DISTROS=(
 	["openEuler"]="OpenEuler"
 	["ol"]="Oracle"
 	["photon"]="Photon OS"
-	["rhel"]="RHEL")
+	["rhel"]="RHEL"
+	["amzn"]="Amazon Linux")
 
 
 warn() {


### PR DESCRIPTION
Make kpatch-build aware about the ID of Amazon Linux distributions. No other special changes are needed.