### PR TITLE
Update s390x syscall wrappers for RHEL-9.6

### DIFF
--- a/kmod/patch/kpatch-syscall.h
+++ b/kmod/patch/kpatch-syscall.h
@@ -91,40 +91,23 @@
 
 #elif defined(CONFIG_S390)
 
-/* arch/s390/include/asm/syscall_wrapper.h versions */
 # if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
-
-#define __KPATCH_S390_SYS_STUBx(x, name, ...)                                          \
-	long __s390_sys##name(struct pt_regs *regs);                            \
-	ALLOW_ERROR_INJECTION(__s390_sys##name, ERRNO);                         \
-	static inline long ___se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__));   \
-	long __s390_sys##name(struct pt_regs *regs)                             \
-	{                                                                       \
-		return ___se_sys##name(SC_S390_REGS_TO_ARGS(x, __VA_ARGS__));   \
-	}                                                                       \
-	static inline long ___se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__))    \
-	{                                                                       \
-		__MAP(x, __SC_TEST, __VA_ARGS__);                               \
-		return __kpatch_do_sys##name(__MAP(x, __SC_COMPAT_CAST, __VA_ARGS__)); \
-	}
-
-#define __KPATCH_SYSCALL_DEFINEx(x, name, ...)					\
-       long __s390x_sys##name(struct pt_regs *regs);                           \
-       ALLOW_ERROR_INJECTION(__s390x_sys##name, ERRNO);                        \
-       static inline long __se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__));    \
-       static inline long __kpatch_do_sys##name(__MAP(x, __SC_DECL, __VA_ARGS__));    \
-       __KPATCH_S390_SYS_STUBx(x, name, __VA_ARGS__);                                 \
-       long __s390x_sys##name(struct pt_regs *regs)                            \
-       {                                                                       \
-               return __se_sys##name(SC_S390_REGS_TO_ARGS(x, __VA_ARGS__));    \
-       }                                                                       \
-       static inline long __se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__))     \
-       {                                                                       \
-               __MAP(x, __SC_TEST, __VA_ARGS__);                               \
-               return __kpatch_do_sys##name(__MAP(x, __SC_CAST, __VA_ARGS__));        \
-       }                                                                       \
-       static inline long __kpatch_do_sys##name(__MAP(x, __SC_DECL, __VA_ARGS__))
+#  define KPATCH_SYSCALL_WRAPPERS_V2
 # else
+#  define KPATCH_SYSCALL_WRAPPERS_V1
+# endif
+
+# if defined(RHEL_RELEASE_CODE)
+#  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 6)
+#   define KPATCH_SYSCALL_WRAPPERS_V2
+#  else
+#   define KPATCH_SYSCALL_WRAPPERS_V1
+#  endif
+# endif
+
+
+/* arch/s390/include/asm/syscall_wrapper.h versions */
+#if defined(KPATCH_SYSCALL_WRAPPERS_V1)
 
 #define __KPATCH_S390_SYS_STUBx(x, name, ...)					\
 	long __s390_sys##name(struct pt_regs *regs);				\
@@ -157,7 +140,40 @@
 	__diag_pop();									\
 	static inline long __kpatch_do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))
 
-#endif /* LINUX_VERSION_CODE */
+# else /* KPATCH_SYSCALL_WRAPPERS_V2 */
+
+#define __KPATCH_S390_SYS_STUBx(x, name, ...)                                          \
+	long __s390_sys##name(struct pt_regs *regs);                            \
+	ALLOW_ERROR_INJECTION(__s390_sys##name, ERRNO);                         \
+	static inline long ___se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__));   \
+	long __s390_sys##name(struct pt_regs *regs)                             \
+	{                                                                       \
+		return ___se_sys##name(SC_S390_REGS_TO_ARGS(x, __VA_ARGS__));   \
+	}                                                                       \
+	static inline long ___se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__))    \
+	{                                                                       \
+		__MAP(x, __SC_TEST, __VA_ARGS__);                               \
+		return __kpatch_do_sys##name(__MAP(x, __SC_COMPAT_CAST, __VA_ARGS__)); \
+	}
+
+#define __KPATCH_SYSCALL_DEFINEx(x, name, ...)					\
+       long __s390x_sys##name(struct pt_regs *regs);                           \
+       ALLOW_ERROR_INJECTION(__s390x_sys##name, ERRNO);                        \
+       static inline long __se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__));    \
+       static inline long __kpatch_do_sys##name(__MAP(x, __SC_DECL, __VA_ARGS__));    \
+       __KPATCH_S390_SYS_STUBx(x, name, __VA_ARGS__);                                 \
+       long __s390x_sys##name(struct pt_regs *regs)                            \
+       {                                                                       \
+               return __se_sys##name(SC_S390_REGS_TO_ARGS(x, __VA_ARGS__));    \
+       }                                                                       \
+       static inline long __se_sys##name(__MAP(x, __SC_LONG, __VA_ARGS__))     \
+       {                                                                       \
+               __MAP(x, __SC_TEST, __VA_ARGS__);                               \
+               return __kpatch_do_sys##name(__MAP(x, __SC_CAST, __VA_ARGS__));        \
+       }                                                                       \
+       static inline long __kpatch_do_sys##name(__MAP(x, __SC_DECL, __VA_ARGS__))
+
+#endif /* KPATCH_SYSCALL_WRAPPERS_V2 */
 
 #elif defined(CONFIG_PPC64)
 


### PR DESCRIPTION
RHEL-9.6 backported upstream s390x syscall wrappers [1] that now need a distro-specific kernel version check.

[1] https://gitlab.com/redhat/centos-stream/src/kernel/centos-stream-9/-/merge_requests/5019/diffs?file=4c7281905bacd504a8205467bfd8e28ac241dbed#diff-content-4c7281905bacd504a8205467bfd8e28ac241dbed
