### PR TITLE
create-diff-object: Include full paths in build.log output for changed object files

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -4161,7 +4161,7 @@ int main(int argc, char *argv[])
 	patch_name    = arguments.args[5];
 	output_obj    = arguments.args[6];
 
-	childobj = basename(orig_obj);
+	childobj = GET_CHILD_OBJ(orig_obj);
 
 	kelf_orig = kpatch_elf_open(orig_obj);
 	kelf_patched = kpatch_elf_open(patched_obj);

--- a/kpatch-build/create-klp-module.c
+++ b/kpatch-build/create-klp-module.c
@@ -442,7 +442,7 @@ int main(int argc, char *argv[])
 
 	elf_version(EV_CURRENT);
 
-	childobj = basename(arguments.args[0]);
+	childobj = GET_CHILD_OBJ(arguments.args[0]);
 
 	kelf = kpatch_elf_open(arguments.args[0]);
 

--- a/kpatch-build/create-kpatch-module.c
+++ b/kpatch-build/create-kpatch-module.c
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
 
 	elf_version(EV_CURRENT);
 
-	childobj = basename(arguments.args[0]);
+	childobj = GET_CHILD_OBJ(arguments.args[0]);
 
 	kelf = kpatch_elf_open(arguments.args[0]);
 

--- a/kpatch-build/kpatch.h
+++ b/kpatch-build/kpatch.h
@@ -8,4 +8,10 @@ enum exit_status {
 	EXIT_STATUS_NO_CHANGE		= 3,
 };
 
+#define GET_CHILD_OBJ(obj) \
+((obj) == NULL ? NULL : ({ \
+	char *_childobj = strchr((obj), '/'); \
+	(_childobj == NULL) ? (obj) : (_childobj + 1 ); \
+}))
+
 #endif /* _KPATCH_H_ */


### PR DESCRIPTION
Hi Joe,

It‘s better  to show full paths in ~/.kpatch/build.log for changed object files.

For examble:
Now output in build.log:
tcp.o: changed function: tcp_sendmsg

Improved output in build.log:
net/ipv4/tcp.o: changed function: tcp_sendmsg