### PR TITLE
kmod/patch: simplify patch-hook.o build dependencies

### DIFF
--- a/kmod/patch/Makefile
+++ b/kmod/patch/Makefile
@@ -18,7 +18,7 @@ $(KPATCH_NAME).ko:
 
 $(obj)/$(KPATCH_NAME).o: $(src)/kpatch.lds
 
-patch-hook.o: patch-hook.c kpatch-patch-hook.c livepatch-patch-hook.c
+patch-hook.o: patch-hook.c
 
 clean:
 	$(RM) -Rf .*.o.cmd .*.ko.cmd .tmp_versions $(BUILDABLE_OBJS) *.ko *.mod.c \


### PR DESCRIPTION
The build dependencies for patch-hook.o are duplicated. The conditional inclusion of kpatch-patch-hook.c and livepatch-patch-hook.c is already managed in patch-hook.c via #if IS_ENABLED(CONFIG_LIVEPATCH).