### PR TITLE
kpatch-build: add missing include for musl

### DIFF
--- a/kpatch-build/create-kpatch-module.c
+++ b/kpatch-build/create-kpatch-module.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <libgen.h>
 #include <argp.h>
+#include <limits.h>
 
 #include "log.h"
 #include "kpatch-elf.h"


### PR DESCRIPTION
create-kpatch-module.c can't compile because limits.h is not included by other file with musl libc.

Adding the import permits the build to work on musl system.

https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/78844/diffs