### PR TITLE
Workaround create-diff-object issue

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -237,6 +237,7 @@ static void kpatch_bundle_symbols(struct kpatch_elf *kelf)
 {
 	struct symbol *sym;
 	unsigned int expected_offset;
+	unsigned int directcall_offset = 16;
 
 	list_for_each_entry(sym, &kelf->symbols, list) {
 		if (is_bundleable(sym)) {
@@ -247,7 +248,8 @@ static void kpatch_bundle_symbols(struct kpatch_elf *kelf)
 			else
 				expected_offset = 0;
 
-			if (sym->sym.st_value != expected_offset) {
+			if (sym->sym.st_value != expected_offset &&
+				!(getenv("CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS") && sym->sym.st_value == directcall_offset)) {
 				ERROR("symbol %s at offset %lu within section %s, expected %u",
 				      sym->name, sym->sym.st_value,
 				      sym->sec->name, expected_offset);

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1186,6 +1186,8 @@ else
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi
 
+grep -q "CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS=y"    "$CONFIGFILE" && export CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS=1
+
 # unsupported kernel option checking
 [[ -n "$CONFIG_DEBUG_INFO_SPLIT" ]] && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
 [[ -n "$CONFIG_GCC_PLUGIN_LATENT_ENTROPY" ]] && die "kernel option 'CONFIG_GCC_PLUGIN_LATENT_ENTROPY' not supported"


### PR DESCRIPTION
We've seen this issue on Linux 6.9 and 6.10:

```
create-diff-object: ERROR: x86.o: kpatch_bundle_symbols: 251: symbol get_cpu_tsc_khz at offset 16 within section .text.get_cpu_tsc_khz, expected 0
```

We found this workaround at:
https://gitee.com/src-openeuler/kpatch/issues/I9I3EZ

We are not sure whether this fix is sane, but the result seems to work. :) 