### PR TITLE
create-diff-object: Fix out of range relocation verification check

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -3011,7 +3011,7 @@ static void kpatch_check_relocations(struct kpatch_elf *kelf)
 			if (!rela->sym->sec)
 				continue;
 
-			sec_size = rela->sym->sec->data->d_size;
+			sec_size = rela->sym->sec->sh.sh_size;
 			sec_off = (long)rela->sym->sym.st_value +
 				  rela_target_offset(kelf, relasec, rela);
 
@@ -4233,6 +4233,7 @@ static void kpatch_build_strings_section_data(struct kpatch_elf *kelf)
 		strcpy(strtab, string->name);
 		strtab += strlen(string->name) + 1;
 	}
+	sec->sh.sh_size = sec->data->d_size;
 }
 
 /*


### PR DESCRIPTION
kpatch_check_relocations() validates relocation targets using sec->data->d_size, which doesnt reflect entire section size.

Sections such as __bug_table may be represented by multiple records. In this case, data->d_size is lesser than the logical section size, leading to false out-of-range relocation errors.

ERROR: kernel/fork.o: kpatch_check_relocations:
.text.kernel_clone+0x2f6: out-of-range relocation __bug_table+0x1b2
sec_off: 432 sec_size: 48

The correct size of the section is sec->sh.sh_size, total size of __bug_table (480 bytes, corresponding to 30 struct bug_entry records).

Fix this by using sec->sh.sh_size instead of sec->data->d_size when verifying relocation bounds.

Additionally, ensure that newly rebuilt .kpatch.strings sections update sh.sh_size after the string table is finalized. Without this update, kpatch may fail with:

ERROR: kernel/fork.o: kpatch_check_relocations:
.kpatch.funcs+0x28: out-of-range relocation .kpatch.strings+0x8
sec_off: 8 sec_size: 0