### PR TITLE
test/integration/rhel-9.9: Add integration-kernel-5.14.0-722.el9 tests

### DIFF
--- a/test/integration/rhel-9.9/data-new-LOADED.test
+++ b/test/integration/rhel-9.9/data-new-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep "kpatch:         5" /proc/meminfo

--- a/test/integration/rhel-9.9/data-new.patch
+++ b/test/integration/rhel-9.9/data-new.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2026-07-23 11:46:12.653547066 -0400
++++ src/fs/proc/meminfo.c	2026-07-23 11:46:12.971797768 -0400
+@@ -31,6 +31,8 @@ static void show_val_kb(struct seq_file
+ 	seq_write(m, " kB\n", 4);
+ }
+ 
++static int foo = 5;
++
+ static int meminfo_proc_show(struct seq_file *m, void *v)
+ {
+ 	struct sysinfo i;
+@@ -158,6 +160,7 @@ static int meminfo_proc_show(struct seq_
+ 	show_val_kb(m, "CmaFree:        ",
+ 		    global_zone_page_state(NR_FREE_CMA_PAGES));
+ #endif
++	seq_printf(m, "kpatch:         %d\n", foo);
+ 
+ #ifdef CONFIG_UNACCEPTED_MEMORY
+ 	show_val_kb(m, "Unaccepted:     ",

--- a/test/integration/rhel-9.9/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-9.9/gcc-static-local-var-6.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/net/ipv6/netfilter.c src/net/ipv6/netfilter.c
+--- src.orig/net/ipv6/netfilter.c	2026-07-23 11:46:12.749446142 -0400
++++ src/net/ipv6/netfilter.c	2026-07-23 11:46:14.734258156 -0400
+@@ -97,6 +97,8 @@ static int nf_ip6_reroute(struct sk_buff
+ 	return 0;
+ }
+ 
++#include "kpatch-macros.h"
++
+ int __nf_ip6_route(struct net *net, struct dst_entry **dst,
+ 		   struct flowi *fl, bool strict)
+ {
+@@ -110,6 +112,9 @@ int __nf_ip6_route(struct net *net, stru
+ 	struct dst_entry *result;
+ 	int err;
+ 
++	if (!jiffies)
++		printk("kpatch nf_ip6_route foo\n");
++
+ 	result = ip6_route_output(net, sk, &fl->u.ip6);
+ 	err = result->error;
+ 	if (err)

--- a/test/integration/rhel-9.9/macro-callbacks.patch
+++ b/test/integration/rhel-9.9/macro-callbacks.patch
@@ -1,0 +1,155 @@
+diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
+--- src.orig/drivers/input/joydev.c	2026-07-23 11:46:12.387708934 -0400
++++ src/drivers/input/joydev.c	2026-07-23 11:46:16.433839604 -0400
+@@ -1096,3 +1096,47 @@ static void __exit joydev_exit(void)
+ 
+ module_init(joydev_init);
+ module_exit(joydev_exit);
++
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0; /* return -ENODEV; */
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
+--- src.orig/drivers/input/misc/pcspkr.c	2026-07-23 11:46:12.385106224 -0400
++++ src/drivers/input/misc/pcspkr.c	2026-07-23 11:46:16.434824953 -0400
+@@ -134,3 +134,46 @@ static struct platform_driver pcspkr_pla
+ };
+ module_platform_driver(pcspkr_platform_driver);
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
+diff -Nupr src.orig/fs/aio.c src/fs/aio.c
+--- src.orig/fs/aio.c	2026-07-23 11:46:12.662947209 -0400
++++ src/fs/aio.c	2026-07-23 11:46:16.434967670 -0400
+@@ -50,6 +50,50 @@
+ 
+ #define KIOCB_KEY		0
+ 
++#include <linux/module.h>
++#include "kpatch-macros.h"
++
++static const char *const module_state[] = {
++	[MODULE_STATE_LIVE]	= "[MODULE_STATE_LIVE] Normal state",
++	[MODULE_STATE_COMING]	= "[MODULE_STATE_COMING] Full formed, running module_init",
++	[MODULE_STATE_GOING]	= "[MODULE_STATE_GOING] Going away",
++	[MODULE_STATE_UNFORMED]	= "[MODULE_STATE_UNFORMED] Still setting it up",
++};
++
++static void callback_info(const char *callback, patch_object *obj)
++{
++	if (obj->mod)
++		pr_info("%s: %s -> %s\n", callback, obj->mod->name,
++			module_state[obj->mod->state]);
++	else
++		pr_info("%s: vmlinux\n", callback);
++}
++
++static int pre_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++	return 0;
++}
++KPATCH_PRE_PATCH_CALLBACK(pre_patch_callback);
++
++static void post_patch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_PATCH_CALLBACK(post_patch_callback);
++
++static void pre_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_PRE_UNPATCH_CALLBACK(pre_unpatch_callback);
++
++static void post_unpatch_callback(patch_object *obj)
++{
++	callback_info(__func__, obj);
++}
++KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
++
+ #define AIO_RING_MAGIC			0xa10a10a1
+ #define AIO_RING_COMPAT_FEATURES	1
+ #define AIO_RING_INCOMPAT_FEATURES	0

--- a/test/integration/rhel-9.9/module-LOADED.test
+++ b/test/integration/rhel-9.9/module-LOADED.test
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -o errexit
+
+sudo modprobe xfs
+sleep 5
+grep -q kpatch /sys/fs/xfs/stats/stats
+# TODO: This will trigger a printk on newer kernels which have the .klp.arch
+# removal.  Don't actually do the grep until running on a newer kernel.
+echo "file fs/xfs/xfs_stats.c +p" > /sys/kernel/debug/dynamic_debug/control
+# dmesg | grep -q "kpatch: pr_debug"

--- a/test/integration/rhel-9.9/module.patch
+++ b/test/integration/rhel-9.9/module.patch
@@ -1,0 +1,60 @@
+diff -Nupr src.orig/fs/xfs/xfs_stats.c src/fs/xfs/xfs_stats.c
+--- src.orig/fs/xfs/xfs_stats.c	2026-07-23 11:46:12.662606437 -0400
++++ src/fs/xfs/xfs_stats.c	2026-07-23 11:46:18.188013135 -0400
+@@ -16,6 +16,8 @@ static int counter_val(struct xfsstats _
+ 	return val;
+ }
+ 
++extern char *kpatch_string(void);
++
+ int xfs_stats_format(struct xfsstats __percpu *stats, char *buf)
+ {
+ 	int		i, j;
+@@ -87,6 +89,34 @@ int xfs_stats_format(struct xfsstats __p
+ 		0);
+ #endif
+ 
++	/* Reference a symbol outside the .o yet inside the patch module: */
++	len += scnprintf(buf + len, PATH_MAX-len, "%s\n", kpatch_string());
++
++#ifdef CONFIG_X86_64
++	/* Test alternatives patching: */
++	alternative("ud2", "nop", X86_FEATURE_ALWAYS);
++	alternative("nop", "ud2", X86_FEATURE_IA64);
++
++	/* Test paravirt patching: */
++	slow_down_io();   /* paravirt call */
++#endif
++
++	/* Test pr_debug: */
++	pr_debug("kpatch: pr_debug() test\n");
++
++{
++	/* Test static branches: */
++	static DEFINE_STATIC_KEY_TRUE(kpatch_key);
++
++	if (static_branch_unlikely(&memcg_kmem_online_key))
++		printk("kpatch: memcg_kmem_online_key\n");
++
++	BUG_ON(!static_branch_likely(&kpatch_key));
++	static_branch_disable(&kpatch_key);
++	BUG_ON(static_branch_likely(&kpatch_key));
++	static_branch_enable(&kpatch_key);
++}
++
+ 	return len;
+ }
+ 
+diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
+--- src.orig/net/netlink/af_netlink.c	2026-07-23 11:46:12.755043198 -0400
++++ src/net/netlink/af_netlink.c	2026-07-23 11:46:18.188206251 -0400
+@@ -2961,4 +2961,9 @@ panic:
+ 	panic("netlink_init: Cannot allocate nl_table\n");
+ }
+ 
++char *kpatch_string(void)
++{
++	return "kpatch";
++}
++
+ core_initcall(netlink_proto_init);

--- a/test/integration/rhel-9.9/multiple.test
+++ b/test/integration/rhel-9.9/multiple.test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPTDIR="$(readlink -f $(dirname $(type -p $0)))"
+
+declare -a blacklist=(meminfo-string-LOADED.test)
+
+source ${SCRIPTDIR}/../common/multiple.template

--- a/test/integration/rhel-9.9/new-function.patch
+++ b/test/integration/rhel-9.9/new-function.patch
@@ -1,0 +1,25 @@
+diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
+--- src.orig/drivers/tty/n_tty.c	2026-07-23 11:46:12.604912879 -0400
++++ src/drivers/tty/n_tty.c	2026-07-23 11:46:19.967854685 -0400
+@@ -2355,7 +2355,7 @@ more_to_be_read:
+  *	 (note that the process_output*() functions take this lock themselves)
+  */
+ 
+-static ssize_t n_tty_write(struct tty_struct *tty, struct file *file,
++static ssize_t noinline kpatch_n_tty_write(struct tty_struct *tty, struct file *file,
+ 			   const u8 *buf, size_t nr)
+ {
+ 	const u8 *b = buf;
+@@ -2440,6 +2440,12 @@ break_out:
+ 	return (b - buf) ? b - buf : retval;
+ }
+ 
++static ssize_t __attribute__((optimize("-fno-optimize-sibling-calls"))) n_tty_write(struct tty_struct *tty, struct file *file,
++			   							     const u8 *buf, size_t nr)
++{
++	return kpatch_n_tty_write(tty, file, buf, nr);
++}
++
+ /**
+  * n_tty_poll		-	poll method for N_TTY
+  * @tty: terminal device

--- a/test/integration/rhel-9.9/new-globals.patch
+++ b/test/integration/rhel-9.9/new-globals.patch
@@ -1,0 +1,34 @@
+diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
+--- src.orig/fs/proc/cmdline.c	2026-07-23 11:46:12.653540608 -0400
++++ src/fs/proc/cmdline.c	2026-07-23 11:46:21.749923643 -0400
+@@ -17,3 +17,10 @@ static int __init proc_cmdline_init(void
+ 	return 0;
+ }
+ fs_initcall(proc_cmdline_init);
++
++#include <linux/printk.h>
++void kpatch_print_message(void)
++{
++	if (!jiffies)
++		printk("hello there!\n");
++}
+diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
+--- src.orig/fs/proc/meminfo.c	2026-07-23 11:46:12.653547066 -0400
++++ src/fs/proc/meminfo.c	2026-07-23 11:46:21.750016387 -0400
+@@ -21,6 +21,8 @@
+ #include <asm/page.h>
+ #include "internal.h"
+ 
++void kpatch_print_message(void);
++
+ void __attribute__((weak)) arch_report_meminfo(struct seq_file *m)
+ {
+ }
+@@ -57,6 +59,7 @@ static int meminfo_proc_show(struct seq_
+ 	sreclaimable = global_node_page_state_pages(NR_SLAB_RECLAIMABLE_B);
+ 	sunreclaim = global_node_page_state_pages(NR_SLAB_UNRECLAIMABLE_B);
+ 
++	kpatch_print_message();
+ 	show_val_kb(m, "MemTotal:       ", i.totalram);
+ 	show_val_kb(m, "MemFree:        ", i.freeram);
+ 	show_val_kb(m, "MemAvailable:   ", available);

--- a/test/integration/rhel-9.9/shadow-newpid-LOADED.test
+++ b/test/integration/rhel-9.9/shadow-newpid-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep -q newpid: /proc/$$/status

--- a/test/integration/rhel-9.9/shadow-newpid.patch
+++ b/test/integration/rhel-9.9/shadow-newpid.patch
@@ -1,0 +1,75 @@
+diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
+--- src.orig/fs/proc/array.c	2026-07-23 11:46:12.653555250 -0400
++++ src/fs/proc/array.c	2026-07-23 11:46:23.497459994 -0400
+@@ -403,12 +403,19 @@ static inline void task_seccomp(struct s
+ 	seq_putc(m, '\n');
+ }
+ 
++#include <linux/livepatch.h>
+ static inline void task_context_switch_counts(struct seq_file *m,
+ 						struct task_struct *p)
+ {
++	int *newpid;
++
+ 	seq_put_decimal_ull(m, "voluntary_ctxt_switches:\t", p->nvcsw);
+ 	seq_put_decimal_ull(m, "\nnonvoluntary_ctxt_switches:\t", p->nivcsw);
+ 	seq_putc(m, '\n');
++
++	newpid = klp_shadow_get(p, 0);
++	if (newpid)
++		seq_printf(m, "newpid:\t%d\n", *newpid);
+ }
+ 
+ static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
+diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
+--- src.orig/kernel/exit.c	2026-07-23 11:46:12.729189154 -0400
++++ src/kernel/exit.c	2026-07-23 11:46:23.497647967 -0400
+@@ -791,6 +791,7 @@ static void synchronize_group_exit(struc
+ 	spin_unlock_irq(&sighand->siglock);
+ }
+ 
++#include <linux/livepatch.h>
+ void __noreturn do_exit(long code)
+ {
+ 	struct task_struct *tsk = current;
+@@ -856,6 +857,8 @@ void __noreturn do_exit(long code)
+ 	exit_task_work(tsk);
+ 	exit_thread(tsk);
+ 
++	klp_shadow_free(tsk, 0, NULL);
++
+ 	/*
+ 	 * Flush inherited counters to the parent - before the parent
+ 	 * gets woken up by child-exit notifications.
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2026-07-23 11:46:12.729209809 -0400
++++ src/kernel/fork.c	2026-07-23 11:46:23.497875768 -0400
+@@ -2799,6 +2799,7 @@ struct task_struct *create_io_thread(int
+  *
+  * args->exit_signal is expected to be checked for sanity by the caller.
+  */
++#include <linux/livepatch.h>
+ pid_t kernel_clone(struct kernel_clone_args *args)
+ {
+ 	u64 clone_flags = args->flags;
+@@ -2807,6 +2808,8 @@ pid_t kernel_clone(struct kernel_clone_a
+ 	struct task_struct *p;
+ 	int trace = 0;
+ 	pid_t nr;
++	int *newpid;
++	static int ctr = 0;
+ 
+ 	/*
+ 	 * For legacy clone() calls, CLONE_PIDFD uses the parent_tid argument
+@@ -2846,6 +2849,11 @@ pid_t kernel_clone(struct kernel_clone_a
+ 	if (IS_ERR(p))
+ 		return PTR_ERR(p);
+ 
++	newpid = klp_shadow_get_or_alloc(p, 0, sizeof(*newpid), GFP_KERNEL,
++					 NULL, NULL);
++	if (newpid)
++		*newpid = ctr++;
++
+ 	/*
+ 	 * Do this prior waking up the new thread - the thread pointer
+ 	 * might get invalid after that point, if the thread exits quickly.

--- a/test/integration/rhel-9.9/special-static.patch
+++ b/test/integration/rhel-9.9/special-static.patch
@@ -1,0 +1,22 @@
+diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
+--- src.orig/kernel/fork.c	2026-07-23 11:46:12.729209809 -0400
++++ src/kernel/fork.c	2026-07-23 11:46:25.200074097 -0400
+@@ -1877,10 +1877,18 @@ static void posix_cpu_timers_init_group(
+ 	posix_cputimers_group_init(pct, cpu_limit);
+ }
+ 
++void kpatch_foo(void)
++{
++	if (!jiffies)
++		printk("kpatch copy signal\n");
++}
++
+ static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ {
+ 	struct signal_struct *sig;
+ 
++	kpatch_foo();
++
+ 	if (clone_flags & CLONE_THREAD)
+ 		return 0;
+ 

--- a/test/integration/rhel-9.9/symvers-disagreement-FAIL.patch
+++ b/test/integration/rhel-9.9/symvers-disagreement-FAIL.patch
@@ -1,0 +1,24 @@
+diff -Nupr src.orig/drivers/base/core.c src/drivers/base/core.c
+--- src.orig/drivers/base/core.c	2026-07-23 11:46:12.096303139 -0400
++++ src/drivers/base/core.c	2026-07-23 11:46:26.936529765 -0400
+@@ -37,6 +37,8 @@
+ #include "physical_location.h"
+ #include "power/power.h"
+ 
++#include <linux/blktrace_api.h>
++
+ /* Device links support. */
+ static LIST_HEAD(deferred_sync);
+ static unsigned int defer_sync_state_count = 1;
+diff -Nupr src.orig/drivers/usb/core/usb.c src/drivers/usb/core/usb.c
+--- src.orig/drivers/usb/core/usb.c	2026-07-23 11:46:12.609689829 -0400
++++ src/drivers/usb/core/usb.c	2026-07-23 11:46:26.936837797 -0400
+@@ -770,6 +770,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
+  */
+ struct usb_device *usb_get_dev(struct usb_device *dev)
+ {
++	barrier();
++
+ 	if (dev)
+ 		get_device(&dev->dev);
+ 	return dev;

--- a/test/integration/rhel-9.9/syscall-LOADED.test
+++ b/test/integration/rhel-9.9/syscall-LOADED.test
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+uname -s | grep -q kpatch

--- a/test/integration/rhel-9.9/syscall.patch
+++ b/test/integration/rhel-9.9/syscall.patch
@@ -1,0 +1,20 @@
+diff -Nupr src.orig/kernel/sys.c src/kernel/sys.c
+--- src.orig/kernel/sys.c	2026-07-23 11:46:12.729244215 -0400
++++ src/kernel/sys.c	2026-07-23 11:46:28.664410768 -0400
+@@ -1292,13 +1292,15 @@ static int override_release(char __user
+ 	return ret;
+ }
+ 
+-SYSCALL_DEFINE1(newuname, struct new_utsname __user *, name)
++#include "kpatch-syscall.h"
++KPATCH_SYSCALL_DEFINE1(newuname, struct new_utsname __user *, name)
+ {
+ 	struct new_utsname tmp;
+ 
+ 	down_read(&uts_sem);
+ 	memcpy(&tmp, utsname(), sizeof(tmp));
+ 	up_read(&uts_sem);
++	strcat(tmp.sysname, ".kpatch");
+ 	if (copy_to_user(name, &tmp, sizeof(tmp)))
+ 		return -EFAULT;
+ 

--- a/test/integration/rhel-9.9/warn-detect-FAIL.patch
+++ b/test/integration/rhel-9.9/warn-detect-FAIL.patch
@@ -1,0 +1,9 @@
+diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
+--- src.orig/arch/x86/kvm/x86.c	2026-07-23 11:46:12.078054511 -0400
++++ src/arch/x86/kvm/x86.c	2026-07-23 11:46:30.401618912 -0400
+@@ -1,4 +1,5 @@
+ // SPDX-License-Identifier: GPL-2.0-only
++
+ /*
+  * Kernel-based Virtual Machine driver for Linux
+  *


### PR DESCRIPTION
- Use the updated module.patch and module-LOADED.test that uses xfs and not nfsd
- Add new-function.patch and symvers-disagreement-FAIL.patch back to the rhel-9 integration test suite

Internal beaker tests passed: ppc64le, s390x, and x86_64