### PR TITLE
kpatch-cc: exclude arch/x86/platform/pvh/* from diffing

### DIFF
--- a/kpatch-build/kpatch-cc
+++ b/kpatch-build/kpatch-cc
@@ -33,6 +33,7 @@ if [[ "$TOOLCHAINCMD" =~ ^(.*-)?gcc$ || "$TOOLCHAINCMD" =~ ^(.*-)?clang$ ]] ; th
 				.tmp_kallsyms2.o|\
 				arch/x86/boot/*|\
 				arch/x86/entry/vdso/*|\
+				arch/x86/platform/pvh/*|\
 				arch/x86/purgatory/*|\
 				arch/x86/realmode/*|\
 				arch/x86/tools/*|\


### PR DESCRIPTION
Part of #1514.

`arch/x86/platform/pvh/head.o` is Xen PVH boot entry code: it runs
exactly once, very early at boot, before the kernel proper (and
therefore before livepatch infrastructure) is even up. It can never
legitimately be part of any livepatch.

`kpatch-cc` already excludes the same category of early-boot-only,
never-livepatchable code (`arch/x86/boot/*`, `arch/x86/entry/vdso/*`,
`arch/x86/purgatory/*`, `arch/x86/realmode/*`, the EFI stub, etc.)
from being copied into the orig/patched diffing pipeline at all.
`arch/x86/platform/pvh/*` was simply missing from that list.

Without this, a patch series that happens to touch a widely-included
header (kpatch-build recompiles any file Kbuild considers stale, not
just the files a patch series actually changes) can drag
`pvh/head.o` into diffing, where its unusual 32-bit relocations and
low-level address arithmetic can trip `create-diff-object` in ways
unrelated to any real patch content.

## Testing

Reproduced and fixed while building a real cumulative EL9 5.14
kernel livepatch (11 CVEs, base 5.14.0-687.25.1.el9_8 → target
5.14.0-687.38.1.el9_8). See #1514 for the full context, including
the other three fixes needed to get that build all the way through.

Co-authored-by: Claude <noreply@anthropic.com>