### PR TITLE
kpatch-build: Add support for module symbol namespaces

### DIFF
--- a/kpatch-build/Makefile
+++ b/kpatch-build/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.inc
 
 CFLAGS += -std=gnu11 -MMD -MP -I../kmod/patch -Iinsn -Wall -Wsign-compare \
-	  -Wconversion -Wno-sign-conversion -g -Werror
+	  -Wconversion -Wno-sign-conversion -g -Werror -D_GNU_SOURCE
 LDLIBS = -lelf
 
 TARGETS = create-diff-object create-klp-module create-kpatch-module

--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -896,18 +896,11 @@ void kpatch_create_symtab(struct kpatch_elf *kelf)
 	symtab->sh.sh_info = nr_local;
 }
 
-struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
-                                    int entsize, int nr)
+struct section *create_section(struct kpatch_elf *kelf, char *name,
+                               int entsize, int nr)
 {
-	char *relaname;
-	struct section *sec, *relasec;
+	struct section *sec;
 	int size = entsize * nr;
-
-	relaname = malloc(strlen(name) + strlen(".rela") + 1);
-	if (!relaname)
-		ERROR("malloc");
-	strcpy(relaname, ".rela");
-	strcat(relaname, name);
 
 	/* allocate text section resources */
 	ALLOC_LINK(sec, &kelf->sections);
@@ -930,6 +923,24 @@ struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
 	sec->sh.sh_addralign = 8;
 	sec->sh.sh_flags = SHF_ALLOC;
 	sec->sh.sh_size = size;
+
+	return sec;
+
+}
+
+struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
+                                    int entsize, int nr)
+{
+	char *relaname;
+	struct section *sec, *relasec;
+
+	relaname = malloc(strlen(name) + strlen(".rela") + 1);
+	if (!relaname)
+		ERROR("malloc");
+	strcpy(relaname, ".rela");
+	strcat(relaname, name);
+
+	sec = create_section(kelf, name, entsize, nr);
 
 	/* allocate rela section resources */
 	ALLOC_LINK(relasec, &kelf->sections);

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -128,6 +128,8 @@ struct kpatch_elf {
 	int fd;
 	bool has_pfe;
 	bool pfe_ordered;
+	int modinfo_data_len;
+	char *modinfo_data;
 };
 
 /*******************

--- a/kpatch-build/kpatch-elf.h
+++ b/kpatch-build/kpatch-elf.h
@@ -181,6 +181,8 @@ void print_strtab(char *buf, size_t size);
 void kpatch_create_shstrtab(struct kpatch_elf *kelf);
 void kpatch_create_strtab(struct kpatch_elf *kelf);
 void kpatch_create_symtab(struct kpatch_elf *kelf);
+struct section *create_section(struct kpatch_elf *kelf, char *name,
+                               int entsize, int nr);
 struct section *create_section_pair(struct kpatch_elf *kelf, char *name,
                                     int entsize, int nr);
 void kpatch_remove_and_free_section(struct kpatch_elf *kelf, char *secname);


### PR DESCRIPTION
Roberto Bergantinos Corpas <rbergant@redhat.com> reported a problem when building a kpatch for:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/patch/?id=021ba7f1babd029e714d13a6bf2571b08af96d0f

```
MODPOST /root/.kpatch/tmp/patch/Module.symvers
ERROR: modpost: module livepatch-021ba7f1babd029e714d13a6bf2571b08af96d0f uses symbol dma_buf_export from namespace DMA_BUF, but does not import it.
ERROR: modpost: module livepatch-021ba7f1babd029e714d13a6bf2571b08af96d0f uses symbol dma_buf_put from namespace DMA_BUF, but does not import it.
ERROR: modpost: module livepatch-021ba7f1babd029e714d13a6bf2571b08af96d0f uses symbol dma_buf_fd from namespace DMA_BUF, but does not import it.
```

The problem is that the livepatch needs to access symbols exported via the "DMA_BUF" symbol namespace.  A workaround is to add `MODULE_IMPORT_NS("DMA_BUF")` to the kpatch, but then kpatch-build complains about unhandled .modinfo changes.

Update kpatch-build to allow .modinfo changes and extract the `import_ns=<value>` strings from .modinfo for inclusion in the output ELF object file.  Coupled with `MODULE_IMPORT_NS("DMA_BUF")`, this allows kpatch to build a livepatch that accesses a module symbol namespace.