### PR TITLE
Small upstream kernel fixes

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -956,7 +956,7 @@ if [[ -n "$USERSRCDIR" ]]; then
 	# save original vmlinux before it gets overwritten by sourcedir build
 	if [[ "$VMLINUX" -ef "$KERNEL_SRCDIR"/vmlinux ]]; then
 		backup_kernel_file "vmlinux"
-		VMLINUX="$TEMPDIR/vmlinux"
+		VMLINUX="$KERNEL_BACKUPDIR/vmlinux"
 	fi
 elif [[ -n "$OOT_MODULE" ]]; then
 	if [[ -z "${CONFIGFILE}" ]]; then

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1132,7 +1132,7 @@ if [[ -n "$USERSRCDIR" && -e "$KERNEL_SRCDIR/.git" ]]; then
 	cd "$KERNEL_SRCDIR" || die
 	if ! ./scripts/setlocalversion --save-scmversion &>/dev/null; then
 		backup_kernel_file "scripts/setlocalversion"
-		LOCALVERSION="$(make kernelversion)"
+		LOCALVERSION="$(make --no-print-directory kernelversion)"
 		LOCALVERSION="$(KERNELVERSION="$LOCALVERSION" ./scripts/setlocalversion)"
 		[[ -n "$LOCALVERSION" ]] || die "setlocalversion failed"
 		echo "echo $LOCALVERSION" > scripts/setlocalversion

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -689,11 +689,11 @@ module_name_string() {
 }
 
 is_supported_deb_distro(){
-	[[ -n "${SUPPORTED_DEB_DISTROS[$1]:-}" ]]
+	[[ -n "$1" ]] && [[ -n "${SUPPORTED_DEB_DISTROS[$1]:-}" ]]
 }
 
 is_supported_rpm_distro(){
-	[[ -n "${SUPPORTED_RPM_DISTROS[$1]:-}" ]]
+	[[ -n "$1" ]] && [[ -n "${SUPPORTED_RPM_DISTROS[$1]:-}" ]]
 }
 
 print_supported_distro(){

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -210,6 +210,8 @@ restore_kernel_files() {
 }
 
 cleanup() {
+	rm -f "$BUILDDIR/.scmversion"
+
 	remove_patches
 	restore_kernel_files
 
@@ -1118,18 +1120,23 @@ fi
 # appended to the kernel version string (VERMAGIC_STRING), even if the original
 # kernel was not dirty.  That can complicate both the build (create-diff-object
 # false positive changes) and the patch module link (module version mismatch
-# load failures).
+# load failures).  Before making any changes to the source:
 #
-# Prevent that by replacing the original setlocalversion with a friendlier one
-# which just echo's the original version.  This should be done before any
-# changes to the source.
+# For pre-v6.3 kernels:
+# Run `./scripts/setlocalversion --save-scmversion`.
+#
+# For v6.3+ kernels:
+# Replace the original setlocalversion with a friendlier one which just echo's
+# the original version.
 if [[ -n "$USERSRCDIR" && -e "$KERNEL_SRCDIR/.git" ]]; then
 	cd "$KERNEL_SRCDIR" || die
-	backup_kernel_file "scripts/setlocalversion"
-	LOCALVERSION="$(make kernelversion)"
-	LOCALVERSION="$(KERNELVERSION="$LOCALVERSION" ./scripts/setlocalversion)"
-	[[ -n "$LOCALVERSION" ]] || die "setlocalversion failed"
-	echo "echo $LOCALVERSION" > scripts/setlocalversion
+	if ! ./scripts/setlocalversion --save-scmversion &>/dev/null; then
+		backup_kernel_file "scripts/setlocalversion"
+		LOCALVERSION="$(make kernelversion)"
+		LOCALVERSION="$(KERNELVERSION="$LOCALVERSION" ./scripts/setlocalversion)"
+		[[ -n "$LOCALVERSION" ]] || die "setlocalversion failed"
+		echo "echo $LOCALVERSION" > scripts/setlocalversion
+	fi
 fi
 
 # kernel option checking


### PR DESCRIPTION
Three minor fix-ups for kpatch-build and upstream kernel trees:

1. The supported_{deb,rpm}_distro() functions are now called when running with `USERSRCDIR`.  Protect against indexing their associated arrays with empty strings
2. Set the correct `VMLINUX` path when `USERSRCDIR` is specified ($TEMPDIR vs. $KERNEL_BACKUPDIR)
3. Fix setlocalversion for pre-v6.3 kernels - we fixed this for newer kernels, but sometimes it's handy to run tests against older kernels... it's not too difficult to support both pre and post v6.3 kernels here.