### PR TITLE
kpatch-build: Enable cross compiling with env TARGET_ARCH

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -40,6 +40,7 @@ set -o pipefail
 BASE="$PWD"
 SCRIPTDIR="$(readlink -f "$(dirname "$(type -p "$0")")")"
 ARCH="$(uname -m)"
+TARGET_ARCH="${TARGET_ARCH:-$ARCH}"
 CPUS="$(getconf _NPROCESSORS_ONLN)"
 CACHEDIR="${CACHEDIR:-$HOME/.kpatch}"
 KERNEL_SRCDIR="$CACHEDIR/src"
@@ -390,7 +391,7 @@ find_special_section_data() {
 	check[e]=true						# exception_table_entry
 
 	# Arch-specific features
-	case "$ARCH" in
+	case "$TARGET_ARCH" in
 		"x86_64")
 			check[a]=true					# alt_instr
 			kernel_version_gte 5.10.0 && check[s]=true	# static_call_site
@@ -719,6 +720,15 @@ print_supported_distro(){
 	fi
 }
 
+# Used in "make ARCH=xxx" when making the kernel.
+# Match "aarch64" to "arm64", while keep everything else the same.
+kernel_make_arch() {
+	if [[ "$1" == "aarch64" ]]; then
+		echo "arm64"
+	else
+		echo "$1"
+	fi
+}
 
 usage() {
 	echo "usage: $(basename "$0") [options] <patch1 ... patchN>" >&2
@@ -1296,6 +1306,11 @@ else
 	MAKEVARS+=("LD=${KPATCH_CC_PREFIX}${LD}")
 fi
 
+if [[ "$ARCH" != "$TARGET_ARCH" ]]; then
+	KARCH=$(kernel_make_arch "$TARGET_ARCH")
+	MAKEVARS+=("ARCH=$KARCH")
+fi
+
 
 # $TARGETS used as list, no quotes.
 # shellcheck disable=SC2086
@@ -1486,7 +1501,12 @@ fi
 cd "$TEMPDIR/output" || die
 # $KPATCH_LDFLAGS and result of find used as list, no quotes.
 # shellcheck disable=SC2086,SC2046
-"$LD" -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") 2>&1 | logger || die
+if [[ "$ARCH" != "$TARGET_ARCH" ]]; then
+	# if cross compiling, use LLD to link
+	"$LLD" -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") 2>&1 | logger || die
+else
+	"$LD" -r $KPATCH_LDFLAGS -o ../patch/tmp_output.o $(find . -name "*.o") 2>&1 | logger || die
+fi
 
 if [[ "$USE_KLP" -eq 1 ]]; then
 	cp -f "$TEMPDIR"/patch/tmp_output.o "$TEMPDIR"/patch/output.o || die


### PR DESCRIPTION
llvm/clang supports cross compiling of the kernel. To build livepatch in the same cross compile environment, enable specifying TARGET_ARCH for kpatch-build. For example, in a x86_64 host, we can build livepatch for aarch64 kernel with:

   TARGET=aarch64 kpatch-build ...