### PR TITLE
kmod: fix OOT kpatch kmod build

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -19,7 +19,6 @@ $(KPATCH_NAME).ko:
 $(obj)/$(KPATCH_NAME).o: $(src)/kpatch.lds
 
 patch-hook.o: patch-hook.c kpatch-patch-hook.c livepatch-patch-hook.c
-	$(KPATCH_MAKE) patch-hook.o
 
 clean:
 	$(RM) -Rf .*.o.cmd .*.ko.cmd .tmp_versions $(BUILDABLE_OBJS) *.ko *.mod.c \


### PR DESCRIPTION
Starting from linux commit 13b25489b6f8 ("kbuild: change working directory to external module directory with M="), the kpatch-build fails:

  make -C /root/linux M=/root/.kpatch/tmp/patch CFLAGS_MODULE=''
  make[1]: Entering directory '/root/linux'
  make[2]: Entering directory '/root/.kpatch/tmp/patch'
    LDS     kpatch.lds
  make -C /root/linux M=/root/.kpatch/tmp/patch CFLAGS_MODULE='' patch-hook.o
  ***
  *** The external module source tree is not clean.
  *** Please run 'make -C /root/linux M=/root/linux clean'
  ***

The easiest and quickest way to fix the build is to remove the $(KPATCH_MAKE) patch-hook.o in Makefile.  Unfortunately this would mean make `patch-hook.o` cannot be performed directly.  However the Makefile still lists patch-hook.o's source dependencies, so if any are updated, the kpatch module would be rebuilt anyway.

Thanks for Sumanth Korikkar for reporting, debugging, and suggesting this workaround.

Closes: #1430 ("kpatch-build fails: unable to locate patch-hook.o since linux commit 13b25489b6f8")
Reported-by: Sumanth Korikkar <sumanthk@linux.ibm.com>