### PR TITLE
man: fix reproducibility - remove file timestamps

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -3,10 +3,10 @@ include ../Makefile.inc
 all: kpatch.1.gz kpatch-build.1.gz
 
 kpatch.1.gz: kpatch.1
-	gzip -c -9 $< > $@
+	gzip -n -c -9 $< > $@
 
 kpatch-build.1.gz: kpatch-build.1
-	gzip -c -9 $< > $@
+	gzip -n -c -9 $< > $@
 
 install: all
 	$(INSTALL) -d $(MANDIR)


### PR DESCRIPTION
Man pages for kpatch are created via gzip which includes timestamp of original file by default. This means the compressed file will change depending on the time at which the repository was cloned / updated, leading to non-deterministic builds. Pass option to disable this.