### PR TITLE
kpatch/kpatch: Optimize patch transition timing with a while loop

### DIFF
--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -245,29 +245,31 @@ signal_stalled_processes() {
 
 wait_for_patch_transition() {
 	local module="$1"
-	local i
+	local i=0
 
 	in_transition "$module" || return 0
 
 	echo "waiting (up to $POST_ENABLE_WAIT seconds) for patch transition to complete..."
-	for (( i=0; i<POST_ENABLE_WAIT; i++ )); do
+	start_time=$SECONDS
+	while [ $i -lt $POST_ENABLE_WAIT ]; do
 		if ! in_transition "$module" ; then
 			echo "transition complete ($i seconds)"
 			return 0
 		fi
-		sleep 1s
+		i=$(( SECONDS - start_time ))
 	done
 
 	echo "patch transition has stalled!"
 	signal_stalled_processes
 
 	echo "waiting (up to $POST_SIGNAL_WAIT seconds) for patch transition to complete..."
-	for (( i=0; i<POST_SIGNAL_WAIT; i++ )); do
+	start_time=$SECONDS
+	while [ $i -lt $POST_SIGNAL_WAIT ]; do
 		if ! in_transition "$module" ; then
 			echo "transition complete ($i seconds)"
 			return 0
 		fi
-		sleep 1s
+		i=$(( SECONDS - start_time ))
 	done
 
 	return 1


### PR DESCRIPTION
Optimize the timing of patch transitions by using a `while` loop to check the transition status, replacing the `for` loop with a 1-second sleep. This approach reduces the likelihood of timeouts due to system load, potentially speeding up patch transitions.