### PR TITLE
kpatch-build: restore source code from patched

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -900,7 +900,11 @@ else
 	BUILDDIR="$KERNEL_SRCDIR"
 fi
 
-[[ "$SKIPCLEANUP" -eq 0 ]] && trap cleanup EXIT INT TERM HUP
+if [[ "$SKIPCLEANUP" -eq 0 ]]; then
+	trap cleanup EXIT INT TERM HUP
+else
+	trap remove_patches EXIT INT TERM HUP
+fi
 
 # Don't check external file.
 # shellcheck disable=SC1090


### PR DESCRIPTION
The purpose of using `--skip-cleanup` is to save
the intermediate build products. Leaving the patch 
in the source code does not make much sense and
may even increase the workload for debugging.

Let's restore the source code from the patch.