### PR TITLE
  kpatch: add openEuler 6.6 kernel support

### DIFF
--- a/kmod/patch/livepatch-patch-hook.c
+++ b/kmod/patch/livepatch-patch-hook.c
@@ -86,6 +86,11 @@
 #define KLP_REPLACE_ENABLE true
 #endif
 
+
+#ifdef CONFIG_LIVEPATCH_WO_FTRACE
+#define HAVE_WO_FTRACE_ENABLE
+#endif
+
 /*
  * There are quite a few similar structures at play in this file:
  * - livepatch.h structs prefixed with klp_*
@@ -576,6 +581,7 @@ static int __init patch_init(void)
 	}
 #endif
 
+#if defined(HAVE_WO_FTRACE_ENABLE)
 	ret = klp_enable_patch(lpatch);
 	if (ret) {
 #ifndef HAVE_SIMPLE_ENABLE
@@ -584,6 +590,7 @@ static int __init patch_init(void)
 		patch_free_livepatch(lpatch);
 		return ret;
 	}
+#endif
 
 	return 0;
 out:

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1194,7 +1194,7 @@ trace_off "reading .config"
 source "$CONFIGFILE"
 trace_on
 
-[[ "$DISTRO" = openEuler ]] && [[ -z "$CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY" ]] && \
+[[ "$DISTRO" = openEuler ]] && ! kernel_version_gte 6.6.0 && [[ -z "$CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY" ]] && \
 	die "openEuler kernel doesn't have 'CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY' enabled"
 
 [[ -z "$CONFIG_DEBUG_INFO" ]] && die "kernel doesn't have 'CONFIG_DEBUG_INFO' enabled"

--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -1232,6 +1232,8 @@ else
 	KBUILD_EXTRA_SYMBOLS="$SYMVERSFILE"
 fi
 
+grep -q "CONFIG_LIVEPATCH_WO_FTRACE=y" "$CONFIGFILE" && export NO_PROFILING_CALLS=1
+
 # unsupported kernel option checking
 [[ -n "$CONFIG_DEBUG_INFO_SPLIT" ]] && die "kernel option 'CONFIG_DEBUG_INFO_SPLIT' not supported"
 [[ -n "$CONFIG_GCC_PLUGIN_LATENT_ENTROPY" ]] && die "kernel option 'CONFIG_GCC_PLUGIN_LATENT_ENTROPY' not supported"


### PR DESCRIPTION
  ## Summary

  Add compatibility support for openEuler 6.6 kernel, which introduces
  `CONFIG_LIVEPATCH_WO_FTRACE` (livepatch without ftrace) and removes the
  `CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY` requirement.

  ## Changes

  **kpatch-build: skip CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY check on kernel >= 6.6**

  The `CONFIG_LIVEPATCH_PER_TASK_CONSISTENCY` check was previously required
  for all openEuler kernels. On openEuler 6.6+, this config option no longer
  exists, so the check is now skipped for kernels >= 6.6.0 to avoid a false
  build failure.

  **kpatch: add support for CONFIG_LIVEPATCH_WO_FTRACE on openEuler 6.6**

  openEuler 6.6 introduces `CONFIG_LIVEPATCH_WO_FTRACE`, a livepatch
  mechanism that does not rely on ftrace. When this option is enabled:

  - `HAVE_WO_FTRACE_ENABLE` is defined in the patch hook, and
    `klp_enable_patch()` is conditionally compiled for this path.
  - `NO_PROFILING_CALLS=1` is exported during build to suppress ftrace-based
    profiling instrumentation, which is incompatible with the wo-ftrace path.
