### PR TITLE
kpatch-build: Add .L__const symbols to maybe_discarded_sym

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -85,6 +85,7 @@ static bool maybe_discarded_sym(const char *name)
 	    strstr(name, "__addressable_") ||
 	    strstr(name, "__UNIQUE_ID_") ||
 	    !strncmp(name, ".L.str", 6) ||
+	    !strncmp(name, ".L__const", 9) ||
 	    is_ubsan_sec(name))
 		return true;
 


### PR DESCRIPTION
Clang uses .L__const symbols for some constant variables, which is later removed by ld.lld. Add them to maybe_discarded_sym, so that we can avoid rare errors like:

  couldn't find matching xxx.c local symbols in vmlinux symbol table