### PR TITLE
Remove trailing slash from $SRCDIR and check for required env vars

### DIFF
--- a/test/integration/rebase-patches
+++ b/test/integration/rebase-patches
@@ -18,9 +18,15 @@
 #    ID=rhel VERSION_ID=7.8 ./rebase-patches rhel-7.7/*{.patch,.disabled}
 # % cp rhel-7.7/*.test rhel-7.8/
 
-OUTDIR=$(pwd)/${ID}-${VERSION_ID}
-mkdir -p "$OUTDIR"
+if [ -z "$SRCDIR" ] || [ -z "$ID" ] || [ -z "$VERSION_ID" ]; then
+  echo "ERROR: SRCDIR, ID, and VERSION_ID environment variables must be set"
+  exit 1
+fi
 
+SRCDIR="$(realpath "$SRCDIR")"
+OUTDIR="$(realpath "${ID}"-"${VERSION_ID}")"
+
+mkdir -p "$OUTDIR"
 echo "* Making backup copy of kernel sources"
 rm -rf "${SRCDIR}.orig"
 cp -r "$SRCDIR" "${SRCDIR}.orig"


### PR DESCRIPTION
If $SRCDIR has a trailing slash (e.g., `kernel/`), the command `cp -r "$SRCDIR" "${SRCDIR}.orig"` incorrectly copies the backup *inside* the source directory instead of alongside it. This causes the subsequent `diff -Nupr` to fail or compute an incorrect diff.

Also checks for the definitions of required env vars.