### PR TITLE
create-diff-object: handle R_X86_64_32 in rela_target_offset

### DIFF
--- a/kpatch-build/kpatch-elf.c
+++ b/kpatch-build/kpatch-elf.c
@@ -229,6 +229,7 @@ long rela_target_offset(struct kpatch_elf *kelf, struct section *relasec,
 	case X86_64:
 		if (!is_text_section(sec) ||
 		    rela->type == R_X86_64_64 ||
+		    rela->type == R_X86_64_32 ||
 		    rela->type == R_X86_64_32S)
 			add_off = 0;
 		else if (rela->type == R_X86_64_PC32 ||


### PR DESCRIPTION
Part of #1514.

`rela_target_offset()` treats `R_X86_64_64` and `R_X86_64_32S` as
absolute (non-PC-relative) relocations needing no
instruction-decode-based offset adjustment, but was missing
`R_X86_64_32` (ELF reloc type 10). Any file containing one hits
`ERROR: unhandled rela type 10` and aborts the whole build.

`R_X86_64_32` and `R_X86_64_32S` are both absolute relocations; per
the x86-64 psABI they differ only in how the linker
validates/truncates the value during relocation *application*
(zero- vs sign-extension), which has no bearing on `add_off` here —
the instruction-decode adjustment this function computes only
matters for PC-relative encodings. So `R_X86_64_32` belongs in the
same branch as `R_X86_64_32S`.

`R_X86_64_32` shows up in low-level x86 code that still executes in
32-bit protected mode before the switch to long mode (observed in
`arch/x86/platform/pvh/head.o`, Xen PVH boot entry — see #1515 for a
targeted exclusion of that file from diffing entirely, since it can
never be livepatchable, but this relocation-type gap is real and
independent of that).

## Testing

Reproduced and fixed while building a real cumulative EL9 5.14
kernel livepatch. See #1514 for full context.

Co-authored-by: Claude <noreply@anthropic.com>