### PR TITLE
tree: fix latest shellcheck complaints

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1167,7 +1167,7 @@ if [[ -n "$CONFIG_LIVEPATCH" ]] && (kernel_is_rhel || kernel_version_gte 4.9.0);
 	if use_klp_arch; then
 		USE_KLP_ARCH=1
 		KPATCH_LDFLAGS="--unique=.parainstructions --unique=.altinstructions"
-		CDO_FLAGS="--klp-arch"
+		CDO_FLAGS+=("--klp-arch")
 	fi
 
 	if [[  "$KLP_REPLACE" -eq 1 ]] ; then
@@ -1421,7 +1421,7 @@ for i in $FILES; do
 
 		# create-diff-object orig.o patched.o parent-name parent-symtab
 		#		     Module.symvers patch-mod-name output.o
-		"$TOOLSDIR"/create-diff-object $CDO_FLAGS "orig/$i" "patched/$i" "$KOBJFILE_NAME" \
+		"$TOOLSDIR"/create-diff-object "${CDO_FLAGS[@]}" "orig/$i" "patched/$i" "$KOBJFILE_NAME" \
 			"$SYMTAB" "$SYMVERS_FILE" "${MODNAME//-/_}" \
 			"output/$i" 2>&1 | logger 1
 		check_pipe_status create-diff-object
@@ -1491,7 +1491,7 @@ cd "$TEMPDIR/patch" || die
 
 # We no longer need kpatch-cc
 for ((idx=0; idx<${#MAKEVARS[@]}; idx++)); do
-    MAKEVARS[$idx]=${MAKEVARS[$idx]/${KPATCH_CC_PREFIX}/}
+    MAKEVARS[idx]=${MAKEVARS[idx]/${KPATCH_CC_PREFIX}/}
 done
 
 export KPATCH_BUILD="$KERNEL_SRCDIR" KPATCH_NAME="$MODNAME" \
@@ -1504,10 +1504,10 @@ make "${MAKEVARS[@]}" 2>&1 | logger || die
 
 if [[ "$USE_KLP" -eq 1 ]]; then
 	if [[ "$USE_KLP_ARCH" -eq 0 ]]; then
-		extra_flags="--no-klp-arch-sections"
+		extra_flags+=("--no-klp-arch-sections")
 	fi
 	cp -f "$TEMPDIR/patch/$MODNAME.ko" "$TEMPDIR/patch/tmp.ko" || die
-	"$TOOLSDIR"/create-klp-module $extra_flags "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
+	"$TOOLSDIR"/create-klp-module "${extra_flags[@]}" "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
 	check_pipe_status create-klp-module
 	[[ "$rc" -ne 0 ]] && die "create-klp-module: exited with return code: $rc"
 fi

--- a/kpatch/kpatch
+++ b/kpatch/kpatch
@@ -355,7 +355,6 @@ load_module () {
 			i=$((i+1))
 			if [[ $i -eq $MAX_LOAD_ATTEMPTS ]]; then
 				die "failed to load module $module"
-				break
 			else
 				warn "retrying..."
 				sleep $RETRY_INTERVAL

--- a/test/integration/lib.sh
+++ b/test/integration/lib.sh
@@ -116,7 +116,7 @@ kpatch_photon_dependencies()
 	if [[ -z "$flavor" ]]; then
 		tdnf install -y linux-debuginfo
 	else
-		tdnf install -y linux-$flavor-debuginfo
+		tdnf install -y linux-"$flavor"-debuginfo
 	fi
 }
 


### PR DESCRIPTION
Fix the following:

  In kpatch/kpatch line 358:
                                  break
                                  ^-- SC2317 (info): Command appears to be unreachable. Check usage (or ignore if invoked indirectly).

  In kpatch-build/kpatch-build line 1424:
                  "$TOOLSDIR"/create-diff-object $CDO_FLAGS "orig/$i" "patched/$i" "$KOBJFILE_NAME" \
                                                 ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

  In kpatch-build/kpatch-build line 1494:
      MAKEVARS[$idx]=${MAKEVARS[$idx]/${KPATCH_CC_PREFIX}/}
               ^--^ SC2004 (style): $/${} is unnecessary on arithmetic variables.

  In kpatch-build/kpatch-build line 1510:
          "$TOOLSDIR"/create-klp-module $extra_flags "$TEMPDIR/patch/tmp.ko" "$TEMPDIR/patch/$MODNAME.ko" 2>&1 | logger 1
                                        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

  In test/integration/lib.sh line 119:
                  tdnf install -y linux-$flavor-debuginfo
                                        ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Signed-off-by: Joe Lawrence <joe.lawrence@redhat.com>

squash