### PR TITLE
Patches from Photon OS

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -236,19 +236,19 @@ static struct rela *toc_rela(const struct rela *rela)
 static void kpatch_bundle_symbols(struct kpatch_elf *kelf)
 {
 	struct symbol *sym;
-	unsigned int expected_offset;
+	uint64_t expected_offset;
 
 	list_for_each_entry(sym, &kelf->symbols, list) {
 		if (is_bundleable(sym)) {
 			if (sym->pfx)
-				expected_offset = 16;
+				expected_offset = sym->pfx->sym.st_size;
 			else if (is_gcc6_localentry_bundled_sym(kelf, sym))
 				expected_offset = 8;
 			else
 				expected_offset = 0;
 
 			if (sym->sym.st_value != expected_offset) {
-				ERROR("symbol %s at offset %lu within section %s, expected %u",
+				ERROR("symbol %s at offset %lu within section %s, expected %lu",
 				      sym->name, sym->sym.st_value,
 				      sym->sec->name, expected_offset);
 			}

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -470,7 +470,7 @@ static void kpatch_link_prefixed_functions(struct kpatch_elf *kelf)
 
 		list_for_each_entry(func, &kelf->symbols, list) {
 			if (func->type == STT_FUNC && func->sec == pfx->sec &&
-			    func->sym.st_value == pfx->sym.st_value + 16) {
+			    func->sym.st_value == pfx->sym.st_value + pfx->sym.st_size) {
 
 				/*
 				 * If a func has aliases, it's possible for


### PR DESCRIPTION
These two patches are logically separate but are based on recent fixes for bugs I encountered recently in Photon OS. I think they can also be applicable to upstream kpatch.

The changes are:
1. Using the dynamically read prefix symbol size instead of hardcoding to 16 (fixes cases with non-standard padding for __cfi)
2. Refactor definitions of callback structs in kpatch-patch.h to compile with the correct input type for the callback function. Fixes a "bad function cast" gcc error that I ran into, which occurs during the final livepatch module compilation.