### PR TITLE
s390/kpatch-build: Restrict -mno-pic-data-is-text-relative flag

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -269,6 +269,15 @@ use_klp_arch()
 	fi
 }
 
+use_s390_no_pic_data_is_text_relative_flag()
+{
+	if kernel_is_rhel; then
+		! rhel_kernel_version_gte 5.14.0-595.el9
+	else
+		! kernel_version_gte 6.10.0
+	fi
+}
+
 support_klp_replace()
 {
 	if kernel_is_rhel; then
@@ -1285,7 +1294,8 @@ if [[ "$ARCH" = "ppc64le" ]]; then
 fi
 
 if [[ "$ARCH" = "s390x" ]]; then
-	ARCH_KCFLAGS="-mno-pic-data-is-text-relative -fno-section-anchors"
+	ARCH_KCFLAGS="-fno-section-anchors"
+	use_s390_no_pic_data_is_text_relative_flag && ARCH_KCFLAGS+=" -mno-pic-data-is-text-relative"
 	! kernel_version_gte 6.10.0 && ARCH_KCFLAGS+=" -fPIE"
 fi
 


### PR DESCRIPTION
s390 -mno-pic-data-is-text-relative prevents relative addressing between code and data. The cflag option was introduced to avoid PC32 relocation errors when the kpatch text and data segments are placed far apart.

However, since the Linux kernel commit c98d2ecae08f ("s390/mm: Uncouple physical vs virtual address spaces"), the kernel, modules, and data segments remain close to each other, and therefore no longer risk PC32 relocation errors.

Additionally, with the recent kernel commit 04dabb4261c3 ("s390/bug: Implement __WARN_printf()")
git.kernel.org/pub/scm/linux/kernel/git/s390/linux.git for-next branch, it has inline assembly which uses string literals as immediate operands. gcc fails to compile kpatch module when -mno-pic-data-is-text-relative is used.

Therefore, restrict the use of -mno-pic-data-is-text-relative to kernels prior to commit c98d2ecae08f.