### PR TITLE
kpatch-build: fail CONFIG_X86_KERNEL_IBT as not supported

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1190,6 +1190,7 @@ fi
 [[ -n "$CONFIG_DEBUG_INFO_SPLIT" ]] && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
 [[ -n "$CONFIG_GCC_PLUGIN_LATENT_ENTROPY" ]] && die "kernel option 'CONFIG_GCC_PLUGIN_LATENT_ENTROPY' not supported"
 [[ -n "$CONFIG_GCC_PLUGIN_RANDSTRUCT" ]] && die "kernel option 'CONFIG_GCC_PLUGIN_RANDSTRUCT' not supported"
+[[ -n "$CONFIG_X86_KERNEL_IBT" ]] && die "kernel option 'CONFIG_X86_KERNEL_IBT' not supported"
 
 # CONFIG_DEBUG_INFO_BTF invokes pahole, for which some versions don't
 # support extended ELF sections.  Disable the BTF typeinfo generation in


### PR DESCRIPTION
With IBT enabled, the kernel build runs objtool not on individual object files, but the post-linked vmlinux.o.  Kpatch-build does not currently and may not ever support binary comparison of vmlinux.o, so mark it as not supported for now.