### PR TITLE
CDO: Handle .data..once sections.

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -372,7 +372,8 @@ static bool is_special_static(struct symbol *sym)
 	if (sym->type != STT_OBJECT || sym->bind != STB_LOCAL)
 		return false;
 
-	if  (!strcmp(sym->sec->name, ".data.once"))
+	if  (!strcmp(sym->sec->name, ".data.once") ||
+	     !strcmp(sym->sec->name, ".data..once"))
 		return true;
 
 	for (var_name = var_names; *var_name; var_name++) {
@@ -1734,11 +1735,13 @@ static void kpatch_verify_patchability(struct kpatch_elf *kelf)
 
 		/*
 		 * ensure we aren't including .data.* or .bss.*
-		 * (.data.unlikely and .data.once is ok b/c it only has __warned vars)
+		 * (.data.unlikely, .data.once, and .data..once is ok b/c it only
+		 * has __warned vars)
 		 */
 		if (sec->include && sec->status != NEW &&
 		    (!strncmp(sec->name, ".data", 5) || !strncmp(sec->name, ".bss", 4)) &&
-		    (strcmp(sec->name, ".data.unlikely") && strcmp(sec->name, ".data.once"))) {
+		    (strcmp(sec->name, ".data.unlikely") && strcmp(sec->name, ".data.once") &&
+		     strcmp(sec->name, ".data..once"))) {
 			log_normal("data section %s selected for inclusion\n",
 				   sec->name);
 			errs++;


### PR DESCRIPTION
Upstream commit [1] renamed .data.once section as .data..once. Handle it the same as .data.once sections.

[1] dbefa1f31a91 ("Rename .data.once to .data..once to fix resetting WARN*_ONCE")
Signed-off-by: Song Liu <song@kernel.org>