### PR TITLE
NixOS Fixes

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1236,7 +1236,10 @@ verify_patch_files
 apply_patches
 remove_patches
 
+# cp preserves mode and the files might have been read-only. This would
+# interfere with cleanup later, so ensure the $TEMPDIR is read/write.
 cp -LR "$DATADIR/patch" "$TEMPDIR" || die
+chmod -R u+rw "$TEMPDIR" || die
 
 if [[ "$ARCH" = "ppc64le" ]]; then
 	ARCH_KCFLAGS="-mcmodel=large -fplugin=$PLUGINDIR/ppc64le-plugin.so"


### PR DESCRIPTION
I'm currently experimenting with generating live patches for NixOS. These are some tiny fixes that make the script work for me.

There are two changes here:

- The first patch fixes the case where kpatch files are installed as read-only (which is the default on NixOS).
- ~~The second patch allows skipping the distro checks, which allows experimenting with new distros.~~ (not necessary)