### PR TITLE
lookup: For each function symbol in x86_64, there is a corresponding symbol prefixed with __pfx_, which should be ignored.

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -108,6 +108,8 @@ static bool locals_match(struct lookup_table *table, int idx,
 			continue;
 		if (table_sym->type != STT_FUNC && table_sym->type != STT_OBJECT)
 			continue;
+		if(!strncmp(table_sym->name, "__pfx_", 6))
+			continue;
 
 		found = 0;
 		sym = file_sym;
@@ -136,6 +138,8 @@ static bool locals_match(struct lookup_table *table, int idx,
 			continue;
 		if (sym->type != STT_FUNC && sym->type != STT_OBJECT)
 			continue;
+		if(!strncmp(sym->name, "__pfx_", 6))
+			continue;		
 		/*
 		 * Symbols which get discarded at link time are missing from
 		 * the lookup table, so skip them.


### PR DESCRIPTION
Skip symbols starting with __pfx_
6.6 kernel version, each function symbol in vmlinux/ko has a corresponding __pfx_-prefixed symbol, but it is not present in .o files. When creating a patch file, the check for searching and matching local symbols fails.