### PR TITLE
kpatch-build: fix find_parent_obj KVM shortcut for all arches

### DIFF
--- a/kpatch-build/kpatch-build
+++ b/kpatch-build/kpatch-build
@@ -662,7 +662,7 @@ find_parent_obj() {
 		[[ -n "$PARENT" ]] && return
 	fi
 	if [[ $file = virt/kvm/* ]]; then
-		find_parent_obj_in_dir "$file" "arch/x86/kvm"
+		find_parent_obj_in_dir "$file" "arch/$(kernel_src_arch "$TARGET_ARCH")/kvm"
 		[[ -n "$PARENT" ]] && return
 	fi
 	if [[ $file = drivers/oprofile/* ]]; then
@@ -757,14 +757,20 @@ print_supported_distro(){
 	fi
 }
 
-# Used in "make ARCH=xxx" when making the kernel.
-# Match "aarch64" to "arm64", while keep everything else the same.
-kernel_make_arch() {
-	if [[ "$1" == "aarch64" ]]; then
-		echo "arm64"
-	else
-		echo "$1"
-	fi
+# Translate a kpatch TARGET_ARCH into the corresponding kernel source arch
+# directory name (and the value expected by "make ARCH=").  kpatch's
+# TARGET_ARCH values don't always match the kernel arch names, e.g.
+# x86_64 -> x86, aarch64 -> arm64, ppc64le -> powerpc, s390x -> s390,
+# loongarch64 -> loongarch.
+kernel_src_arch() {
+	case "$1" in
+		x86_64)      echo "x86" ;;
+		aarch64)     echo "arm64" ;;
+		ppc64le)     echo "powerpc" ;;
+		s390x)       echo "s390" ;;
+		loongarch64) echo "loongarch" ;;
+		*)           echo "$1" ;;
+	esac
 }
 
 usage() {
@@ -1339,7 +1345,7 @@ else
 fi
 
 if [[ "$ARCH" != "$TARGET_ARCH" ]]; then
-	KARCH=$(kernel_make_arch "$TARGET_ARCH")
+	KARCH=$(kernel_src_arch "$TARGET_ARCH")
 	MAKEVARS+=("ARCH=$KARCH")
 fi
 


### PR DESCRIPTION
## Summary

The `find_parent_obj()` shortcut for `virt/kvm/*` files hardcodes `arch/x86/kvm`, which only works when the target arch is x86. On every other architecture the parent-object lookup for KVM files misses the shortcut and falls through to a deep (and slow) full-tree search — and as reported in #1519, on arm64 it can even miss the parent entirely.

Instead of adding per-arch `if` blocks, derive the arch-specific KVM directory from `$TARGET_ARCH`. The kpatch `TARGET_ARCH` values don't always match the kernel arch directory names, so a small mapping is needed:

| kpatch TARGET_ARCH | kernel arch dir |
|---|---|
| `x86_64` | `arch/x86/kvm` |
| `aarch64` | `arch/arm64/kvm` |
| `ppc64le` | `arch/powerpc/kvm` |
| `s390x` | `arch/s390/kvm` |
| `loongarch64` | `arch/loongarch/kvm` |

## Verification

All kpatch-supported arches build the common KVM code from `virt/kvm/` (v4.19: arm64/x86/s390/powerpc use `KVM=../../../virt/kvm` in their KVM Makefiles; modern kernels set `KVM ?= ../../../virt/kvm` in `virt/kvm/Makefile.kvm`; loongarch follows the same pattern). So the `virt/kvm/*` shortcut now correctly maps to the right arch directory on every supported arch.

Tested only on arm64 (4.19 kernel, gcc 8.2) — I don't have hardware for the other arches, but the change is mechanical and the mapping table above is complete.

Fixes: #1519
