### PR TITLE
kpatch-build: ignore gendwarfksyms and export_symbol local symbols

### DIFF
--- a/kpatch-build/lookup.c
+++ b/kpatch-build/lookup.c
@@ -87,6 +87,8 @@ static bool maybe_discarded_sym(const char *name)
 	    strstr(name, "__UNIQUE_ID_") ||
 	    !strncmp(name, ".L.str", 6) ||
 	    !strncmp(name, ".L__const", 9) ||
+	    !strncmp(name, "__gendwarfksyms_", 16) ||
+	    !strncmp(name, "__export_symbol_", 16) ||
 	    is_ubsan_sec(name))
 		return true;
 


### PR DESCRIPTION
kpatch-build: ignore gendwarfksyms and export_symbol local symbols

Kernel v6.18 introduced two new families of local symbols that are generated in each object file but discarded during the final link of vmlinux:

  - __export_symbol_<name>: generated by the .export_symbol section of the reworked EXPORT_SYMBOL() macro (include/linux/export.h)
  - __gendwarfksyms_ptr_<name>: generated when CONFIG_GENDWARFKSYMS=y to force DWARF emission for exported symbols

Because these symbols only exist in per-object files and are absent from the vmlinux symbol table, create-diff-object's find_local_syms() fails to match them when comparing the patched object's local symbols against the parent symbol table, e.g.:

  create-diff-object: ERROR: mm/vmscan.o: find_local_syms: 219:
  couldn't find matching vmscan.c local symbols in vmlinux symbol table

Add them to maybe_discarded_sym() so they are skipped when comparing local symbol tables.