### PR TITLE
CDO: Ignore section "alloc_tags"

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2862,6 +2862,7 @@ static void kpatch_mark_ignored_sections(struct kpatch_elf *kelf)
 		if (!strncmp(sec->name, ".discard", 8) ||
 		    !strncmp(sec->name, ".rela.discard", 13) ||
 		    !strncmp(sec->name, ".llvm_addrsig", 13) ||
+		    !strcmp(sec->name, "alloc_tags") ||
 		    !strncmp(sec->name, ".llvm.", 6))
 			sec->ignore = 1;
 


### PR DESCRIPTION
Upstream kernel commit [1] introduces a new "alloc_tags" section. Ignore it while building patches.

[1] commit 0db6f8d7820a ("alloc_tag: load module tags into separate contiguous memory")
Signed-off-by: Song Liu <song@kernel.org>