### PR TITLE
create-diff-object: Handle __stack_protector_loc section

### DIFF
--- a/kpatch-build/create-diff-object.c
+++ b/kpatch-build/create-diff-object.c
@@ -2412,6 +2412,11 @@ static int s390_expolines_group_size(struct kpatch_elf *kelf, int offset)
 	return 4;
 }
 
+static int s390_stack_protector_loc_group_size(struct kpatch_elf *kelf, int offset)
+{
+	return 8;
+}
+
 /*
  * The rela groups in the .fixup section vary in size.  The beginning of each
  * .fixup rela group is referenced by the __ex_table section. To find the size
@@ -2737,6 +2742,11 @@ static struct special_section special_sections[] = {
 		.name		= ".s390_indirect_jump",
 		.arch		= S390,
 		.group_size	= s390_expolines_group_size,
+	},
+	{
+		.name		= "__stack_protector_loc",
+		.arch		= S390,
+		.group_size	= s390_stack_protector_loc_group_size,
 	},
 	{},
 };


### PR DESCRIPTION
kpatch fails to build modules when s390 stack protector is enabled: 

ERROR: changed section .rela__stack_protector_loc not selected for inclusion 
ERROR: fs/proc/meminfo.o: 1 unsupported section change(s)

Recent gcc versions introduce new s390 stack protector options:

-mstack-protector-guard=global
-mstack-protector-guard-record

These generate __stack_protector_loc section that records canary reference locations. The kernel later patches these at runtime to use pertask canaries.

kpatch currently does not handle this section, leading to kpatch build failures.  Add __stack_protector_loc to the special_sections list with an appropriate group handler, so kpatch can correctly regenerate the section and update relocations for patched functions.

Details:
* Disassembly of section __stack_protector_loc:

```
0000000000000000 <__stack_protector_loc>:
        ...
                        0: R_390_64     meminfo_proc_show+0x20
                        8: R_390_64     meminfo_proc_show+0xb6e
```

* Load canary value and store it in the stack (prologue)

```
0000000000000510 <meminfo_proc_show>:
static int meminfo_proc_show(struct seq_file *m, void *v) {
     510:       c0 04 00 00 00 00       jgnop   510 <meminfo_proc_show>
     516:       eb 6f f0 48 00 24       stmg    %r6,%r15,72(%r15)
     51c:       b9 04 00 ef             lgr     %r14,%r15
     520:       b9 04 00 b2             lgr     %r11,%r2
     524:       e3 f0 fe f8 ff 71       lay     %r15,-264(%r15)
     52a:       e3 e0 f0 98 00 24       stg     %r14,152(%r15)
     530:       c4 18 00 00 00 00       lgrl    %r1,530 <meminfo_proc_show+0x20>
                        532: R_390_GOTENT       __stack_chk_guard+0x2
     536:       d2 07 f1 48 10 00       mvc     328(8,%r15),0(%r1)
```

* Compare canary value (epilogue):
```
    107e:       c4 b8 00 00 00 00       lgrl    %r11,107e <meminfo_proc_show+0xb6e>
                        1080: R_390_GOTENT      __stack_chk_guard+0x2
    1084:       d5 07 f1 48 b0 00       clc     328(8,%r15),0(%r11)
    108a:       a7 74 00 0a             jne     109e <meminfo_proc_show+0xb8e>
...
    109e:       c0 e5 00 00 00 00       brasl   %r14,109e <meminfo_proc_show+0xb8e>
                        10a0: R_390_PLT32DBL    __stack_chk_fail+0x2
```

References:
- gcc commit 0cd1f03939d5 ("s390: Support global stack protector")
- kernel commit f5730d44e05e ("s390: Add stackprotector support")