### PR TITLE
kpatch.service: explictly depend on /var/lib

### DIFF
--- a/contrib/kpatch.service
+++ b/contrib/kpatch.service
@@ -3,6 +3,8 @@ Description="Apply kpatch kernel patches"
 ConditionKernelCommandLine=!kpatch.enable=0
 Before=network-pre.target
 Wants=network-pre.target
+DefaultDependencies=no
+RequiresMountsFor=/var/lib/
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Like firewalld[1], there is a systemd service dependency loop between cloud-init-local and kpatch. As result, services like docker.socket of a virtual machine that enables cloud-init may not start. The related logs are as follows.

systemd[1]: sockets.target: Found ordering cycle on docker.socket/start
systemd[1]: sockets.target: Found dependency on sysinit.target/start
systemd[1]: sockets.target: Found dependency on cloud-init.service/start
systemd[1]: sockets.target: Found dependency on systemd-networkd-wait-online.service/start
systemd[1]: sockets.target: Found dependency on systemd-networkd.service/start
systemd[1]: socketsn.target: Found dependency on network-pre.target/start
systemd[1]: sockets.target: Found dependency on kpatch.service/start
systemd[1]: sockets.target: Found dependency on basic.target/start
systemd[1]: sockets.target: Found dependency on sockets.target/start
systemd[1]: sockets.target: Job docker.socket/start deleted to break ordering cycle starting with sockets.target/start

As a workaround, set DefaultDependencies=no and explictly depend on /var/lib.

[1] https://github.com/firewalld/firewalld/issues/414#issuecomment-2391967980