### PR TITLE
kpatch-build: fix ppc64le trampoline handling after BPF changes

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3854,9 +3854,8 @@ static void kpatch_create_ftrace_callsite_sections(struct kpatch_elf *kelf)
 				insn_offset = sym->sym.st_value + PPC64_LOCAL_ENTRY_OFFSET(sym->sym.st_other);
 				insn = sym->sec->data->d_buf + insn_offset;
 
-				/* verify nops */
-				if (insn[0] != 0x00 || insn[1] != 0x00 || insn[2] != 0x00 || insn[3] != 0x60 ||
-				    insn[4] != 0x00 || insn[5] != 0x00 || insn[6] != 0x00 || insn[7] != 0x60)
+				/* verify nop */
+				if (insn[0] != 0x00 || insn[1] != 0x00 || insn[2] != 0x00 || insn[3] != 0x60)
 					ERROR("%s: unexpected instruction in patch section of function\n", sym->name);
 			} else {
 				bool found = false;

--- a/kpatch-build/kpatch-cc
+++ b/kpatch-build/kpatch-cc
@@ -39,6 +39,7 @@ if [[ "$TOOLCHAINCMD" =~ ^(.*-)?gcc$ || "$TOOLCHAINCMD" =~ ^(.*-)?clang$ ]] ; th
 				arch/x86/vdso/*|\
 				arch/powerpc/kernel/prom_init.o|\
 				arch/powerpc/kernel/vdso64/*|\
+				arch/powerpc/tools/vmlinux.arch.o|\
 				arch/s390/boot/*|\
 				arch/s390/purgatory/*|\
 				arch/s390/kernel/vdso64/*|\


### PR DESCRIPTION
kpatch-build: fix ppc64le trampoline handling after BPF changes

Starting from linux commit eec37961a56a (powerpc64/ftrace: Move
ftrace sequence out of line) the kpatch-build fails

        Extracting new and modified ELF sections
        create-diff-object: ERROR: fs/proc/cmdline.o: kpatch_create_ftrace_callsite_sections: 3860: cmdline_proc_show: unexpected instruction in patch section of function

        fs/proc/cmdline.o: changed function: cmdline_proc_show
        doing "deep find" for parent object
        ERROR: invalid ancestor arch/powerpc/tools/vmlinux.arch.o for arch/powerpc/tools/vmlinux.arch.o. Check /root/.kpatch/build.log for more details.


Moving the ftrace stubs out-of-line modified the prologue on ppc64le
and it now uses a single nop instead of two.
Update the nop check in create-diff-object.c accordingly.

Also add vmlinux.arch.o to the list of objects excluded from
instrumentation, since it only contains the out-of-line ftrace stubs
for vmlinux.
The module loader will create any necessary (livepatch) module
ftrace stubs, so we don't care about modifications to this file.

Closes: #1470 ("cs-10: ppc64le builds fail")
Reported-by: Joe Lawrence <joe.lawrence@redhat.com>
Signed-off-by: Radomir Vrbovsky <rvrbovsk@redhat.com>