### PR TITLE
kpatch: Handle __trace_check symbols as discardable

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -82,6 +82,7 @@ static bool maybe_discarded_sym(const char *name)
 	if (!strncmp(name, "__exitcall_", 11) ||
 	    !strncmp(name, "__brk_reservation_fn_", 21) ||
 	    !strncmp(name, "__func_stack_frame_non_standard_", 32) ||
+	    !strncmp(name, "__trace_check", 13) ||
 	    strstr(name, "__addressable_") ||
 	    strstr(name, "__UNIQUE_ID_") ||
 	    !strncmp(name, ".L.str", 6) ||


### PR DESCRIPTION
Starting with kernel commit e30f8e61e251 ("tracing: Add a tracepoint verification check at build time"), each defined and used tracepoint adds its name to the __tracepoint_check section for build-time verification.  This section is discarded when linking vmlinux, so symbols prefixed with __trace_check do not appear in vmlinux.symtab.

As a result, kpatch-build fails with: "couldn't find matching local symbols in symbol table" for syscall.patch

i.e
readelf -p __tracepoint_check sys.o
String dump of section '__tracepoint_check':
  [     0]  task_prctl_unknown

Disassembly of section __tracepoint_check:
0000000000000000 <__trace_check_task_prctl_unknown.1>:
   0:   74 61 73 6b             .long   0x7461736b
   4:   5f 70 72 63             sl      %r7,611(%r7)
   8:   74 6c 5f 75             .long   0x746c5f75
   c:   6e 6b 6e 6f             aw      %f6,3695(%r11,%r6)
  10:   77 6e 00 00             .long   0x776e0000

To fix this, add symbols starting with __trace_check to maybe_discarded_sym() so they are treated as discardable.