### PR TITLE
s390/kpatch-build: add -fPIC flag with -mno-pic-data-is-text-relative

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1237,6 +1237,7 @@ fi
 
 if [[ "$ARCH" = "s390x" ]]; then
 	ARCH_KCFLAGS="-mno-pic-data-is-text-relative -fno-section-anchors"
+	! kernel_version_gte 6.10.0 && ARCH_KCFLAGS+=" -fPIE"
 fi
 
 export KCFLAGS="-I$DATADIR/patch -ffunction-sections -fdata-sections \


### PR DESCRIPTION
    s390/kpatch-build: add -fPIE flag with -mno-pic-data-is-text-relative
    
    -mno-pic-data-is-text-relative compiler flag expects -fPIC/-fPIE flag
    along with it.  Since kernel commit 778666df60f0 ("s390: compile
    relocatable kernel without -fPIE"), the -fPIC/-fPIE flag is missing when
    creating kpatch module and this can lead to the following error:
    
    cc1: error: ‘-mno-pic-data-is-text-relative’ cannot be used without
    ‘-fpic’/‘-fPIC’.
    
    Previously kpatch-build didnt show up this issue, as the previous kernel
    was built with -fPIE.
    
    However, kpatch build could fail with kernel commit 778666df60f0 ("s390:
    compile relocatable kernel without -fPIE"), where -fPIE is not included.
    Hence, include it in kpatch-build for all kernels < 6.10.0
    
    Note:
    Latest s390 kernel is built with -fPIC flag.
    i.e. kernel commit 00cda11d3b2e ("s390: Compile kernel with -fPIC and
    link with -no-pie"). Hence, there is no need to explicitly add it again
    in kpatch-build.


 git tag --contains 00cda11d3b2e
next-20240430
next-20240502
next-20240607
next-20240613
v6.10-rc1
v6.10-rc2
v6.10-rc3