### PR TITLE
CDO: Handle .data..unlikely sections.

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -1735,13 +1735,13 @@ static void kpatch_verify_patchability(struct kpatch_elf *kelf)
 
 		/*
 		 * ensure we aren't including .data.* or .bss.*
-		 * (.data.unlikely, .data.once, and .data..once is ok b/c it only
-		 * has __warned vars)
+		 * (.data.unlikely, .data..unlikely, .data.once, and .data..once is ok
+		 * b/c it only has __warned vars)
 		 */
 		if (sec->include && sec->status != NEW &&
 		    (!strncmp(sec->name, ".data", 5) || !strncmp(sec->name, ".bss", 4)) &&
-		    (strcmp(sec->name, ".data.unlikely") && strcmp(sec->name, ".data.once") &&
-		     strcmp(sec->name, ".data..once"))) {
+		    (strcmp(sec->name, ".data.unlikely") && strcmp(sec->name, ".data..unlikely") &&
+		     strcmp(sec->name, ".data.once") && strcmp(sec->name, ".data..once"))) {
 			log_normal("data section %s selected for inclusion\n",
 				   sec->name);
 			errs++;


### PR DESCRIPTION
Upstream kernel commit [1] renamed .data.unlikely section as .data..unlikely. Handle it the same as .data.unlikely sections.

[1] bb43a59944f4 ("Rename .data.unlikely to .data..unlikely")
Signed-off-by: Song Liu <song@kernel.org>