### PR TITLE
Add support for Arm64 including all changes in PR #1302 (@swine, @surajjs95, @t-msn, and others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Supported Architectures
 
 - [x] x86-64
 - [x] ppc64le
-- [ ] arm64
+- [x] arm64
 - [x] s390 [upstream prerequisites](doc/s390-upstream-prerequisites.md)
 
 Installation

--- a/kmod/patch/kpatch-syscall.h
+++ b/kmod/patch/kpatch-syscall.h
@@ -209,7 +209,34 @@
 
 # endif /* LINUX_VERSION_CODE */
 
-#endif /* CONFIG_X86_64 */
+#elif defined(CONFIG_ARM64)
+
+/* arm64/include/asm/syscall_wrapper.h versions */
+
+#define SC_ARM64_REGS_TO_ARGS(x, ...)       \
+  __MAP(x,__SC_ARGS         \
+        ,,regs->regs[0],,regs->regs[1],,regs->regs[2] \
+        ,,regs->regs[3],,regs->regs[4],,regs->regs[5])
+
+#define __KPATCH_SYSCALL_DEFINEx(x, name, ...)           \
+  asmlinkage long __arm64_sys##name(const struct pt_regs *regs);    \
+  ALLOW_ERROR_INJECTION(__arm64_sys##name, ERRNO);      \
+  static long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__));   \
+  static inline long __kpatch_do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__));  \
+  asmlinkage long __arm64_sys##name(const struct pt_regs *regs)   \
+  {                 \
+    return __se_sys##name(SC_ARM64_REGS_TO_ARGS(x,__VA_ARGS__));  \
+  }                 \
+  static long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__))    \
+  {                 \
+    long ret = __kpatch_do_sys##name(__MAP(x,__SC_CAST,__VA_ARGS__));  \
+    __MAP(x,__SC_TEST,__VA_ARGS__);         \
+    __PROTECT(x, ret,__MAP(x,__SC_ARGS,__VA_ARGS__));   \
+    return ret;             \
+  }                 \
+  static inline long __kpatch_do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))
+
+#endif /* which arch */
 
 
 #ifndef __KPATCH_SYSCALL_DEFINEx

--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -21,7 +21,7 @@ PLUGIN_CFLAGS := $(filter-out -std=gnu11 -Wconversion, $(CFLAGS))
 PLUGIN_CFLAGS += -shared -I$(GCC_PLUGINS_DIR)/include \
 		   -Igcc-plugins -fPIC -fno-rtti -O2 -Wall
 endif
-ifeq ($(filter $(ARCH),s390x x86_64 ppc64le),)
+ifeq ($(filter $(ARCH),s390x x86_64 ppc64le aarch64),)
 $(error Unsupported architecture ${ARCH}, check https://github.com/dynup/kpatch/#supported-architectures)
 endif
 

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -687,6 +687,8 @@ static void kpatch_compare_correlated_section(struct section *sec)
 	 */
 	if (!strcmp(sec->name, ".rela__mcount_loc") ||
 	    !strcmp(sec->name, "__mcount_loc") ||
+	    !strcmp(sec->name, ".sframe") ||
+	    !strcmp(sec->name, ".rela.sframe") ||
 	    !strcmp(sec->name, ".rela__patchable_function_entries") ||
 	    !strcmp(sec->name, "__patchable_function_entries")) {
 		sec->status = SAME;

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1700,8 +1700,8 @@ static void kpatch_check_func_profiling_calls(struct kpatch_elf *kelf)
 		    (sym->parent && sym->parent->status == CHANGED))
 			continue;
 		if (!sym->twin->has_func_profiling) {
-			log_error("function %s has no fentry/mcount call, unable to patch\n",
-				  sym->name);
+			log_error("function %s doesn't have patchable function entry, unable to patch\n",
+				   sym->name);
 			errs++;
 		}
 	}
@@ -4178,6 +4178,10 @@ static void kpatch_find_func_profiling_calls(struct kpatch_elf *kelf)
 			if (insn[0] == 0xc0 && insn[1] == 0x04 &&
 				insn[2] == 0x00 && insn[3] == 0x00 &&
 				insn[4] == 0x00 && insn[5] == 0x00)
+				sym->has_func_profiling = 1;
+			break;
+		case AARCH64:
+			if (kpatch_symbol_has_pfe_entry(kelf, sym))
 				sym->has_func_profiling = 1;
 			break;
 		default:

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1645,6 +1645,13 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 		if (!is_rela_section(relasec) || is_debug_section(relasec))
 			continue;
 
+		/*
+		 * We regenerate __patchable_function_entries from scratch so
+		 * don't bother replacing section symbols in its relasec.
+		 */
+		if (is_patchable_function_entries_section(relasec))
+			continue;
+
 		list_for_each_entry(rela, &relasec->relas, list) {
 
 			if (rela->sym->type != STT_SECTION || !rela->sym->sec)

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1706,6 +1706,9 @@ static void kpatch_replace_sections_syms(struct kpatch_elf *kelf)
 					 */
 				} else if (target_off == start && target_off == end) {
 
+					if(kpatch_is_mapping_symbol(kelf, sym))
+						continue;
+
 					/*
 					 * Allow replacement for references to
 					 * empty symbols.

--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1950,6 +1950,7 @@ static void kpatch_include_standard_elements(struct kpatch_elf *kelf)
 		    !strcmp(sec->name, ".symtab") ||
 		    !strcmp(sec->name, ".toc") ||
 		    !strcmp(sec->name, ".rodata") ||
+		    !strcmp(sec->name, ".rodata.str") ||
 		    is_string_literal_section(sec)) {
 			kpatch_include_section(sec);
 		}

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -402,6 +402,9 @@ find_special_section_data() {
 		"s390x")
 			check[a]=true					# alt_instr
 			;;
+		"aarch64")
+			check[a]=true					# alt_instr
+			;;
 	esac
 
 	# Kernel CONFIG_ features

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -33,7 +33,7 @@
 # - Builds the patched kernel/module and monitors changed objects
 # - Builds the patched objects with gcc flags -f[function|data]-sections
 # - Runs kpatch tools to create and link the patch kernel module
-VERSION=0.9.9
+VERSION=0.9.10
 
 set -o pipefail
 

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -142,6 +142,8 @@ unsigned int absolute_rela_type(struct kpatch_elf *kelf)
 		return R_X86_64_64;
 	case S390:
 		return R_390_64;
+	case AARCH64:
+		return R_AARCH64_ABS64;
 	default:
 		ERROR("unsupported arch");
 	}
@@ -206,6 +208,7 @@ long rela_target_offset(struct kpatch_elf *kelf, struct section *relasec,
 
 	switch(kelf->arch) {
 	case PPC64:
+	case AARCH64:
 		add_off = 0;
 		break;
 	case X86_64:
@@ -255,6 +258,8 @@ unsigned int insn_length(struct kpatch_elf *kelf, void *addr)
 
 	switch(kelf->arch) {
 
+	case AARCH64:
+		return 4;
 	case X86_64:
 		insn_init(&decoded_insn, addr, 1);
 		insn_get_length(&decoded_insn);
@@ -595,7 +600,7 @@ struct kpatch_elf *kpatch_elf_open(const char *name)
 		kelf->arch = S390;
 		break;
 	case EM_AARCH64:
-		kelf->arch = ARM64;
+		kelf->arch = AARCH64;
 		break;
 	default:
 		ERROR("Unsupported target architecture");

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -594,6 +594,9 @@ struct kpatch_elf *kpatch_elf_open(const char *name)
 	case EM_S390:
 		kelf->arch = S390;
 		break;
+	case EM_AARCH64:
+		kelf->arch = ARM64;
+		break;
 	default:
 		ERROR("Unsupported target architecture");
 	}

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -65,6 +65,18 @@ bool is_text_section(struct section *sec)
 		(sec->sh.sh_flags & SHF_EXECINSTR));
 }
 
+bool is_patchable_function_entries_section(struct section *sec)
+{
+	char *name;
+
+	if (is_rela_section(sec))
+		name = sec->base->name;
+	else
+		name = sec->name;
+
+	return !strcmp(name, "__patchable_function_entries");
+}
+
 bool is_debug_section(struct section *sec)
 {
 	char *name;

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -139,6 +139,7 @@ struct kpatch_elf {
 char *status_str(enum status status);
 bool is_rela_section(struct section *sec);
 bool is_text_section(struct section *sec);
+bool is_patchable_function_entries_section(struct section *sec);
 bool is_debug_section(struct section *sec);
 
 struct section *find_section_by_index(struct list_head *list, unsigned int index);

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -116,6 +116,7 @@ enum architecture {
 	PPC64  = 0x1 << 0,
 	X86_64 = 0x1 << 1,
 	S390   = 0x1 << 2,
+	AARCH64  = 0x1 << 3,
 };
 
 struct kpatch_elf {

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,4 +1,4 @@
-ARCHES ?= ppc64le x86_64
+ARCHES ?= aarch64 ppc64le x86_64
 
 .PHONY: all clean submodule-check
 


### PR DESCRIPTION
This is a rebase of #1302 with some more changes and some already merged patches removed.
It is supposed to work with the `sframe` based reliable stack unwinder posted upstream: 

[[PATCH 0/8] unwind, arm64: add sframe unwinder for kernel](https://lore.kernel.org/all/20250127213310.2496133-1-wnliu@google.com/)

NOTE:
- The sframe sections are skipped for now in the livepatch module because the above series doesn't support modules yet. I am trying to make that work both from the kernel side and also in Kpatch and will add a patch later.

Building and testing a livepatch on a 6.12 arm64 kernel for the following basic patch:

```
[ec2-user@ip-172-31-32-86 ~]$ cat CVE-1234-5678.patch
From 9c372fa658da9ac55e3acb7c3e4f3035f9241c1d Mon Sep 17 00:00:00 2001
From: Puranjay Mohan <pjy@amazon.com>
Date: Tue, 14 Jan 2025 09:40:34 +0000
Subject: [PATCH] fs: proc: cmdline: livepatch test

This patch will be turned into a livepatch.

Signed-off-by: Puranjay Mohan <pjy@amazon.com>
---
 fs/proc/cmdline.c | 3 +--
 1 file changed, 1 insertion(+), 2 deletions(-)

diff --git a/fs/proc/cmdline.c b/fs/proc/cmdline.c
index a6f76121955f..90bef8411dbf 100644
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -7,8 +7,7 @@

 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-       seq_puts(m, saved_command_line);
-       seq_putc(m, '\n');
+       seq_printf(m, "%s\n", "this has been live patched");
        return 0;
 }

--
2.47.1
```
```
[ec2-user@ip-172-31-32-86 ~]$ uname -r
6.12.11-6.47.al2023pjy.aarch64

[ec2-user@ip-172-31-32-86 ~]$ ./kpatch/kpatch-build/kpatch-build -v /usr/lib/debug/lib/modules/6.12.11-6.47.al2023pjy.aarch64/vmlinux -r kernel-6.12.11-6.47.al2023pjy.src.rpm CVE-1234-5678.patch
Using cache at /home/ec2-user/.kpatch/src
Testing patch file(s)
Reading special section data
Building original source
Building patched source
Extracting new and modified ELF sections
cmdline.o: changed function: cmdline_proc_show
Patched objects: vmlinux
Building patch module: livepatch-CVE-1234-5678.ko
SUCCESS
[ec2-user@ip-172-31-32-86 ~]$
```

#### Load and Unload test
```
[root@ip-172-31-32-86 ec2-user]# kpatch load livepatch-CVE-1234-5678.ko
loading patch module: livepatch-CVE-1234-5678.ko
waiting (up to 15 seconds) for patch transition to complete...
transition complete (2 seconds)
[root@ip-172-31-32-86 ec2-user]# dmesg
[69888.542598] livepatch: enabling patch 'livepatch_CVE_1234_5678'
[69888.544388] livepatch: 'livepatch_CVE_1234_5678': starting patching transition
[69890.128882] livepatch: 'livepatch_CVE_1234_5678': patching complete
[root@ip-172-31-32-86 ec2-user]#

[root@ip-172-31-32-86 ec2-user]# cat /proc/cmdline
this has been live patched

[root@ip-172-31-32-86 ec2-user]# kpatch unload livepatch-CVE-1234-5678.ko
disabling patch module: livepatch_CVE_1234_5678
waiting (up to 15 seconds) for patch transition to complete...
transition complete (1 seconds)
unloading patch module: livepatch_CVE_1234_5678
[root@ip-172-31-32-86 ec2-user]# dmesg
[69888.542598] livepatch: enabling patch 'livepatch_CVE_1234_5678'
[69888.544388] livepatch: 'livepatch_CVE_1234_5678': starting patching transition
[69890.128882] livepatch: 'livepatch_CVE_1234_5678': patching complete
[69906.212505] livepatch: 'livepatch_CVE_1234_5678': starting unpatching transition
[69907.128716] livepatch: 'livepatch_CVE_1234_5678': unpatching complete

[root@ip-172-31-32-86 ec2-user]# cat /proc/cmdline
BOOT_IMAGE=(hd0,gpt1)/boot/vmlinuz-6.12.11-6.47.al2023pjy.aarch64 root=UUID=da8e1b79-5f9e-4471-89e7-958620dff70a ro console=tty0 console=ttyS0,115200n8 nvme_core.io_timeout=4294967295 rd.emergency=poweroff rd.shell=0 selinux=1 security=selinux quiet numa_cma=1:64M
```


#### Unit tests pass with the objects at: https://github.com/mihails-strasuns/kpatch-unit-test-objs/tree/arm64
```
CC=gcc10 ARCHES=aarch64 make -j64 unit
make -C kpatch-build
make[1]: Entering directory '/local/home/pjy/code/Kpatch/kpatch-build'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/local/home/pjy/code/Kpatch/kpatch-build'
make -C test/unit
make[1]: Entering directory '/local/home/pjy/code/Kpatch/test/unit'
make -C objs/aarch64
make[2]: Entering directory '/local/home/pjy/code/Kpatch/test/unit/objs/aarch64'
BUILD bug-table-section
BUILD cmdline-string
BUILD data-new
BUILD data-read-mostly
BUILD fixup-section
BUILD gcc-isra
BUILD gcc-static-local-var-2
BUILD gcc-static-local-var-3
BUILD gcc-static-local-var-4
BUILD gcc-static-local-var-5
BUILD gcc-static-local-var-6
BUILD mapping
BUILD meminfo-init-FAIL
BUILD meminfo-string
BUILD new-function
BUILD parainstructions-section
BUILD smp-locks-section
BUILD special-static
BUILD syscall
BUILD tracepoints-section
TEST bug-table-section
TEST cmdline-string
TEST data-new
TEST fixup-section
TEST gcc-isra
TEST gcc-static-local-var-2
TEST gcc-static-local-var-3
TEST gcc-static-local-var-4
TEST gcc-static-local-var-5
TEST gcc-static-local-var-6
TEST meminfo-init
TEST meminfo-string
TEST new-function
TEST parainstructions-section
TEST smp-locks-section
BUILD ASSERT_RTNL-detect
TEST special-static
TEST mapping
TEST tracepoints-section
TEST syscall
TEST data-read-mostly
TEST ASSERT_RTNL-detect
make[2]: Leaving directory '/local/home/pjy/code/Kpatch/test/unit/objs/aarch64'
make[1]: Leaving directory '/local/home/pjy/code/Kpatch/test/unit'
```

##### Integration tests

```
[root@ip-172-31-32-86 kpatch]# KPATCH_BUILD_OPTS=-R make -j64 integration-slow
make -C kpatch-build
make -C kpatch
make -C kmod
make[1]: Entering directory '/home/ec2-user/kpatch/kpatch-build'
make[1]: Entering directory '/home/ec2-user/kpatch/kmod'
make[1]: Entering directory '/home/ec2-user/kpatch/kpatch'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/ec2-user/kpatch/kpatch'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/ec2-user/kpatch/kmod'
make[1]: Nothing to be done for 'all'.
make[1]: Leaving directory '/home/ec2-user/kpatch/kpatch-build'
make -C test/integration slow
make[1]: Entering directory '/home/ec2-user/kpatch/test/integration'
rm -f *.ko *.log COMBINED.patch
./kpatch-test --kpatch-build-opts="-R" -d "amzn"-"2023"
build: data-new
build: gcc-static-local-var-6
build: macro-callbacks
build: module
build: new-function
build: new-globals
build: shadow-newpid
build: special-static
build: symvers-disagreement-FAIL
build: syscall
build: warn-detect-FAIL
combine: skipping amzn-2023/symvers-disagreement-FAIL.patch
combine: skipping amzn-2023/warn-detect-FAIL.patch
build: combined module
load test: data-new
load test: gcc-static-local-var-6 (no test prog)
load test: macro-callbacks (no test prog)
load test: module
load test: new-function (no test prog)
load test: new-globals (no test prog)
load test: shadow-newpid
load test: special-static (no test prog)
load test: syscall
load test: combined module
custom test: multiple
SUCCESS
make[1]: Leaving directory '/home/ec2-user/kpatch/test/integration'
[root@ip-172-31-32-86 kpatch]# echo $?
0
```