### PR TITLE
packit: initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ kpatch-build/create-klp-module
 kpatch-build/create-kpatch-module
 man/kpatch.1.gz
 man/kpatch-build.1.gz
+prepare_sources_result*/

--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,42 @@
+jobs:
+  - job: tests
+    trigger: pull_request
+    branch: main
+    identifier: "integration-upstream"
+    labels:
+      - integration-pr
+    use_internal_tf: true
+    targets:
+      - fedora-37-x86_64
+      - fedora-37-s390x
+      - fedora-37-ppc64le
+    skip_build: true
+    manual_trigger: true
+    tmt_plan: kpatch-integration-upstream
+    fmf_url: https://gitlab.com/redhat/centos-stream/tests/kernel/test-plans.git
+    fmf_ref: main
+    tf_extra_params:
+      environment:
+        - variables:
+          KPATCH_REV: "$PACKIT_COMMIT_SHA"
+
+  - job: tests
+    trigger: commit
+    branch: main
+    identifier: "integration-upstream"
+    labels:
+      - integration-commit
+    use_internal_tf: true
+    targets:
+      - fedora-37-x86_64
+      - fedora-37-s390x
+      - fedora-37-ppc64le
+    skip_build: true
+    manual_trigger: true
+    tmt_plan: kpatch-integration-upstream
+    fmf_url: https://gitlab.com/redhat/centos-stream/tests/kernel/test-plans.git
+    fmf_ref: main
+    tf_extra_params:
+      environment:
+        - variables:
+          KPATCH_REV: "$PACKIT_COMMIT_SHA"


### PR DESCRIPTION
This MR adds a packit [1] configuration to enable integration testing of upstream commits and downstream kernel combinations. The initial version would test upstream kernels and manually triggered.  It will be later enhanced by Red Hat QE to test RHEL composes, etc.

[1] https://packit.dev/docs/about
