### PR TITLE
Draft: test/integration/rhel-10.2: Rebase patches to kernel-6.12.0-250.el10

### DIFF
--- a/test/integration/rhel-10.2/data-new.patch
+++ b/test/integration/rhel-10.2/data-new.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
---- src.orig/fs/proc/meminfo.c	2026-06-29 20:46:12.063043096 +0000
-+++ src/fs/proc/meminfo.c	2026-06-29 20:46:12.353377118 +0000
+--- src.orig/fs/proc/meminfo.c	2026-07-23 10:53:36.355085982 -0400
++++ src/fs/proc/meminfo.c	2026-07-23 10:53:36.726078009 -0400
 @@ -31,6 +31,8 @@ static void show_val_kb(struct seq_file
  	seq_write(m, " kB\n", 4);
  }

--- a/test/integration/rhel-10.2/gcc-static-local-var-6.patch
+++ b/test/integration/rhel-10.2/gcc-static-local-var-6.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/net/ipv6/netfilter.c src/net/ipv6/netfilter.c
---- src.orig/net/ipv6/netfilter.c	2026-06-29 20:46:06.888141846 +0000
-+++ src/net/ipv6/netfilter.c	2026-06-29 20:46:48.306351476 +0000
+--- src.orig/net/ipv6/netfilter.c	2026-07-23 10:53:36.453464150 -0400
++++ src/net/ipv6/netfilter.c	2026-07-23 10:53:38.635420643 -0400
 @@ -97,6 +97,8 @@ static int nf_ip6_reroute(struct sk_buff
  	return 0;
  }

--- a/test/integration/rhel-10.2/macro-callbacks.patch
+++ b/test/integration/rhel-10.2/macro-callbacks.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
---- src.orig/drivers/input/joydev.c	2026-06-29 20:46:08.880103835 +0000
-+++ src/drivers/input/joydev.c	2026-06-29 20:46:54.087620103 +0000
+--- src.orig/drivers/input/joydev.c	2026-07-23 10:53:36.070138215 -0400
++++ src/drivers/input/joydev.c	2026-07-23 10:53:40.548839395 -0400
 @@ -1095,3 +1095,47 @@ static void __exit joydev_exit(void)
  
  module_init(joydev_init);
@@ -50,8 +50,8 @@ diff -Nupr src.orig/drivers/input/joydev.c src/drivers/input/joydev.c
 +}
 +KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
 diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
---- src.orig/drivers/input/misc/pcspkr.c	2026-06-29 20:46:08.893103587 +0000
-+++ src/drivers/input/misc/pcspkr.c	2026-06-29 20:46:54.087928955 +0000
+--- src.orig/drivers/input/misc/pcspkr.c	2026-07-23 10:53:36.067151665 -0400
++++ src/drivers/input/misc/pcspkr.c	2026-07-23 10:53:40.548967661 -0400
 @@ -132,3 +132,46 @@ static struct platform_driver pcspkr_pla
  };
  module_platform_driver(pcspkr_platform_driver);
@@ -100,8 +100,8 @@ diff -Nupr src.orig/drivers/input/misc/pcspkr.c src/drivers/input/misc/pcspkr.c
 +}
 +KPATCH_POST_UNPATCH_CALLBACK(post_unpatch_callback);
 diff -Nupr src.orig/fs/aio.c src/fs/aio.c
---- src.orig/fs/aio.c	2026-06-29 20:46:12.203040424 +0000
-+++ src/fs/aio.c	2026-06-29 20:46:54.088264119 +0000
+--- src.orig/fs/aio.c	2026-07-23 10:53:36.364567041 -0400
++++ src/fs/aio.c	2026-07-23 10:53:40.549104195 -0400
 @@ -50,6 +50,50 @@
  
  #define KIOCB_KEY		0

--- a/test/integration/rhel-10.2/module.patch
+++ b/test/integration/rhel-10.2/module.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/fs/xfs/xfs_stats.c src/fs/xfs/xfs_stats.c
---- src.orig/fs/xfs/xfs_stats.c	2026-06-29 20:46:12.188040711 +0000
-+++ src/fs/xfs/xfs_stats.c	2026-06-29 20:46:59.902822221 +0000
+--- src.orig/fs/xfs/xfs_stats.c	2026-07-23 10:53:36.364486828 -0400
++++ src/fs/xfs/xfs_stats.c	2026-07-23 10:53:42.433455786 -0400
 @@ -16,6 +16,8 @@ static int counter_val(struct xfsstats _
  	return val;
  }
@@ -46,8 +46,8 @@ diff -Nupr src.orig/fs/xfs/xfs_stats.c src/fs/xfs/xfs_stats.c
  }
  
 diff -Nupr src.orig/net/netlink/af_netlink.c src/net/netlink/af_netlink.c
---- src.orig/net/netlink/af_netlink.c	2026-06-29 20:46:07.000962142 +0000
-+++ src/net/netlink/af_netlink.c	2026-06-29 20:46:59.903130180 +0000
+--- src.orig/net/netlink/af_netlink.c	2026-07-23 10:53:36.459451880 -0400
++++ src/net/netlink/af_netlink.c	2026-07-23 10:53:42.433595906 -0400
 @@ -2964,4 +2964,10 @@ panic:
  	panic("netlink_init: Cannot allocate nl_table\n");
  }

--- a/test/integration/rhel-10.2/new-function.patch
+++ b/test/integration/rhel-10.2/new-function.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/drivers/tty/n_tty.c src/drivers/tty/n_tty.c
---- src.orig/drivers/tty/n_tty.c	2026-06-29 20:46:10.959064163 +0000
-+++ src/drivers/tty/n_tty.c	2026-06-29 20:47:05.771464459 +0000
+--- src.orig/drivers/tty/n_tty.c	2026-07-23 10:53:36.307765373 -0400
++++ src/drivers/tty/n_tty.c	2026-07-23 10:53:44.337929722 -0400
 @@ -2355,7 +2355,7 @@ more_to_be_read:
   *	 (note that the process_output*() functions take this lock themselves)
   */

--- a/test/integration/rhel-10.2/new-globals.patch
+++ b/test/integration/rhel-10.2/new-globals.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
---- src.orig/fs/proc/cmdline.c	2026-06-29 20:46:12.062146421 +0000
-+++ src/fs/proc/cmdline.c	2026-06-29 20:47:11.592571976 +0000
+--- src.orig/fs/proc/cmdline.c	2026-07-23 10:53:36.355079577 -0400
++++ src/fs/proc/cmdline.c	2026-07-23 10:53:46.256472219 -0400
 @@ -22,3 +22,11 @@ static int __init proc_cmdline_init(void
  	return 0;
  }
@@ -14,8 +14,8 @@ diff -Nupr src.orig/fs/proc/cmdline.c src/fs/proc/cmdline.c
 +		printk("hello there!\n");
 +}
 diff -Nupr src.orig/fs/proc/meminfo.c src/fs/proc/meminfo.c
---- src.orig/fs/proc/meminfo.c	2026-06-29 20:46:12.063043096 +0000
-+++ src/fs/proc/meminfo.c	2026-06-29 20:47:11.592828034 +0000
+--- src.orig/fs/proc/meminfo.c	2026-07-23 10:53:36.355085982 -0400
++++ src/fs/proc/meminfo.c	2026-07-23 10:53:46.256612241 -0400
 @@ -21,6 +21,8 @@
  #include <asm/page.h>
  #include "internal.h"

--- a/test/integration/rhel-10.2/shadow-newpid.patch
+++ b/test/integration/rhel-10.2/shadow-newpid.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
---- src.orig/fs/proc/array.c	2026-06-29 20:46:12.062146421 +0000
-+++ src/fs/proc/array.c	2026-06-29 20:47:17.526917281 +0000
+--- src.orig/fs/proc/array.c	2026-07-23 10:53:36.355094092 -0400
++++ src/fs/proc/array.c	2026-07-23 10:53:48.213012760 -0400
 @@ -395,12 +395,19 @@ static inline void task_seccomp(struct s
  	seq_putc(m, '\n');
  }
@@ -22,8 +22,8 @@ diff -Nupr src.orig/fs/proc/array.c src/fs/proc/array.c
  
  static void task_cpus_allowed(struct seq_file *m, struct task_struct *task)
 diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
---- src.orig/kernel/exit.c	2026-06-29 20:46:12.285038860 +0000
-+++ src/kernel/exit.c	2026-06-29 20:47:17.527335896 +0000
+--- src.orig/kernel/exit.c	2026-07-23 10:53:36.433407829 -0400
++++ src/kernel/exit.c	2026-07-23 10:53:48.213280401 -0400
 @@ -877,6 +877,7 @@ static void synchronize_group_exit(struc
  	spin_unlock_irq(&sighand->siglock);
  }
@@ -42,9 +42,9 @@ diff -Nupr src.orig/kernel/exit.c src/kernel/exit.c
  	 * FIXME: do that only when needed, using sched_exit tracepoint
  	 */
 diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
---- src.orig/kernel/fork.c	2026-06-29 20:46:12.285038860 +0000
-+++ src/kernel/fork.c	2026-06-29 20:47:17.527781283 +0000
-@@ -2765,6 +2765,7 @@ struct task_struct *create_io_thread(int
+--- src.orig/kernel/fork.c	2026-07-23 10:53:36.433436460 -0400
++++ src/kernel/fork.c	2026-07-23 10:53:48.213620602 -0400
+@@ -2559,6 +2559,7 @@ struct task_struct *create_io_thread(int
   *
   * args->exit_signal is expected to be checked for sanity by the caller.
   */
@@ -52,7 +52,7 @@ diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
  pid_t kernel_clone(struct kernel_clone_args *args)
  {
  	u64 clone_flags = args->flags;
-@@ -2773,6 +2774,8 @@ pid_t kernel_clone(struct kernel_clone_a
+@@ -2567,6 +2568,8 @@ pid_t kernel_clone(struct kernel_clone_a
  	struct task_struct *p;
  	int trace = 0;
  	pid_t nr;
@@ -61,7 +61,7 @@ diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
  
  	/*
  	 * For legacy clone() calls, CLONE_PIDFD uses the parent_tid argument
-@@ -2812,6 +2815,11 @@ pid_t kernel_clone(struct kernel_clone_a
+@@ -2606,6 +2609,11 @@ pid_t kernel_clone(struct kernel_clone_a
  	if (IS_ERR(p))
  		return PTR_ERR(p);
  

--- a/test/integration/rhel-10.2/special-static.patch
+++ b/test/integration/rhel-10.2/special-static.patch
@@ -1,7 +1,7 @@
 diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
---- src.orig/kernel/fork.c	2026-06-17 17:26:06.007130089 -0400
-+++ src/kernel/fork.c	2026-06-17 17:26:52.379797003 -0400
-@@ -1840,10 +1840,18 @@ static void posix_cpu_timers_init_group(
+--- src.orig/kernel/fork.c	2026-07-23 10:53:36.433436460 -0400
++++ src/kernel/fork.c	2026-07-23 10:53:50.145628857 -0400
+@@ -1631,10 +1631,18 @@ static void posix_cpu_timers_init_group(
  	posix_cputimers_group_init(pct, cpu_limit);
  }
  
@@ -11,7 +11,7 @@ diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
 +		printk("kpatch copy signal\n");
 +}
 +
- static int copy_signal(unsigned long clone_flags, struct task_struct *tsk)
+ static int copy_signal(u64 clone_flags, struct task_struct *tsk)
  {
  	struct signal_struct *sig;
  
@@ -19,3 +19,4 @@ diff -Nupr src.orig/kernel/fork.c src/kernel/fork.c
 +
  	if (clone_flags & CLONE_THREAD)
  		return 0;
+ 

--- a/test/integration/rhel-10.2/symvers-disagreement-FAIL.patch
+++ b/test/integration/rhel-10.2/symvers-disagreement-FAIL.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/drivers/base/core.c src/drivers/base/core.c
---- src.orig/drivers/base/core.c	2026-06-29 20:46:09.537091298 +0000
-+++ src/drivers/base/core.c	2026-06-29 20:47:23.321712480 +0000
+--- src.orig/drivers/base/core.c	2026-07-23 10:53:35.766142795 -0400
++++ src/drivers/base/core.c	2026-07-23 10:53:52.063341392 -0400
 @@ -37,6 +37,8 @@
  #include "physical_location.h"
  #include "power/power.h"
@@ -11,9 +11,9 @@ diff -Nupr src.orig/drivers/base/core.c src/drivers/base/core.c
  static LIST_HEAD(deferred_sync);
  static unsigned int defer_sync_state_count = 1;
 diff -Nupr src.orig/drivers/usb/core/usb.c src/drivers/usb/core/usb.c
---- src.orig/drivers/usb/core/usb.c	2026-06-29 20:46:11.001063361 +0000
-+++ src/drivers/usb/core/usb.c	2026-06-29 20:47:23.322405500 +0000
-@@ -767,6 +767,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
+--- src.orig/drivers/usb/core/usb.c	2026-07-23 10:53:36.309791205 -0400
++++ src/drivers/usb/core/usb.c	2026-07-23 10:53:52.063646938 -0400
+@@ -770,6 +770,8 @@ EXPORT_SYMBOL_GPL(usb_alloc_dev);
   */
  struct usb_device *usb_get_dev(struct usb_device *dev)
  {

--- a/test/integration/rhel-10.2/syscall.patch
+++ b/test/integration/rhel-10.2/syscall.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/kernel/sys.c src/kernel/sys.c
---- src.orig/kernel/sys.c	2026-06-29 20:46:12.295038669 +0000
-+++ src/kernel/sys.c	2026-06-29 20:47:29.122572597 +0000
+--- src.orig/kernel/sys.c	2026-07-23 10:53:36.433384038 -0400
++++ src/kernel/sys.c	2026-07-23 10:53:53.973537001 -0400
 @@ -1315,13 +1315,15 @@ static int override_release(char __user
  	return ret;
  }

--- a/test/integration/rhel-10.2/warn-detect-FAIL.patch
+++ b/test/integration/rhel-10.2/warn-detect-FAIL.patch
@@ -1,6 +1,6 @@
 diff -Nupr src.orig/arch/x86/kvm/x86.c src/arch/x86/kvm/x86.c
---- src.orig/arch/x86/kvm/x86.c	2026-06-29 20:46:07.078138221 +0000
-+++ src/arch/x86/kvm/x86.c	2026-06-29 20:47:35.256455547 +0000
+--- src.orig/arch/x86/kvm/x86.c	2026-07-23 10:53:35.739475962 -0400
++++ src/arch/x86/kvm/x86.c	2026-07-23 10:53:55.900653447 -0400
 @@ -1,4 +1,5 @@
  // SPDX-License-Identifier: GPL-2.0-only
 +


### PR DESCRIPTION
Note: These patches were not supported/tested on x86_64.

Current internal testing for: arm64, ppc64le, s390x.